### PR TITLE
Adding other fields from JOIN statement

### DIFF
--- a/install.yml
+++ b/install.yml
@@ -4,7 +4,7 @@
   vars: 
     GITHUB_ORG: "computate-org"
     SITE_NAME: "ActiveLearningStudio-API"
-    SITE_REPO: "git@github.com:{{ GITHUB_ORG }}/{{ SITE_NAME }}.git"
+    SITE_REPO: "git@github.com:computate-org/ActiveLearningStudio-API.git"
     SITE_SRC: "{{ playbook_dir }}"
     SITE_JAVA_PACKAGE: "org.curriki.api.enus"
     RELATIVE_PATHS_TO_WATCH: "src/main/java/org/curriki/api/enus"

--- a/local/ansible_install_vars.yml
+++ b/local/ansible_install_vars.yml
@@ -1,5 +1,8 @@
+---
 GITHUB_ORG: computate-org
 PROJECT_NAME: ActiveLearningStudio-API
+PROJECT_REPO: "git@github.com:{{ GITHUB_ORG }}/{{ PROJECT_NAME }}.git"
+PROJECT_REPO_HTTPS: "{{ PROJECT_REPO_SSH | replace('git@github.com:', 'https://github.com/') }}"
 PROJECT_LANG: enUS
 PROJECT_ZONE: "America/New_York"
 PROJECT_LOCALE: "en-US"

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelGen.java
@@ -1,66 +1,65 @@
 package org.curriki.api.enus.model.base;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import java.lang.Object;
-import java.lang.Long;
-import java.lang.String;
-import java.time.ZonedDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
+import org.curriki.api.enus.base.BaseModel;
 import java.util.Date;
-import java.time.format.DateTimeFormatter;
-import java.time.Instant;
+import java.time.ZonedDateTime;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+import java.lang.Long;
 import java.util.Locale;
-import java.time.OffsetDateTime;
-import java.lang.Boolean;
-import io.vertx.core.json.JsonArray;
-import org.computate.search.wrap.Wrap;
-import io.vertx.core.Promise;
+import java.util.Map;
+import java.time.ZoneOffset;
+import java.math.RoundingMode;
+import java.math.MathContext;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
 import io.vertx.core.Future;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.List;
+import java.time.OffsetDateTime;
+import org.apache.solr.client.solrj.SolrQuery;
+import java.util.Optional;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.computate.search.response.solr.SolrResponse;
-import io.vertx.core.json.JsonObject;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.request.api.ApiRequest;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.lang.Boolean;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import org.slf4j.Logger;
+import io.vertx.core.Promise;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.curriki.api.enus.config.ConfigKeys;
+import org.apache.solr.client.solrj.SolrClient;
+import io.vertx.core.json.JsonArray;
+import org.apache.solr.common.SolrDocument;
+import java.time.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
+import org.apache.commons.lang3.math.NumberUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.lang.Object;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel">Find the class BaseModel in Solr. </a>
- * <br><br>Delete the class BaseModel in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.base in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.base&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class BaseModelGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModel.class);
@@ -77,10 +76,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br> The entity siteRequest_
+	/**	<br/> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> w);
@@ -116,10 +115,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br> The entity pk
+	/**	<br/> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -149,16 +148,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrPk(siteRequest_, BaseModel.staticSearchPk(siteRequest_, BaseModel.staticSetPk(siteRequest_, o)));
+	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrPk(siteRequest_, BaseModel.staticSolrPk(siteRequest_, BaseModel.staticSetPk(siteRequest_, o)));
 	}
 
 	///////////////
@@ -172,10 +171,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String inheritPk;
 
-	/**	<br> The entity inheritPk
+	/**	<br/> The entity inheritPk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:inheritPk">Find the entity inheritPk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:inheritPk">Find the entity inheritPk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _inheritPk(Wrap<String> w);
@@ -198,20 +197,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchInheritPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrInheritPk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrInheritPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrInheritPk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInheritPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrInheritPk(siteRequest_, BaseModel.staticSearchInheritPk(siteRequest_, BaseModel.staticSetInheritPk(siteRequest_, o)));
-	}
-
-	public String sqlInheritPk() {
-		return inheritPk;
+	public static String staticSolrFqInheritPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrInheritPk(siteRequest_, BaseModel.staticSolrInheritPk(siteRequest_, BaseModel.staticSetInheritPk(siteRequest_, o)));
 	}
 
 	/////////////
@@ -222,16 +217,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime created;
 
-	/**	<br> The entity created
+	/**	<br/> The entity created
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:created">Find the entity created in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:created">Find the entity created in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _created(Wrap<ZonedDateTime> w);
@@ -253,8 +248,6 @@ public abstract class BaseModelGen<DEV> extends Object {
 		this.created = BaseModel.staticSetCreated(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetCreated(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -273,20 +266,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Date staticSearchCreated(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrCreated(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrCreated(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrCreated(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqCreated(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrCreated(siteRequest_, BaseModel.staticSearchCreated(siteRequest_, BaseModel.staticSetCreated(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlCreated() {
-		return created == null ? null : created.toOffsetDateTime();
+	public static String staticSolrFqCreated(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrCreated(siteRequest_, BaseModel.staticSolrCreated(siteRequest_, BaseModel.staticSetCreated(siteRequest_, o)));
 	}
 
 	//////////////
@@ -297,16 +286,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime modified;
 
-	/**	<br> The entity modified
+	/**	<br/> The entity modified
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:modified">Find the entity modified in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:modified">Find the entity modified in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _modified(Wrap<ZonedDateTime> w);
@@ -328,8 +317,6 @@ public abstract class BaseModelGen<DEV> extends Object {
 		this.modified = BaseModel.staticSetModified(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetModified(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -348,16 +335,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Date staticSearchModified(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrModified(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrModified(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrModified(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqModified(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrModified(siteRequest_, BaseModel.staticSearchModified(siteRequest_, BaseModel.staticSetModified(siteRequest_, o)));
+	public static String staticSolrFqModified(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrModified(siteRequest_, BaseModel.staticSolrModified(siteRequest_, BaseModel.staticSetModified(siteRequest_, o)));
 	}
 
 	//////////////
@@ -371,10 +358,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean archived;
 
-	/**	<br> The entity archived
+	/**	<br/> The entity archived
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:archived">Find the entity archived in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archived">Find the entity archived in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _archived(Wrap<Boolean> w);
@@ -402,20 +389,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Boolean staticSearchArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSolrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSearchStrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSolrStrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqArchived(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrArchived(siteRequest_, BaseModel.staticSearchArchived(siteRequest_, BaseModel.staticSetArchived(siteRequest_, o)));
-	}
-
-	public Boolean sqlArchived() {
-		return archived;
+	public static String staticSolrFqArchived(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrArchived(siteRequest_, BaseModel.staticSolrArchived(siteRequest_, BaseModel.staticSetArchived(siteRequest_, o)));
 	}
 
 	/////////////
@@ -429,10 +412,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean deleted;
 
-	/**	<br> The entity deleted
+	/**	<br/> The entity deleted
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:deleted">Find the entity deleted in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deleted">Find the entity deleted in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deleted(Wrap<Boolean> w);
@@ -460,20 +443,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Boolean staticSearchDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSolrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSearchStrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSolrStrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDeleted(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrDeleted(siteRequest_, BaseModel.staticSearchDeleted(siteRequest_, BaseModel.staticSetDeleted(siteRequest_, o)));
-	}
-
-	public Boolean sqlDeleted() {
-		return deleted;
+	public static String staticSolrFqDeleted(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrDeleted(siteRequest_, BaseModel.staticSolrDeleted(siteRequest_, BaseModel.staticSetDeleted(siteRequest_, o)));
 	}
 
 	////////////////////////
@@ -487,10 +466,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classCanonicalName;
 
-	/**	<br> The entity classCanonicalName
+	/**	<br/> The entity classCanonicalName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:classCanonicalName">Find the entity classCanonicalName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalName">Find the entity classCanonicalName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classCanonicalName(Wrap<String> w);
@@ -513,16 +492,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrClassCanonicalName(siteRequest_, BaseModel.staticSearchClassCanonicalName(siteRequest_, BaseModel.staticSetClassCanonicalName(siteRequest_, o)));
+	public static String staticSolrFqClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrClassCanonicalName(siteRequest_, BaseModel.staticSolrClassCanonicalName(siteRequest_, BaseModel.staticSetClassCanonicalName(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -536,10 +515,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classSimpleName;
 
-	/**	<br> The entity classSimpleName
+	/**	<br/> The entity classSimpleName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classSimpleName(Wrap<String> w);
@@ -562,16 +541,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrClassSimpleName(siteRequest_, BaseModel.staticSearchClassSimpleName(siteRequest_, BaseModel.staticSetClassSimpleName(siteRequest_, o)));
+	public static String staticSolrFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrClassSimpleName(siteRequest_, BaseModel.staticSolrClassSimpleName(siteRequest_, BaseModel.staticSetClassSimpleName(siteRequest_, o)));
 	}
 
 	/////////////////////////
@@ -579,18 +558,18 @@ public abstract class BaseModelGen<DEV> extends Object {
 	/////////////////////////
 
 	/**	 The entity classCanonicalNames
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> classCanonicalNames = new ArrayList<String>();
 
-	/**	<br> The entity classCanonicalNames
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:classCanonicalNames">Find the entity classCanonicalNames in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity classCanonicalNames
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalNames">Find the entity classCanonicalNames in Solr</a>
+	 * <br/>
+	 * @param classCanonicalNames is the entity already constructed. 
 	 **/
 	protected abstract void _classCanonicalNames(List<String> l);
 
@@ -628,16 +607,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrClassCanonicalNames(siteRequest_, BaseModel.staticSearchClassCanonicalNames(siteRequest_, BaseModel.staticSetClassCanonicalNames(siteRequest_, o)));
+	public static String staticSolrFqClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrClassCanonicalNames(siteRequest_, BaseModel.staticSolrClassCanonicalNames(siteRequest_, BaseModel.staticSetClassCanonicalNames(siteRequest_, o)));
 	}
 
 	///////////////
@@ -651,10 +630,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionId;
 
-	/**	<br> The entity sessionId
+	/**	<br/> The entity sessionId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionId(Wrap<String> w);
@@ -677,20 +656,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSessionId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrSessionId(siteRequest_, BaseModel.staticSearchSessionId(siteRequest_, BaseModel.staticSetSessionId(siteRequest_, o)));
-	}
-
-	public String sqlSessionId() {
-		return sessionId;
+	public static String staticSolrFqSessionId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrSessionId(siteRequest_, BaseModel.staticSolrSessionId(siteRequest_, BaseModel.staticSetSessionId(siteRequest_, o)));
 	}
 
 	/////////////
@@ -705,10 +680,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br> The entity userKey
+	/**	<br/> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> c);
@@ -738,20 +713,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrUserKey(siteRequest_, BaseModel.staticSearchUserKey(siteRequest_, BaseModel.staticSetUserKey(siteRequest_, o)));
-	}
-
-	public Long sqlUserKey() {
-		return userKey;
+	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrUserKey(siteRequest_, BaseModel.staticSolrUserKey(siteRequest_, BaseModel.staticSetUserKey(siteRequest_, o)));
 	}
 
 	///////////
@@ -759,18 +730,18 @@ public abstract class BaseModelGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity saves
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> saves = new ArrayList<String>();
 
-	/**	<br> The entity saves
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:saves">Find the entity saves in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity saves
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:saves">Find the entity saves in Solr</a>
+	 * <br/>
+	 * @param saves is the entity already constructed. 
 	 **/
 	protected abstract void _saves(List<String> l);
 
@@ -808,16 +779,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchSaves(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSaves(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSaves(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSaves(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSaves(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrSaves(siteRequest_, BaseModel.staticSearchSaves(siteRequest_, BaseModel.staticSetSaves(siteRequest_, o)));
+	public static String staticSolrFqSaves(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrSaves(siteRequest_, BaseModel.staticSolrSaves(siteRequest_, BaseModel.staticSetSaves(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -831,10 +802,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectTitle;
 
-	/**	<br> The entity objectTitle
+	/**	<br/> The entity objectTitle
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:objectTitle">Find the entity objectTitle in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectTitle">Find the entity objectTitle in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectTitle(Wrap<String> w);
@@ -857,16 +828,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqObjectTitle(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrObjectTitle(siteRequest_, BaseModel.staticSearchObjectTitle(siteRequest_, BaseModel.staticSetObjectTitle(siteRequest_, o)));
+	public static String staticSolrFqObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrObjectTitle(siteRequest_, BaseModel.staticSolrObjectTitle(siteRequest_, BaseModel.staticSetObjectTitle(siteRequest_, o)));
 	}
 
 	//////////////
@@ -880,10 +851,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectId;
 
-	/**	<br> The entity objectId
+	/**	<br/> The entity objectId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:objectId">Find the entity objectId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectId">Find the entity objectId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectId(Wrap<String> w);
@@ -906,16 +877,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchObjectId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrObjectId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrObjectId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrObjectId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqObjectId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrObjectId(siteRequest_, BaseModel.staticSearchObjectId(siteRequest_, BaseModel.staticSetObjectId(siteRequest_, o)));
+	public static String staticSolrFqObjectId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrObjectId(siteRequest_, BaseModel.staticSolrObjectId(siteRequest_, BaseModel.staticSetObjectId(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -929,10 +900,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectNameVar;
 
-	/**	<br> The entity objectNameVar
+	/**	<br/> The entity objectNameVar
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:objectNameVar">Find the entity objectNameVar in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectNameVar">Find the entity objectNameVar in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectNameVar(Wrap<String> w);
@@ -955,16 +926,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrObjectNameVar(siteRequest_, BaseModel.staticSearchObjectNameVar(siteRequest_, BaseModel.staticSetObjectNameVar(siteRequest_, o)));
+	public static String staticSolrFqObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrObjectNameVar(siteRequest_, BaseModel.staticSolrObjectNameVar(siteRequest_, BaseModel.staticSetObjectNameVar(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -978,10 +949,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectSuggest;
 
-	/**	<br> The entity objectSuggest
+	/**	<br/> The entity objectSuggest
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:objectSuggest">Find the entity objectSuggest in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectSuggest">Find the entity objectSuggest in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectSuggest(Wrap<String> w);
@@ -1004,16 +975,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrObjectSuggest(siteRequest_, BaseModel.staticSearchObjectSuggest(siteRequest_, BaseModel.staticSetObjectSuggest(siteRequest_, o)));
+	public static String staticSolrFqObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrObjectSuggest(siteRequest_, BaseModel.staticSolrObjectSuggest(siteRequest_, BaseModel.staticSetObjectSuggest(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1027,10 +998,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectText;
 
-	/**	<br> The entity objectText
+	/**	<br/> The entity objectText
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:objectText">Find the entity objectText in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectText">Find the entity objectText in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectText(Wrap<String> w);
@@ -1053,16 +1024,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchObjectText(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrObjectText(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrObjectText(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrObjectText(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqObjectText(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrObjectText(siteRequest_, BaseModel.staticSearchObjectText(siteRequest_, BaseModel.staticSetObjectText(siteRequest_, o)));
+	public static String staticSolrFqObjectText(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrObjectText(siteRequest_, BaseModel.staticSolrObjectText(siteRequest_, BaseModel.staticSetObjectText(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1076,10 +1047,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlId;
 
-	/**	<br> The entity pageUrlId
+	/**	<br/> The entity pageUrlId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:pageUrlId">Find the entity pageUrlId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlId">Find the entity pageUrlId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlId(Wrap<String> w);
@@ -1102,16 +1073,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageUrlId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrPageUrlId(siteRequest_, BaseModel.staticSearchPageUrlId(siteRequest_, BaseModel.staticSetPageUrlId(siteRequest_, o)));
+	public static String staticSolrFqPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrPageUrlId(siteRequest_, BaseModel.staticSolrPageUrlId(siteRequest_, BaseModel.staticSetPageUrlId(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1125,10 +1096,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlPk;
 
-	/**	<br> The entity pageUrlPk
+	/**	<br/> The entity pageUrlPk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:pageUrlPk">Find the entity pageUrlPk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlPk">Find the entity pageUrlPk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlPk(Wrap<String> w);
@@ -1151,16 +1122,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrPageUrlPk(siteRequest_, BaseModel.staticSearchPageUrlPk(siteRequest_, BaseModel.staticSetPageUrlPk(siteRequest_, o)));
+	public static String staticSolrFqPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrPageUrlPk(siteRequest_, BaseModel.staticSolrPageUrlPk(siteRequest_, BaseModel.staticSetPageUrlPk(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1174,10 +1145,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlApi;
 
-	/**	<br> The entity pageUrlApi
+	/**	<br/> The entity pageUrlApi
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:pageUrlApi">Find the entity pageUrlApi in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlApi">Find the entity pageUrlApi in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlApi(Wrap<String> w);
@@ -1200,16 +1171,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrPageUrlApi(siteRequest_, BaseModel.staticSearchPageUrlApi(siteRequest_, BaseModel.staticSetPageUrlApi(siteRequest_, o)));
+	public static String staticSolrFqPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrPageUrlApi(siteRequest_, BaseModel.staticSolrPageUrlApi(siteRequest_, BaseModel.staticSetPageUrlApi(siteRequest_, o)));
 	}
 
 	////////
@@ -1223,10 +1194,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String id;
 
-	/**	<br> The entity id
+	/**	<br/> The entity id
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _id(Wrap<String> w);
@@ -1249,16 +1220,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSearchStrId(siteRequest_, BaseModel.staticSearchId(siteRequest_, BaseModel.staticSetId(siteRequest_, o)));
+	public static String staticSolrFqId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSolrStrId(siteRequest_, BaseModel.staticSolrId(siteRequest_, BaseModel.staticSetId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -1491,234 +1462,194 @@ public abstract class BaseModelGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchBaseModel(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSearchPk(siteRequest_, (Long)o);
+			return BaseModel.staticSolrPk(siteRequest_, (Long)o);
 		case "inheritPk":
-			return BaseModel.staticSearchInheritPk(siteRequest_, (String)o);
+			return BaseModel.staticSolrInheritPk(siteRequest_, (String)o);
 		case "created":
-			return BaseModel.staticSearchCreated(siteRequest_, (ZonedDateTime)o);
+			return BaseModel.staticSolrCreated(siteRequest_, (ZonedDateTime)o);
 		case "modified":
-			return BaseModel.staticSearchModified(siteRequest_, (ZonedDateTime)o);
+			return BaseModel.staticSolrModified(siteRequest_, (ZonedDateTime)o);
 		case "archived":
-			return BaseModel.staticSearchArchived(siteRequest_, (Boolean)o);
+			return BaseModel.staticSolrArchived(siteRequest_, (Boolean)o);
 		case "deleted":
-			return BaseModel.staticSearchDeleted(siteRequest_, (Boolean)o);
+			return BaseModel.staticSolrDeleted(siteRequest_, (Boolean)o);
 		case "classCanonicalName":
-			return BaseModel.staticSearchClassCanonicalName(siteRequest_, (String)o);
+			return BaseModel.staticSolrClassCanonicalName(siteRequest_, (String)o);
 		case "classSimpleName":
-			return BaseModel.staticSearchClassSimpleName(siteRequest_, (String)o);
+			return BaseModel.staticSolrClassSimpleName(siteRequest_, (String)o);
 		case "classCanonicalNames":
-			return BaseModel.staticSearchClassCanonicalNames(siteRequest_, (String)o);
+			return BaseModel.staticSolrClassCanonicalNames(siteRequest_, (String)o);
 		case "sessionId":
-			return BaseModel.staticSearchSessionId(siteRequest_, (String)o);
+			return BaseModel.staticSolrSessionId(siteRequest_, (String)o);
 		case "userKey":
-			return BaseModel.staticSearchUserKey(siteRequest_, (Long)o);
+			return BaseModel.staticSolrUserKey(siteRequest_, (Long)o);
 		case "saves":
-			return BaseModel.staticSearchSaves(siteRequest_, (String)o);
+			return BaseModel.staticSolrSaves(siteRequest_, (String)o);
 		case "objectTitle":
-			return BaseModel.staticSearchObjectTitle(siteRequest_, (String)o);
+			return BaseModel.staticSolrObjectTitle(siteRequest_, (String)o);
 		case "objectId":
-			return BaseModel.staticSearchObjectId(siteRequest_, (String)o);
+			return BaseModel.staticSolrObjectId(siteRequest_, (String)o);
 		case "objectNameVar":
-			return BaseModel.staticSearchObjectNameVar(siteRequest_, (String)o);
+			return BaseModel.staticSolrObjectNameVar(siteRequest_, (String)o);
 		case "objectSuggest":
-			return BaseModel.staticSearchObjectSuggest(siteRequest_, (String)o);
+			return BaseModel.staticSolrObjectSuggest(siteRequest_, (String)o);
 		case "objectText":
-			return BaseModel.staticSearchObjectText(siteRequest_, (String)o);
+			return BaseModel.staticSolrObjectText(siteRequest_, (String)o);
 		case "pageUrlId":
-			return BaseModel.staticSearchPageUrlId(siteRequest_, (String)o);
+			return BaseModel.staticSolrPageUrlId(siteRequest_, (String)o);
 		case "pageUrlPk":
-			return BaseModel.staticSearchPageUrlPk(siteRequest_, (String)o);
+			return BaseModel.staticSolrPageUrlPk(siteRequest_, (String)o);
 		case "pageUrlApi":
-			return BaseModel.staticSearchPageUrlApi(siteRequest_, (String)o);
+			return BaseModel.staticSolrPageUrlApi(siteRequest_, (String)o);
 		case "id":
-			return BaseModel.staticSearchId(siteRequest_, (String)o);
+			return BaseModel.staticSolrId(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrBaseModel(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSearchStrPk(siteRequest_, (Long)o);
+			return BaseModel.staticSolrStrPk(siteRequest_, (Long)o);
 		case "inheritPk":
-			return BaseModel.staticSearchStrInheritPk(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrInheritPk(siteRequest_, (String)o);
 		case "created":
-			return BaseModel.staticSearchStrCreated(siteRequest_, (Date)o);
+			return BaseModel.staticSolrStrCreated(siteRequest_, (Date)o);
 		case "modified":
-			return BaseModel.staticSearchStrModified(siteRequest_, (Date)o);
+			return BaseModel.staticSolrStrModified(siteRequest_, (Date)o);
 		case "archived":
-			return BaseModel.staticSearchStrArchived(siteRequest_, (Boolean)o);
+			return BaseModel.staticSolrStrArchived(siteRequest_, (Boolean)o);
 		case "deleted":
-			return BaseModel.staticSearchStrDeleted(siteRequest_, (Boolean)o);
+			return BaseModel.staticSolrStrDeleted(siteRequest_, (Boolean)o);
 		case "classCanonicalName":
-			return BaseModel.staticSearchStrClassCanonicalName(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrClassCanonicalName(siteRequest_, (String)o);
 		case "classSimpleName":
-			return BaseModel.staticSearchStrClassSimpleName(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrClassSimpleName(siteRequest_, (String)o);
 		case "classCanonicalNames":
-			return BaseModel.staticSearchStrClassCanonicalNames(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrClassCanonicalNames(siteRequest_, (String)o);
 		case "sessionId":
-			return BaseModel.staticSearchStrSessionId(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrSessionId(siteRequest_, (String)o);
 		case "userKey":
-			return BaseModel.staticSearchStrUserKey(siteRequest_, (Long)o);
+			return BaseModel.staticSolrStrUserKey(siteRequest_, (Long)o);
 		case "saves":
-			return BaseModel.staticSearchStrSaves(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrSaves(siteRequest_, (String)o);
 		case "objectTitle":
-			return BaseModel.staticSearchStrObjectTitle(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrObjectTitle(siteRequest_, (String)o);
 		case "objectId":
-			return BaseModel.staticSearchStrObjectId(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrObjectId(siteRequest_, (String)o);
 		case "objectNameVar":
-			return BaseModel.staticSearchStrObjectNameVar(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrObjectNameVar(siteRequest_, (String)o);
 		case "objectSuggest":
-			return BaseModel.staticSearchStrObjectSuggest(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrObjectSuggest(siteRequest_, (String)o);
 		case "objectText":
-			return BaseModel.staticSearchStrObjectText(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrObjectText(siteRequest_, (String)o);
 		case "pageUrlId":
-			return BaseModel.staticSearchStrPageUrlId(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrPageUrlId(siteRequest_, (String)o);
 		case "pageUrlPk":
-			return BaseModel.staticSearchStrPageUrlPk(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrPageUrlPk(siteRequest_, (String)o);
 		case "pageUrlApi":
-			return BaseModel.staticSearchStrPageUrlApi(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrPageUrlApi(siteRequest_, (String)o);
 		case "id":
-			return BaseModel.staticSearchStrId(siteRequest_, (String)o);
+			return BaseModel.staticSolrStrId(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqBaseModel(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqBaseModel(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqBaseModel(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSearchFqPk(siteRequest_, o);
+			return BaseModel.staticSolrFqPk(siteRequest_, o);
 		case "inheritPk":
-			return BaseModel.staticSearchFqInheritPk(siteRequest_, o);
+			return BaseModel.staticSolrFqInheritPk(siteRequest_, o);
 		case "created":
-			return BaseModel.staticSearchFqCreated(siteRequest_, o);
+			return BaseModel.staticSolrFqCreated(siteRequest_, o);
 		case "modified":
-			return BaseModel.staticSearchFqModified(siteRequest_, o);
+			return BaseModel.staticSolrFqModified(siteRequest_, o);
 		case "archived":
-			return BaseModel.staticSearchFqArchived(siteRequest_, o);
+			return BaseModel.staticSolrFqArchived(siteRequest_, o);
 		case "deleted":
-			return BaseModel.staticSearchFqDeleted(siteRequest_, o);
+			return BaseModel.staticSolrFqDeleted(siteRequest_, o);
 		case "classCanonicalName":
-			return BaseModel.staticSearchFqClassCanonicalName(siteRequest_, o);
+			return BaseModel.staticSolrFqClassCanonicalName(siteRequest_, o);
 		case "classSimpleName":
-			return BaseModel.staticSearchFqClassSimpleName(siteRequest_, o);
+			return BaseModel.staticSolrFqClassSimpleName(siteRequest_, o);
 		case "classCanonicalNames":
-			return BaseModel.staticSearchFqClassCanonicalNames(siteRequest_, o);
+			return BaseModel.staticSolrFqClassCanonicalNames(siteRequest_, o);
 		case "sessionId":
-			return BaseModel.staticSearchFqSessionId(siteRequest_, o);
+			return BaseModel.staticSolrFqSessionId(siteRequest_, o);
 		case "userKey":
-			return BaseModel.staticSearchFqUserKey(siteRequest_, o);
+			return BaseModel.staticSolrFqUserKey(siteRequest_, o);
 		case "saves":
-			return BaseModel.staticSearchFqSaves(siteRequest_, o);
+			return BaseModel.staticSolrFqSaves(siteRequest_, o);
 		case "objectTitle":
-			return BaseModel.staticSearchFqObjectTitle(siteRequest_, o);
+			return BaseModel.staticSolrFqObjectTitle(siteRequest_, o);
 		case "objectId":
-			return BaseModel.staticSearchFqObjectId(siteRequest_, o);
+			return BaseModel.staticSolrFqObjectId(siteRequest_, o);
 		case "objectNameVar":
-			return BaseModel.staticSearchFqObjectNameVar(siteRequest_, o);
+			return BaseModel.staticSolrFqObjectNameVar(siteRequest_, o);
 		case "objectSuggest":
-			return BaseModel.staticSearchFqObjectSuggest(siteRequest_, o);
+			return BaseModel.staticSolrFqObjectSuggest(siteRequest_, o);
 		case "objectText":
-			return BaseModel.staticSearchFqObjectText(siteRequest_, o);
+			return BaseModel.staticSolrFqObjectText(siteRequest_, o);
 		case "pageUrlId":
-			return BaseModel.staticSearchFqPageUrlId(siteRequest_, o);
+			return BaseModel.staticSolrFqPageUrlId(siteRequest_, o);
 		case "pageUrlPk":
-			return BaseModel.staticSearchFqPageUrlPk(siteRequest_, o);
+			return BaseModel.staticSolrFqPageUrlPk(siteRequest_, o);
 		case "pageUrlApi":
-			return BaseModel.staticSearchFqPageUrlApi(siteRequest_, o);
+			return BaseModel.staticSolrFqPageUrlApi(siteRequest_, o);
 		case "id":
-			return BaseModel.staticSearchFqId(siteRequest_, o);
+			return BaseModel.staticSolrFqId(siteRequest_, o);
 			default:
 				return null;
 		}
 	}
 
 	/////////////
-	// persist //
+	// define //
 	/////////////
 
-	public boolean persistForClass(String var, Object val) {
+	public boolean defineForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = persistBaseModel(v, val);
+					o = defineBaseModel(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.persistForClass(v, val);
+					o = oBaseModel.defineForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object persistBaseModel(String var, Object val) {
+	public Object defineBaseModel(String var, Object val) {
 		switch(var.toLowerCase()) {
-			case "inheritpk":
-				if(val instanceof String)
-					setInheritPk((String)val);
-				saves.add("inheritPk");
-				return val;
-			case "created":
-				if(val instanceof ZonedDateTime)
-					setCreated((ZonedDateTime)val);
-				else if(val instanceof String)
-					setCreated((String)val);
-				else if(val instanceof OffsetDateTime)
-					setCreated(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("created");
-				return val;
-			case "archived":
-				if(val instanceof Boolean)
-					setArchived((Boolean)val);
-				else if(val instanceof String)
-					setArchived((String)val);
-				saves.add("archived");
-				return val;
-			case "deleted":
-				if(val instanceof Boolean)
-					setDeleted((Boolean)val);
-				else if(val instanceof String)
-					setDeleted((String)val);
-				saves.add("deleted");
-				return val;
-			case "sessionid":
-				if(val instanceof String)
-					setSessionId((String)val);
-				saves.add("sessionId");
-				return val;
-			case "userkey":
-				if(val instanceof Long)
-					setUserKey((Long)val);
-				else if(val instanceof String)
-					setUserKey((String)val);
-				saves.add("userKey");
-				return val;
 			default:
 				return null;
 		}
@@ -1728,128 +1659,81 @@ public abstract class BaseModelGen<DEV> extends Object {
 	// populate //
 	/////////////
 
-	public void populateForClass(SolrResponse.Doc doc) {
-		populateBaseModel(doc);
+	public void populateForClass(SolrDocument solrDocument) {
+		populateBaseModel(solrDocument);
 	}
-	public void populateBaseModel(SolrResponse.Doc doc) {
+	public void populateBaseModel(SolrDocument solrDocument) {
 		BaseModel oBaseModel = (BaseModel)this;
-		saves = doc.get("saves_docvalues_strings");
+		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
 		if(saves != null) {
 		}
 	}
 
-	public void indexBaseModel(JsonObject doc) {
+	public void indexBaseModel(SolrInputDocument document) {
 		if(pk != null) {
-			doc.put("pk_docvalues_long", pk);
+			document.addField("pk_docvalues_long", pk);
 		}
 		if(inheritPk != null) {
-			doc.put("inheritPk_docvalues_string", inheritPk);
+			document.addField("inheritPk_docvalues_string", inheritPk);
 		}
 		if(created != null) {
-			doc.put("created_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(created.toInstant(), ZoneId.of("UTC"))));
+			document.addField("created_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(created.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(modified != null) {
-			doc.put("modified_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(modified.toInstant(), ZoneId.of("UTC"))));
+			document.addField("modified_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(modified.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(archived != null) {
-			doc.put("archived_docvalues_boolean", archived);
+			document.addField("archived_docvalues_boolean", archived);
 		}
 		if(deleted != null) {
-			doc.put("deleted_docvalues_boolean", deleted);
+			document.addField("deleted_docvalues_boolean", deleted);
 		}
 		if(classCanonicalName != null) {
-			doc.put("classCanonicalName_docvalues_string", classCanonicalName);
+			document.addField("classCanonicalName_docvalues_string", classCanonicalName);
 		}
 		if(classSimpleName != null) {
-			doc.put("classSimpleName_docvalues_string", classSimpleName);
+			document.addField("classSimpleName_docvalues_string", classSimpleName);
 		}
 		if(classCanonicalNames != null) {
-			JsonArray l = new JsonArray();
-			doc.put("classCanonicalNames_docvalues_strings", l);
-			for(String o : classCanonicalNames) {
-				l.add(o);
+			for(java.lang.String o : classCanonicalNames) {
+				document.addField("classCanonicalNames_docvalues_strings", o);
 			}
 		}
 		if(sessionId != null) {
-			doc.put("sessionId_docvalues_string", sessionId);
+			document.addField("sessionId_docvalues_string", sessionId);
 		}
 		if(userKey != null) {
-			doc.put("userKey_docvalues_long", userKey);
+			document.addField("userKey_docvalues_long", userKey);
 		}
 		if(saves != null) {
-			JsonArray l = new JsonArray();
-			doc.put("saves_docvalues_strings", l);
-			for(String o : saves) {
-				l.add(o);
+			for(java.lang.String o : saves) {
+				document.addField("saves_docvalues_strings", o);
 			}
 		}
 		if(objectTitle != null) {
-			doc.put("objectTitle_docvalues_string", objectTitle);
+			document.addField("objectTitle_docvalues_string", objectTitle);
 		}
 		if(objectId != null) {
-			doc.put("objectId_docvalues_string", objectId);
+			document.addField("objectId_docvalues_string", objectId);
 		}
 		if(objectSuggest != null) {
-			doc.put("objectSuggest_suggested", objectSuggest);
+			document.addField("objectSuggest_suggested", objectSuggest);
 		}
 		if(objectText != null) {
-			doc.put("objectText_text_enUS", objectText.toString());
-			doc.put("objectText_docvalues_string", objectText);
+			document.addField("objectText_text_enUS", objectText.toString());
+			document.addField("objectText_docvalues_string", objectText);
 		}
 		if(pageUrlId != null) {
-			doc.put("pageUrlId_docvalues_string", pageUrlId);
+			document.addField("pageUrlId_docvalues_string", pageUrlId);
 		}
 		if(pageUrlPk != null) {
-			doc.put("pageUrlPk_docvalues_string", pageUrlPk);
+			document.addField("pageUrlPk_docvalues_string", pageUrlPk);
 		}
 		if(pageUrlApi != null) {
-			doc.put("pageUrlApi_docvalues_string", pageUrlApi);
+			document.addField("pageUrlApi_docvalues_string", pageUrlApi);
 		}
 		if(id != null) {
-			doc.put("id", id);
-		}
-	}
-
-	public static String varStoredBaseModel(String entityVar) {
-		switch(entityVar) {
-			case "pk":
-				return "pk_docvalues_long";
-			case "inheritPk":
-				return "inheritPk_docvalues_string";
-			case "created":
-				return "created_docvalues_date";
-			case "modified":
-				return "modified_docvalues_date";
-			case "archived":
-				return "archived_docvalues_boolean";
-			case "deleted":
-				return "deleted_docvalues_boolean";
-			case "classCanonicalName":
-				return "classCanonicalName_docvalues_string";
-			case "classSimpleName":
-				return "classSimpleName_docvalues_string";
-			case "classCanonicalNames":
-				return "classCanonicalNames_docvalues_strings";
-			case "sessionId":
-				return "sessionId_docvalues_string";
-			case "userKey":
-				return "userKey_docvalues_long";
-			case "saves":
-				return "saves_docvalues_strings";
-			case "objectTitle":
-				return "objectTitle_docvalues_string";
-			case "objectId":
-				return "objectId_docvalues_string";
-			case "objectText":
-				return "objectText_docvalues_string";
-			case "pageUrlId":
-				return "pageUrlId_docvalues_string";
-			case "pageUrlPk":
-				return "pageUrlPk_docvalues_string";
-			case "pageUrlApi":
-				return "pageUrlApi_docvalues_string";
-			default:
-				return null;
+			document.addField("id", id);
 		}
 	}
 
@@ -1924,37 +1808,37 @@ public abstract class BaseModelGen<DEV> extends Object {
 	// store //
 	/////////////
 
-	public void storeForClass(SolrResponse.Doc doc) {
-		storeBaseModel(doc);
+	public void storeForClass(SolrDocument solrDocument) {
+		storeBaseModel(solrDocument);
 	}
-	public void storeBaseModel(SolrResponse.Doc doc) {
+	public void storeBaseModel(SolrDocument solrDocument) {
 		BaseModel oBaseModel = (BaseModel)this;
 
-		oBaseModel.setPk(Optional.ofNullable(doc.get("pk_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setInheritPk(Optional.ofNullable(doc.get("inheritPk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setCreated(Optional.ofNullable(doc.get("created_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setModified(Optional.ofNullable(doc.get("modified_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setArchived(Optional.ofNullable(doc.get("archived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setDeleted(Optional.ofNullable(doc.get("deleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setClassCanonicalName(Optional.ofNullable(doc.get("classCanonicalName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setClassSimpleName(Optional.ofNullable(doc.get("classSimpleName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)doc.get("classCanonicalNames_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oBaseModel.setPk(Optional.ofNullable(solrDocument.get("pk_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setInheritPk(Optional.ofNullable(solrDocument.get("inheritPk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setCreated(Optional.ofNullable(solrDocument.get("created_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setModified(Optional.ofNullable(solrDocument.get("modified_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setArchived(Optional.ofNullable(solrDocument.get("archived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setDeleted(Optional.ofNullable(solrDocument.get("deleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setClassCanonicalName(Optional.ofNullable(solrDocument.get("classCanonicalName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setClassSimpleName(Optional.ofNullable(solrDocument.get("classSimpleName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)solrDocument.get("classCanonicalNames_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oBaseModel.addClassCanonicalNames(v.toString());
 		});
-		oBaseModel.setSessionId(Optional.ofNullable(doc.get("sessionId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setUserKey(Optional.ofNullable(doc.get("userKey_docvalues_long")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)doc.get("saves_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oBaseModel.setSessionId(Optional.ofNullable(solrDocument.get("sessionId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setUserKey(Optional.ofNullable(solrDocument.get("userKey_docvalues_long")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)solrDocument.get("saves_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oBaseModel.addSaves(v.toString());
 		});
-		oBaseModel.setObjectTitle(Optional.ofNullable(doc.get("objectTitle_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setObjectId(Optional.ofNullable(doc.get("objectId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		String objectSuggest = (String)doc.get("objectSuggest_suggested");
+		oBaseModel.setObjectTitle(Optional.ofNullable(solrDocument.get("objectTitle_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setObjectId(Optional.ofNullable(solrDocument.get("objectId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		String objectSuggest = (String)solrDocument.get("objectSuggest_suggested");
 		oBaseModel.setObjectSuggest(objectSuggest);
-		oBaseModel.setObjectText(Optional.ofNullable(doc.get("objectText_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlId(Optional.ofNullable(doc.get("pageUrlId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlPk(Optional.ofNullable(doc.get("pageUrlPk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlApi(Optional.ofNullable(doc.get("pageUrlApi_docvalues_string")).map(v -> v.toString()).orElse(null));
-		String id = (String)doc.get("id");
+		oBaseModel.setObjectText(Optional.ofNullable(solrDocument.get("objectText_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlId(Optional.ofNullable(solrDocument.get("pageUrlId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlPk(Optional.ofNullable(solrDocument.get("pageUrlPk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlApi(Optional.ofNullable(solrDocument.get("pageUrlApi_docvalues_string")).map(v -> v.toString()).orElse(null));
+		String id = (String)solrDocument.get("id");
 		oBaseModel.setId(id);
 	}
 
@@ -1963,7 +1847,7 @@ public abstract class BaseModelGen<DEV> extends Object {
 	//////////////////
 
 	public void apiRequestBaseModel() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof BaseModel) {
 			BaseModel original = (BaseModel)o;
@@ -2039,7 +1923,6 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "BaseModel";
 	public static final String VAR_siteRequest_ = "siteRequest_";
 	public static final String VAR_pk = "pk";
 	public static final String VAR_inheritPk = "inheritPk";
@@ -2062,296 +1945,4 @@ public abstract class BaseModelGen<DEV> extends Object {
 	public static final String VAR_pageUrlPk = "pageUrlPk";
 	public static final String VAR_pageUrlApi = "pageUrlApi";
 	public static final String VAR_id = "id";
-
-	public static List<String> varsQForClass() {
-		return BaseModel.varsQBaseModel(new ArrayList<String>());
-	}
-	public static List<String> varsQBaseModel(List<String> vars) {
-		vars.add(VAR_objectSuggest);
-		vars.add(VAR_objectText);
-		return vars;
-	}
-
-	public static List<String> varsFqForClass() {
-		return BaseModel.varsFqBaseModel(new ArrayList<String>());
-	}
-	public static List<String> varsFqBaseModel(List<String> vars) {
-		vars.add(VAR_pk);
-		vars.add(VAR_inheritPk);
-		vars.add(VAR_created);
-		vars.add(VAR_modified);
-		vars.add(VAR_objectTitle);
-		vars.add(VAR_objectId);
-		vars.add(VAR_pageUrlId);
-		vars.add(VAR_pageUrlPk);
-		vars.add(VAR_pageUrlApi);
-		vars.add(VAR_id);
-		return vars;
-	}
-
-	public static List<String> varsRangeForClass() {
-		return BaseModel.varsRangeBaseModel(new ArrayList<String>());
-	}
-	public static List<String> varsRangeBaseModel(List<String> vars) {
-		vars.add(VAR_pk);
-		vars.add(VAR_created);
-		vars.add(VAR_modified);
-		return vars;
-	}
-
-	public static final String DISPLAY_NAME_siteRequest_ = "";
-	public static final String DISPLAY_NAME_pk = "primary key";
-	public static final String DISPLAY_NAME_inheritPk = "";
-	public static final String DISPLAY_NAME_created = "created";
-	public static final String DISPLAY_NAME_modified = "modified";
-	public static final String DISPLAY_NAME_archived = "archived";
-	public static final String DISPLAY_NAME_deleted = "deleted";
-	public static final String DISPLAY_NAME_classCanonicalName = "";
-	public static final String DISPLAY_NAME_classSimpleName = "";
-	public static final String DISPLAY_NAME_classCanonicalNames = "";
-	public static final String DISPLAY_NAME_sessionId = "";
-	public static final String DISPLAY_NAME_userKey = "";
-	public static final String DISPLAY_NAME_saves = "";
-	public static final String DISPLAY_NAME_objectTitle = "";
-	public static final String DISPLAY_NAME_objectId = "ID";
-	public static final String DISPLAY_NAME_objectNameVar = "";
-	public static final String DISPLAY_NAME_objectSuggest = "autosuggest";
-	public static final String DISPLAY_NAME_objectText = "text";
-	public static final String DISPLAY_NAME_pageUrlId = "";
-	public static final String DISPLAY_NAME_pageUrlPk = "";
-	public static final String DISPLAY_NAME_pageUrlApi = "";
-	public static final String DISPLAY_NAME_id = "";
-
-	public static String displayNameForClass(String var) {
-		return BaseModel.displayNameBaseModel(var);
-	}
-	public static String displayNameBaseModel(String var) {
-		switch(var) {
-		case VAR_siteRequest_:
-			return DISPLAY_NAME_siteRequest_;
-		case VAR_pk:
-			return DISPLAY_NAME_pk;
-		case VAR_inheritPk:
-			return DISPLAY_NAME_inheritPk;
-		case VAR_created:
-			return DISPLAY_NAME_created;
-		case VAR_modified:
-			return DISPLAY_NAME_modified;
-		case VAR_archived:
-			return DISPLAY_NAME_archived;
-		case VAR_deleted:
-			return DISPLAY_NAME_deleted;
-		case VAR_classCanonicalName:
-			return DISPLAY_NAME_classCanonicalName;
-		case VAR_classSimpleName:
-			return DISPLAY_NAME_classSimpleName;
-		case VAR_classCanonicalNames:
-			return DISPLAY_NAME_classCanonicalNames;
-		case VAR_sessionId:
-			return DISPLAY_NAME_sessionId;
-		case VAR_userKey:
-			return DISPLAY_NAME_userKey;
-		case VAR_saves:
-			return DISPLAY_NAME_saves;
-		case VAR_objectTitle:
-			return DISPLAY_NAME_objectTitle;
-		case VAR_objectId:
-			return DISPLAY_NAME_objectId;
-		case VAR_objectNameVar:
-			return DISPLAY_NAME_objectNameVar;
-		case VAR_objectSuggest:
-			return DISPLAY_NAME_objectSuggest;
-		case VAR_objectText:
-			return DISPLAY_NAME_objectText;
-		case VAR_pageUrlId:
-			return DISPLAY_NAME_pageUrlId;
-		case VAR_pageUrlPk:
-			return DISPLAY_NAME_pageUrlPk;
-		case VAR_pageUrlApi:
-			return DISPLAY_NAME_pageUrlApi;
-		case VAR_id:
-			return DISPLAY_NAME_id;
-		default:
-			return null;
-		}
-	}
-
-	public static String descriptionBaseModel(String var) {
-		switch(var) {
-		case VAR_siteRequest_:
-			return "The current request object";
-		case VAR_pk:
-			return "The primary key of this object in the database";
-		case VAR_inheritPk:
-			return "An optional inherited primary key from a legacy system for this object in the database";
-		case VAR_created:
-			return "A created timestamp for this record in the database";
-		case VAR_modified:
-			return "A modified timestamp for this record in the database";
-		case VAR_archived:
-			return "For archiving this record";
-		case VAR_deleted:
-			return "For deleting this record";
-		case VAR_classCanonicalName:
-			return "the canonical name of this Java class";
-		case VAR_classSimpleName:
-			return "The simple name of this Java class";
-		case VAR_classCanonicalNames:
-			return "All the inherited canonical names of this Java class";
-		case VAR_sessionId:
-			return "The session ID of the user that created this object";
-		case VAR_userKey:
-			return "The primary key of the user that created this record";
-		case VAR_saves:
-			return "A list of fields that are saved for this record in the database";
-		case VAR_objectTitle:
-			return "The title of this object";
-		case VAR_objectId:
-			return "A URL friendly unique ID for this object";
-		case VAR_objectNameVar:
-			return "The var that identifies this type of object in the API";
-		case VAR_objectSuggest:
-			return "The indexed field in the search engine for this record while using autosuggest";
-		case VAR_objectText:
-			return "The full text search field in the search engine for this record while using autosuggest";
-		case VAR_pageUrlId:
-			return "The link by name for this object in the UI";
-		case VAR_pageUrlPk:
-			return "The link by primary key for this object in the UI";
-		case VAR_pageUrlApi:
-			return "The link to this object in the API";
-		case VAR_id:
-			return "The unique key for this record in the search engine";
-			default:
-				return null;
-		}
-	}
-
-	public static String classSimpleNameBaseModel(String var) {
-		switch(var) {
-		case VAR_siteRequest_:
-			return "SiteRequestEnUS";
-		case VAR_pk:
-			return "Long";
-		case VAR_inheritPk:
-			return "String";
-		case VAR_created:
-			return "ZonedDateTime";
-		case VAR_modified:
-			return "ZonedDateTime";
-		case VAR_archived:
-			return "Boolean";
-		case VAR_deleted:
-			return "Boolean";
-		case VAR_classCanonicalName:
-			return "String";
-		case VAR_classSimpleName:
-			return "String";
-		case VAR_classCanonicalNames:
-			return "List";
-		case VAR_sessionId:
-			return "String";
-		case VAR_userKey:
-			return "Long";
-		case VAR_saves:
-			return "List";
-		case VAR_objectTitle:
-			return "String";
-		case VAR_objectId:
-			return "String";
-		case VAR_objectNameVar:
-			return "String";
-		case VAR_objectSuggest:
-			return "String";
-		case VAR_objectText:
-			return "String";
-		case VAR_pageUrlId:
-			return "String";
-		case VAR_pageUrlPk:
-			return "String";
-		case VAR_pageUrlApi:
-			return "String";
-		case VAR_id:
-			return "String";
-			default:
-				return null;
-		}
-	}
-
-	public static Integer htmlColumnBaseModel(String var) {
-		switch(var) {
-		case VAR_created:
-			return 2;
-		case VAR_objectTitle:
-			return 2;
-			default:
-				return null;
-		}
-	}
-
-	public static Integer htmlRowBaseModel(String var) {
-		switch(var) {
-		case VAR_pk:
-			return 1;
-		case VAR_created:
-			return 1;
-		case VAR_modified:
-			return 1;
-		case VAR_archived:
-			return 2;
-		case VAR_deleted:
-			return 2;
-		case VAR_objectId:
-			return 1;
-			default:
-				return null;
-		}
-	}
-
-	public static Integer htmlCellBaseModel(String var) {
-		switch(var) {
-		case VAR_pk:
-			return 1;
-		case VAR_created:
-			return 2;
-		case VAR_modified:
-			return 3;
-		case VAR_archived:
-			return 1;
-		case VAR_deleted:
-			return 2;
-		case VAR_objectId:
-			return 4;
-			default:
-				return null;
-		}
-	}
-
-	public static Integer lengthMinBaseModel(String var) {
-		switch(var) {
-			default:
-				return null;
-		}
-	}
-
-	public static Integer lengthMaxBaseModel(String var) {
-		switch(var) {
-			default:
-				return null;
-		}
-	}
-
-	public static Integer maxBaseModel(String var) {
-		switch(var) {
-			default:
-				return null;
-		}
-	}
-
-	public static Integer minBaseModel(String var) {
-		switch(var) {
-			default:
-				return null;
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelGen.java
@@ -2,64 +2,60 @@ package org.curriki.api.enus.model.base;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
-import org.curriki.api.enus.base.BaseModel;
 import java.util.Date;
 import java.time.ZonedDateTime;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import org.apache.commons.lang3.StringUtils;
+import org.computate.search.response.solr.SolrResponse;
 import java.lang.Long;
 import java.util.Locale;
 import java.util.Map;
+import io.vertx.core.json.JsonObject;
 import java.time.ZoneOffset;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import java.math.MathContext;
+import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.Instant;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.time.ZoneId;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import java.util.List;
 import java.time.OffsetDateTime;
-import org.apache.solr.client.solrj.SolrQuery;
+import org.computate.search.wrap.Wrap;
 import java.util.Optional;
-import org.apache.solr.client.solrj.util.ClientUtils;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.request.api.ApiRequest;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.lang.Boolean;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
 import org.slf4j.Logger;
 import io.vertx.core.Promise;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.apache.solr.client.solrj.SolrClient;
 import io.vertx.core.json.JsonArray;
-import org.apache.solr.common.SolrDocument;
 import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
 import org.apache.commons.lang3.math.NumberUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.lang.Object;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class BaseModelGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModel.class);
@@ -76,10 +72,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br/> The entity siteRequest_
+	/**	<br> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> w);
@@ -115,10 +111,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br/> The entity pk
+	/**	<br> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -148,16 +144,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrPk(siteRequest_, BaseModel.staticSolrPk(siteRequest_, BaseModel.staticSetPk(siteRequest_, o)));
+	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrPk(siteRequest_, BaseModel.staticSearchPk(siteRequest_, BaseModel.staticSetPk(siteRequest_, o)));
 	}
 
 	///////////////
@@ -171,10 +167,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String inheritPk;
 
-	/**	<br/> The entity inheritPk
+	/**	<br> The entity inheritPk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:inheritPk">Find the entity inheritPk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:inheritPk">Find the entity inheritPk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _inheritPk(Wrap<String> w);
@@ -197,16 +193,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrInheritPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchInheritPk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrInheritPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrInheritPk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInheritPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrInheritPk(siteRequest_, BaseModel.staticSolrInheritPk(siteRequest_, BaseModel.staticSetInheritPk(siteRequest_, o)));
+	public static String staticSearchFqInheritPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrInheritPk(siteRequest_, BaseModel.staticSearchInheritPk(siteRequest_, BaseModel.staticSetInheritPk(siteRequest_, o)));
+	}
+
+	public String sqlInheritPk() {
+		return inheritPk;
 	}
 
 	/////////////
@@ -217,16 +217,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime created;
 
-	/**	<br/> The entity created
+	/**	<br> The entity created
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:created">Find the entity created in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:created">Find the entity created in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _created(Wrap<ZonedDateTime> w);
@@ -248,6 +248,8 @@ public abstract class BaseModelGen<DEV> extends Object {
 		this.created = BaseModel.staticSetCreated(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetCreated(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -266,16 +268,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Date staticSolrCreated(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchCreated(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrCreated(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrCreated(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqCreated(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrCreated(siteRequest_, BaseModel.staticSolrCreated(siteRequest_, BaseModel.staticSetCreated(siteRequest_, o)));
+	public static String staticSearchFqCreated(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrCreated(siteRequest_, BaseModel.staticSearchCreated(siteRequest_, BaseModel.staticSetCreated(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlCreated() {
+		return created == null ? null : created.toOffsetDateTime();
 	}
 
 	//////////////
@@ -286,16 +292,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime modified;
 
-	/**	<br/> The entity modified
+	/**	<br> The entity modified
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:modified">Find the entity modified in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:modified">Find the entity modified in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _modified(Wrap<ZonedDateTime> w);
@@ -317,6 +323,8 @@ public abstract class BaseModelGen<DEV> extends Object {
 		this.modified = BaseModel.staticSetModified(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetModified(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -335,16 +343,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Date staticSolrModified(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchModified(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrModified(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrModified(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqModified(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrModified(siteRequest_, BaseModel.staticSolrModified(siteRequest_, BaseModel.staticSetModified(siteRequest_, o)));
+	public static String staticSearchFqModified(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrModified(siteRequest_, BaseModel.staticSearchModified(siteRequest_, BaseModel.staticSetModified(siteRequest_, o)));
 	}
 
 	//////////////
@@ -358,10 +366,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean archived;
 
-	/**	<br/> The entity archived
+	/**	<br> The entity archived
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archived">Find the entity archived in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archived">Find the entity archived in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _archived(Wrap<Boolean> w);
@@ -389,16 +397,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Boolean staticSolrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSearchArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSolrStrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSearchStrArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqArchived(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrArchived(siteRequest_, BaseModel.staticSolrArchived(siteRequest_, BaseModel.staticSetArchived(siteRequest_, o)));
+	public static String staticSearchFqArchived(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrArchived(siteRequest_, BaseModel.staticSearchArchived(siteRequest_, BaseModel.staticSetArchived(siteRequest_, o)));
+	}
+
+	public Boolean sqlArchived() {
+		return archived;
 	}
 
 	/////////////
@@ -412,10 +424,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean deleted;
 
-	/**	<br/> The entity deleted
+	/**	<br> The entity deleted
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deleted">Find the entity deleted in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deleted">Find the entity deleted in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deleted(Wrap<Boolean> w);
@@ -443,16 +455,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Boolean staticSolrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSearchDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSolrStrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSearchStrDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDeleted(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrDeleted(siteRequest_, BaseModel.staticSolrDeleted(siteRequest_, BaseModel.staticSetDeleted(siteRequest_, o)));
+	public static String staticSearchFqDeleted(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrDeleted(siteRequest_, BaseModel.staticSearchDeleted(siteRequest_, BaseModel.staticSetDeleted(siteRequest_, o)));
+	}
+
+	public Boolean sqlDeleted() {
+		return deleted;
 	}
 
 	////////////////////////
@@ -466,10 +482,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classCanonicalName;
 
-	/**	<br/> The entity classCanonicalName
+	/**	<br> The entity classCanonicalName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalName">Find the entity classCanonicalName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalName">Find the entity classCanonicalName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classCanonicalName(Wrap<String> w);
@@ -492,16 +508,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrClassCanonicalName(siteRequest_, BaseModel.staticSolrClassCanonicalName(siteRequest_, BaseModel.staticSetClassCanonicalName(siteRequest_, o)));
+	public static String staticSearchFqClassCanonicalName(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrClassCanonicalName(siteRequest_, BaseModel.staticSearchClassCanonicalName(siteRequest_, BaseModel.staticSetClassCanonicalName(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -515,10 +531,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classSimpleName;
 
-	/**	<br/> The entity classSimpleName
+	/**	<br> The entity classSimpleName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classSimpleName(Wrap<String> w);
@@ -541,16 +557,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrClassSimpleName(siteRequest_, BaseModel.staticSolrClassSimpleName(siteRequest_, BaseModel.staticSetClassSimpleName(siteRequest_, o)));
+	public static String staticSearchFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrClassSimpleName(siteRequest_, BaseModel.staticSearchClassSimpleName(siteRequest_, BaseModel.staticSetClassSimpleName(siteRequest_, o)));
 	}
 
 	/////////////////////////
@@ -558,18 +574,18 @@ public abstract class BaseModelGen<DEV> extends Object {
 	/////////////////////////
 
 	/**	 The entity classCanonicalNames
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> classCanonicalNames = new ArrayList<String>();
 
-	/**	<br/> The entity classCanonicalNames
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalNames">Find the entity classCanonicalNames in Solr</a>
-	 * <br/>
-	 * @param classCanonicalNames is the entity already constructed. 
+	/**	<br> The entity classCanonicalNames
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classCanonicalNames">Find the entity classCanonicalNames in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _classCanonicalNames(List<String> l);
 
@@ -607,16 +623,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrClassCanonicalNames(siteRequest_, BaseModel.staticSolrClassCanonicalNames(siteRequest_, BaseModel.staticSetClassCanonicalNames(siteRequest_, o)));
+	public static String staticSearchFqClassCanonicalNames(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrClassCanonicalNames(siteRequest_, BaseModel.staticSearchClassCanonicalNames(siteRequest_, BaseModel.staticSetClassCanonicalNames(siteRequest_, o)));
 	}
 
 	///////////////
@@ -630,10 +646,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionId;
 
-	/**	<br/> The entity sessionId
+	/**	<br> The entity sessionId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionId(Wrap<String> w);
@@ -656,16 +672,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSessionId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrSessionId(siteRequest_, BaseModel.staticSolrSessionId(siteRequest_, BaseModel.staticSetSessionId(siteRequest_, o)));
+	public static String staticSearchFqSessionId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrSessionId(siteRequest_, BaseModel.staticSearchSessionId(siteRequest_, BaseModel.staticSetSessionId(siteRequest_, o)));
+	}
+
+	public String sqlSessionId() {
+		return sessionId;
 	}
 
 	/////////////
@@ -680,10 +700,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br/> The entity userKey
+	/**	<br> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> c);
@@ -713,16 +733,20 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrUserKey(siteRequest_, BaseModel.staticSolrUserKey(siteRequest_, BaseModel.staticSetUserKey(siteRequest_, o)));
+	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrUserKey(siteRequest_, BaseModel.staticSearchUserKey(siteRequest_, BaseModel.staticSetUserKey(siteRequest_, o)));
+	}
+
+	public Long sqlUserKey() {
+		return userKey;
 	}
 
 	///////////
@@ -730,18 +754,18 @@ public abstract class BaseModelGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity saves
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> saves = new ArrayList<String>();
 
-	/**	<br/> The entity saves
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:saves">Find the entity saves in Solr</a>
-	 * <br/>
-	 * @param saves is the entity already constructed. 
+	/**	<br> The entity saves
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:saves">Find the entity saves in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _saves(List<String> l);
 
@@ -779,16 +803,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrSaves(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSaves(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSaves(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSaves(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSaves(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrSaves(siteRequest_, BaseModel.staticSolrSaves(siteRequest_, BaseModel.staticSetSaves(siteRequest_, o)));
+	public static String staticSearchFqSaves(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrSaves(siteRequest_, BaseModel.staticSearchSaves(siteRequest_, BaseModel.staticSetSaves(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -802,10 +826,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectTitle;
 
-	/**	<br/> The entity objectTitle
+	/**	<br> The entity objectTitle
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectTitle">Find the entity objectTitle in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectTitle">Find the entity objectTitle in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectTitle(Wrap<String> w);
@@ -828,16 +852,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchObjectTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrObjectTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqObjectTitle(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrObjectTitle(siteRequest_, BaseModel.staticSolrObjectTitle(siteRequest_, BaseModel.staticSetObjectTitle(siteRequest_, o)));
+	public static String staticSearchFqObjectTitle(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrObjectTitle(siteRequest_, BaseModel.staticSearchObjectTitle(siteRequest_, BaseModel.staticSetObjectTitle(siteRequest_, o)));
 	}
 
 	//////////////
@@ -851,10 +875,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectId;
 
-	/**	<br/> The entity objectId
+	/**	<br> The entity objectId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectId">Find the entity objectId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectId">Find the entity objectId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectId(Wrap<String> w);
@@ -877,16 +901,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrObjectId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchObjectId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrObjectId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrObjectId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqObjectId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrObjectId(siteRequest_, BaseModel.staticSolrObjectId(siteRequest_, BaseModel.staticSetObjectId(siteRequest_, o)));
+	public static String staticSearchFqObjectId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrObjectId(siteRequest_, BaseModel.staticSearchObjectId(siteRequest_, BaseModel.staticSetObjectId(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -900,10 +924,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectNameVar;
 
-	/**	<br/> The entity objectNameVar
+	/**	<br> The entity objectNameVar
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectNameVar">Find the entity objectNameVar in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectNameVar">Find the entity objectNameVar in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectNameVar(Wrap<String> w);
@@ -926,16 +950,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrObjectNameVar(siteRequest_, BaseModel.staticSolrObjectNameVar(siteRequest_, BaseModel.staticSetObjectNameVar(siteRequest_, o)));
+	public static String staticSearchFqObjectNameVar(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrObjectNameVar(siteRequest_, BaseModel.staticSearchObjectNameVar(siteRequest_, BaseModel.staticSetObjectNameVar(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -949,10 +973,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectSuggest;
 
-	/**	<br/> The entity objectSuggest
+	/**	<br> The entity objectSuggest
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectSuggest">Find the entity objectSuggest in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectSuggest">Find the entity objectSuggest in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectSuggest(Wrap<String> w);
@@ -975,16 +999,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrObjectSuggest(siteRequest_, BaseModel.staticSolrObjectSuggest(siteRequest_, BaseModel.staticSetObjectSuggest(siteRequest_, o)));
+	public static String staticSearchFqObjectSuggest(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrObjectSuggest(siteRequest_, BaseModel.staticSearchObjectSuggest(siteRequest_, BaseModel.staticSetObjectSuggest(siteRequest_, o)));
 	}
 
 	////////////////
@@ -998,10 +1022,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String objectText;
 
-	/**	<br/> The entity objectText
+	/**	<br> The entity objectText
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectText">Find the entity objectText in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:objectText">Find the entity objectText in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _objectText(Wrap<String> w);
@@ -1024,16 +1048,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrObjectText(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchObjectText(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrObjectText(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrObjectText(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqObjectText(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrObjectText(siteRequest_, BaseModel.staticSolrObjectText(siteRequest_, BaseModel.staticSetObjectText(siteRequest_, o)));
+	public static String staticSearchFqObjectText(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrObjectText(siteRequest_, BaseModel.staticSearchObjectText(siteRequest_, BaseModel.staticSetObjectText(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1047,10 +1071,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlId;
 
-	/**	<br/> The entity pageUrlId
+	/**	<br> The entity pageUrlId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlId">Find the entity pageUrlId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlId">Find the entity pageUrlId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlId(Wrap<String> w);
@@ -1073,16 +1097,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageUrlId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageUrlId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageUrlId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrPageUrlId(siteRequest_, BaseModel.staticSolrPageUrlId(siteRequest_, BaseModel.staticSetPageUrlId(siteRequest_, o)));
+	public static String staticSearchFqPageUrlId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrPageUrlId(siteRequest_, BaseModel.staticSearchPageUrlId(siteRequest_, BaseModel.staticSetPageUrlId(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1096,10 +1120,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlPk;
 
-	/**	<br/> The entity pageUrlPk
+	/**	<br> The entity pageUrlPk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlPk">Find the entity pageUrlPk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlPk">Find the entity pageUrlPk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlPk(Wrap<String> w);
@@ -1122,16 +1146,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrPageUrlPk(siteRequest_, BaseModel.staticSolrPageUrlPk(siteRequest_, BaseModel.staticSetPageUrlPk(siteRequest_, o)));
+	public static String staticSearchFqPageUrlPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrPageUrlPk(siteRequest_, BaseModel.staticSearchPageUrlPk(siteRequest_, BaseModel.staticSetPageUrlPk(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1145,10 +1169,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrlApi;
 
-	/**	<br/> The entity pageUrlApi
+	/**	<br> The entity pageUrlApi
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlApi">Find the entity pageUrlApi in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrlApi">Find the entity pageUrlApi in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrlApi(Wrap<String> w);
@@ -1171,16 +1195,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrPageUrlApi(siteRequest_, BaseModel.staticSolrPageUrlApi(siteRequest_, BaseModel.staticSetPageUrlApi(siteRequest_, o)));
+	public static String staticSearchFqPageUrlApi(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrPageUrlApi(siteRequest_, BaseModel.staticSearchPageUrlApi(siteRequest_, BaseModel.staticSetPageUrlApi(siteRequest_, o)));
 	}
 
 	////////
@@ -1194,10 +1218,10 @@ public abstract class BaseModelGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String id;
 
-	/**	<br/> The entity id
+	/**	<br> The entity id
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModel&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _id(Wrap<String> w);
@@ -1220,16 +1244,16 @@ public abstract class BaseModelGen<DEV> extends Object {
 		return (BaseModel)this;
 	}
 
-	public static String staticSolrId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModel.staticSolrStrId(siteRequest_, BaseModel.staticSolrId(siteRequest_, BaseModel.staticSetId(siteRequest_, o)));
+	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModel.staticSearchStrId(siteRequest_, BaseModel.staticSearchId(siteRequest_, BaseModel.staticSetId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -1462,194 +1486,234 @@ public abstract class BaseModelGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrBaseModel(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSolrPk(siteRequest_, (Long)o);
+			return BaseModel.staticSearchPk(siteRequest_, (Long)o);
 		case "inheritPk":
-			return BaseModel.staticSolrInheritPk(siteRequest_, (String)o);
+			return BaseModel.staticSearchInheritPk(siteRequest_, (String)o);
 		case "created":
-			return BaseModel.staticSolrCreated(siteRequest_, (ZonedDateTime)o);
+			return BaseModel.staticSearchCreated(siteRequest_, (ZonedDateTime)o);
 		case "modified":
-			return BaseModel.staticSolrModified(siteRequest_, (ZonedDateTime)o);
+			return BaseModel.staticSearchModified(siteRequest_, (ZonedDateTime)o);
 		case "archived":
-			return BaseModel.staticSolrArchived(siteRequest_, (Boolean)o);
+			return BaseModel.staticSearchArchived(siteRequest_, (Boolean)o);
 		case "deleted":
-			return BaseModel.staticSolrDeleted(siteRequest_, (Boolean)o);
+			return BaseModel.staticSearchDeleted(siteRequest_, (Boolean)o);
 		case "classCanonicalName":
-			return BaseModel.staticSolrClassCanonicalName(siteRequest_, (String)o);
+			return BaseModel.staticSearchClassCanonicalName(siteRequest_, (String)o);
 		case "classSimpleName":
-			return BaseModel.staticSolrClassSimpleName(siteRequest_, (String)o);
+			return BaseModel.staticSearchClassSimpleName(siteRequest_, (String)o);
 		case "classCanonicalNames":
-			return BaseModel.staticSolrClassCanonicalNames(siteRequest_, (String)o);
+			return BaseModel.staticSearchClassCanonicalNames(siteRequest_, (String)o);
 		case "sessionId":
-			return BaseModel.staticSolrSessionId(siteRequest_, (String)o);
+			return BaseModel.staticSearchSessionId(siteRequest_, (String)o);
 		case "userKey":
-			return BaseModel.staticSolrUserKey(siteRequest_, (Long)o);
+			return BaseModel.staticSearchUserKey(siteRequest_, (Long)o);
 		case "saves":
-			return BaseModel.staticSolrSaves(siteRequest_, (String)o);
+			return BaseModel.staticSearchSaves(siteRequest_, (String)o);
 		case "objectTitle":
-			return BaseModel.staticSolrObjectTitle(siteRequest_, (String)o);
+			return BaseModel.staticSearchObjectTitle(siteRequest_, (String)o);
 		case "objectId":
-			return BaseModel.staticSolrObjectId(siteRequest_, (String)o);
+			return BaseModel.staticSearchObjectId(siteRequest_, (String)o);
 		case "objectNameVar":
-			return BaseModel.staticSolrObjectNameVar(siteRequest_, (String)o);
+			return BaseModel.staticSearchObjectNameVar(siteRequest_, (String)o);
 		case "objectSuggest":
-			return BaseModel.staticSolrObjectSuggest(siteRequest_, (String)o);
+			return BaseModel.staticSearchObjectSuggest(siteRequest_, (String)o);
 		case "objectText":
-			return BaseModel.staticSolrObjectText(siteRequest_, (String)o);
+			return BaseModel.staticSearchObjectText(siteRequest_, (String)o);
 		case "pageUrlId":
-			return BaseModel.staticSolrPageUrlId(siteRequest_, (String)o);
+			return BaseModel.staticSearchPageUrlId(siteRequest_, (String)o);
 		case "pageUrlPk":
-			return BaseModel.staticSolrPageUrlPk(siteRequest_, (String)o);
+			return BaseModel.staticSearchPageUrlPk(siteRequest_, (String)o);
 		case "pageUrlApi":
-			return BaseModel.staticSolrPageUrlApi(siteRequest_, (String)o);
+			return BaseModel.staticSearchPageUrlApi(siteRequest_, (String)o);
 		case "id":
-			return BaseModel.staticSolrId(siteRequest_, (String)o);
+			return BaseModel.staticSearchId(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrBaseModel(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrBaseModel(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSolrStrPk(siteRequest_, (Long)o);
+			return BaseModel.staticSearchStrPk(siteRequest_, (Long)o);
 		case "inheritPk":
-			return BaseModel.staticSolrStrInheritPk(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrInheritPk(siteRequest_, (String)o);
 		case "created":
-			return BaseModel.staticSolrStrCreated(siteRequest_, (Date)o);
+			return BaseModel.staticSearchStrCreated(siteRequest_, (Date)o);
 		case "modified":
-			return BaseModel.staticSolrStrModified(siteRequest_, (Date)o);
+			return BaseModel.staticSearchStrModified(siteRequest_, (Date)o);
 		case "archived":
-			return BaseModel.staticSolrStrArchived(siteRequest_, (Boolean)o);
+			return BaseModel.staticSearchStrArchived(siteRequest_, (Boolean)o);
 		case "deleted":
-			return BaseModel.staticSolrStrDeleted(siteRequest_, (Boolean)o);
+			return BaseModel.staticSearchStrDeleted(siteRequest_, (Boolean)o);
 		case "classCanonicalName":
-			return BaseModel.staticSolrStrClassCanonicalName(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrClassCanonicalName(siteRequest_, (String)o);
 		case "classSimpleName":
-			return BaseModel.staticSolrStrClassSimpleName(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrClassSimpleName(siteRequest_, (String)o);
 		case "classCanonicalNames":
-			return BaseModel.staticSolrStrClassCanonicalNames(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrClassCanonicalNames(siteRequest_, (String)o);
 		case "sessionId":
-			return BaseModel.staticSolrStrSessionId(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrSessionId(siteRequest_, (String)o);
 		case "userKey":
-			return BaseModel.staticSolrStrUserKey(siteRequest_, (Long)o);
+			return BaseModel.staticSearchStrUserKey(siteRequest_, (Long)o);
 		case "saves":
-			return BaseModel.staticSolrStrSaves(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrSaves(siteRequest_, (String)o);
 		case "objectTitle":
-			return BaseModel.staticSolrStrObjectTitle(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrObjectTitle(siteRequest_, (String)o);
 		case "objectId":
-			return BaseModel.staticSolrStrObjectId(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrObjectId(siteRequest_, (String)o);
 		case "objectNameVar":
-			return BaseModel.staticSolrStrObjectNameVar(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrObjectNameVar(siteRequest_, (String)o);
 		case "objectSuggest":
-			return BaseModel.staticSolrStrObjectSuggest(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrObjectSuggest(siteRequest_, (String)o);
 		case "objectText":
-			return BaseModel.staticSolrStrObjectText(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrObjectText(siteRequest_, (String)o);
 		case "pageUrlId":
-			return BaseModel.staticSolrStrPageUrlId(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrPageUrlId(siteRequest_, (String)o);
 		case "pageUrlPk":
-			return BaseModel.staticSolrStrPageUrlPk(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrPageUrlPk(siteRequest_, (String)o);
 		case "pageUrlApi":
-			return BaseModel.staticSolrStrPageUrlApi(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrPageUrlApi(siteRequest_, (String)o);
 		case "id":
-			return BaseModel.staticSolrStrId(siteRequest_, (String)o);
+			return BaseModel.staticSearchStrId(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqBaseModel(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqBaseModel(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqBaseModel(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqBaseModel(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "pk":
-			return BaseModel.staticSolrFqPk(siteRequest_, o);
+			return BaseModel.staticSearchFqPk(siteRequest_, o);
 		case "inheritPk":
-			return BaseModel.staticSolrFqInheritPk(siteRequest_, o);
+			return BaseModel.staticSearchFqInheritPk(siteRequest_, o);
 		case "created":
-			return BaseModel.staticSolrFqCreated(siteRequest_, o);
+			return BaseModel.staticSearchFqCreated(siteRequest_, o);
 		case "modified":
-			return BaseModel.staticSolrFqModified(siteRequest_, o);
+			return BaseModel.staticSearchFqModified(siteRequest_, o);
 		case "archived":
-			return BaseModel.staticSolrFqArchived(siteRequest_, o);
+			return BaseModel.staticSearchFqArchived(siteRequest_, o);
 		case "deleted":
-			return BaseModel.staticSolrFqDeleted(siteRequest_, o);
+			return BaseModel.staticSearchFqDeleted(siteRequest_, o);
 		case "classCanonicalName":
-			return BaseModel.staticSolrFqClassCanonicalName(siteRequest_, o);
+			return BaseModel.staticSearchFqClassCanonicalName(siteRequest_, o);
 		case "classSimpleName":
-			return BaseModel.staticSolrFqClassSimpleName(siteRequest_, o);
+			return BaseModel.staticSearchFqClassSimpleName(siteRequest_, o);
 		case "classCanonicalNames":
-			return BaseModel.staticSolrFqClassCanonicalNames(siteRequest_, o);
+			return BaseModel.staticSearchFqClassCanonicalNames(siteRequest_, o);
 		case "sessionId":
-			return BaseModel.staticSolrFqSessionId(siteRequest_, o);
+			return BaseModel.staticSearchFqSessionId(siteRequest_, o);
 		case "userKey":
-			return BaseModel.staticSolrFqUserKey(siteRequest_, o);
+			return BaseModel.staticSearchFqUserKey(siteRequest_, o);
 		case "saves":
-			return BaseModel.staticSolrFqSaves(siteRequest_, o);
+			return BaseModel.staticSearchFqSaves(siteRequest_, o);
 		case "objectTitle":
-			return BaseModel.staticSolrFqObjectTitle(siteRequest_, o);
+			return BaseModel.staticSearchFqObjectTitle(siteRequest_, o);
 		case "objectId":
-			return BaseModel.staticSolrFqObjectId(siteRequest_, o);
+			return BaseModel.staticSearchFqObjectId(siteRequest_, o);
 		case "objectNameVar":
-			return BaseModel.staticSolrFqObjectNameVar(siteRequest_, o);
+			return BaseModel.staticSearchFqObjectNameVar(siteRequest_, o);
 		case "objectSuggest":
-			return BaseModel.staticSolrFqObjectSuggest(siteRequest_, o);
+			return BaseModel.staticSearchFqObjectSuggest(siteRequest_, o);
 		case "objectText":
-			return BaseModel.staticSolrFqObjectText(siteRequest_, o);
+			return BaseModel.staticSearchFqObjectText(siteRequest_, o);
 		case "pageUrlId":
-			return BaseModel.staticSolrFqPageUrlId(siteRequest_, o);
+			return BaseModel.staticSearchFqPageUrlId(siteRequest_, o);
 		case "pageUrlPk":
-			return BaseModel.staticSolrFqPageUrlPk(siteRequest_, o);
+			return BaseModel.staticSearchFqPageUrlPk(siteRequest_, o);
 		case "pageUrlApi":
-			return BaseModel.staticSolrFqPageUrlApi(siteRequest_, o);
+			return BaseModel.staticSearchFqPageUrlApi(siteRequest_, o);
 		case "id":
-			return BaseModel.staticSolrFqId(siteRequest_, o);
+			return BaseModel.staticSearchFqId(siteRequest_, o);
 			default:
 				return null;
 		}
 	}
 
 	/////////////
-	// define //
+	// persist //
 	/////////////
 
-	public boolean defineForClass(String var, Object val) {
+	public boolean persistForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = defineBaseModel(v, val);
+					o = persistBaseModel(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
+					o = oBaseModel.persistForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object defineBaseModel(String var, Object val) {
+	public Object persistBaseModel(String var, Object val) {
 		switch(var.toLowerCase()) {
+			case "inheritpk":
+				if(val instanceof String)
+					setInheritPk((String)val);
+				saves.add("inheritPk");
+				return val;
+			case "created":
+				if(val instanceof ZonedDateTime)
+					setCreated((ZonedDateTime)val);
+				else if(val instanceof String)
+					setCreated((String)val);
+				else if(val instanceof OffsetDateTime)
+					setCreated(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("created");
+				return val;
+			case "archived":
+				if(val instanceof Boolean)
+					setArchived((Boolean)val);
+				else if(val instanceof String)
+					setArchived((String)val);
+				saves.add("archived");
+				return val;
+			case "deleted":
+				if(val instanceof Boolean)
+					setDeleted((Boolean)val);
+				else if(val instanceof String)
+					setDeleted((String)val);
+				saves.add("deleted");
+				return val;
+			case "sessionid":
+				if(val instanceof String)
+					setSessionId((String)val);
+				saves.add("sessionId");
+				return val;
+			case "userkey":
+				if(val instanceof Long)
+					setUserKey((Long)val);
+				else if(val instanceof String)
+					setUserKey((String)val);
+				saves.add("userKey");
+				return val;
 			default:
 				return null;
 		}
@@ -1659,81 +1723,93 @@ public abstract class BaseModelGen<DEV> extends Object {
 	// populate //
 	/////////////
 
-	public void populateForClass(SolrDocument solrDocument) {
-		populateBaseModel(solrDocument);
+	public void populateForClass(SolrResponse.Doc doc) {
+		populateBaseModel(doc);
 	}
-	public void populateBaseModel(SolrDocument solrDocument) {
+	public void populateBaseModel(SolrResponse.Doc doc) {
 		BaseModel oBaseModel = (BaseModel)this;
-		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
+		saves = doc.get("saves_docvalues_strings");
 		if(saves != null) {
+
+			if(saves.contains("objectSuggest")) {
+				String objectSuggest = (String)doc.get("objectSuggest_suggested");
+				oBaseModel.setObjectSuggest(objectSuggest);
+			}
+
+			String id = (String)doc.get("id");
+			oBaseModel.setId(id);
 		}
 	}
 
-	public void indexBaseModel(SolrInputDocument document) {
+	public void indexBaseModel(JsonObject doc) {
 		if(pk != null) {
-			document.addField("pk_docvalues_long", pk);
+			doc.put("pk_docvalues_long", pk);
 		}
 		if(inheritPk != null) {
-			document.addField("inheritPk_docvalues_string", inheritPk);
+			doc.put("inheritPk_docvalues_string", inheritPk);
 		}
 		if(created != null) {
-			document.addField("created_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(created.toInstant(), ZoneId.of("UTC"))));
+			doc.put("created_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(created.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(modified != null) {
-			document.addField("modified_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(modified.toInstant(), ZoneId.of("UTC"))));
+			doc.put("modified_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(modified.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(archived != null) {
-			document.addField("archived_docvalues_boolean", archived);
+			doc.put("archived_docvalues_boolean", archived);
 		}
 		if(deleted != null) {
-			document.addField("deleted_docvalues_boolean", deleted);
+			doc.put("deleted_docvalues_boolean", deleted);
 		}
 		if(classCanonicalName != null) {
-			document.addField("classCanonicalName_docvalues_string", classCanonicalName);
+			doc.put("classCanonicalName_docvalues_string", classCanonicalName);
 		}
 		if(classSimpleName != null) {
-			document.addField("classSimpleName_docvalues_string", classSimpleName);
+			doc.put("classSimpleName_docvalues_string", classSimpleName);
 		}
 		if(classCanonicalNames != null) {
-			for(java.lang.String o : classCanonicalNames) {
-				document.addField("classCanonicalNames_docvalues_strings", o);
+			JsonArray l = new JsonArray();
+			doc.put("classCanonicalNames_docvalues_strings", l);
+			for(String o : classCanonicalNames) {
+				l.add(o);
 			}
 		}
 		if(sessionId != null) {
-			document.addField("sessionId_docvalues_string", sessionId);
+			doc.put("sessionId_docvalues_string", sessionId);
 		}
 		if(userKey != null) {
-			document.addField("userKey_docvalues_long", userKey);
+			doc.put("userKey_docvalues_long", userKey);
 		}
 		if(saves != null) {
-			for(java.lang.String o : saves) {
-				document.addField("saves_docvalues_strings", o);
+			JsonArray l = new JsonArray();
+			doc.put("saves_docvalues_strings", l);
+			for(String o : saves) {
+				l.add(o);
 			}
 		}
 		if(objectTitle != null) {
-			document.addField("objectTitle_docvalues_string", objectTitle);
+			doc.put("objectTitle_docvalues_string", objectTitle);
 		}
 		if(objectId != null) {
-			document.addField("objectId_docvalues_string", objectId);
+			doc.put("objectId_docvalues_string", objectId);
 		}
 		if(objectSuggest != null) {
-			document.addField("objectSuggest_suggested", objectSuggest);
+			doc.put("objectSuggest_suggested", objectSuggest);
 		}
 		if(objectText != null) {
-			document.addField("objectText_text_enUS", objectText.toString());
-			document.addField("objectText_docvalues_string", objectText);
+			doc.put("objectText_text_enUS", objectText.toString());
+			doc.put("objectText_docvalues_string", objectText);
 		}
 		if(pageUrlId != null) {
-			document.addField("pageUrlId_docvalues_string", pageUrlId);
+			doc.put("pageUrlId_docvalues_string", pageUrlId);
 		}
 		if(pageUrlPk != null) {
-			document.addField("pageUrlPk_docvalues_string", pageUrlPk);
+			doc.put("pageUrlPk_docvalues_string", pageUrlPk);
 		}
 		if(pageUrlApi != null) {
-			document.addField("pageUrlApi_docvalues_string", pageUrlApi);
+			doc.put("pageUrlApi_docvalues_string", pageUrlApi);
 		}
 		if(id != null) {
-			document.addField("id", id);
+			doc.put("id", id);
 		}
 	}
 
@@ -1808,37 +1884,37 @@ public abstract class BaseModelGen<DEV> extends Object {
 	// store //
 	/////////////
 
-	public void storeForClass(SolrDocument solrDocument) {
-		storeBaseModel(solrDocument);
+	public void storeForClass(SolrResponse.Doc doc) {
+		storeBaseModel(doc);
 	}
-	public void storeBaseModel(SolrDocument solrDocument) {
+	public void storeBaseModel(SolrResponse.Doc doc) {
 		BaseModel oBaseModel = (BaseModel)this;
 
-		oBaseModel.setPk(Optional.ofNullable(solrDocument.get("pk_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setInheritPk(Optional.ofNullable(solrDocument.get("inheritPk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setCreated(Optional.ofNullable(solrDocument.get("created_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setModified(Optional.ofNullable(solrDocument.get("modified_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setArchived(Optional.ofNullable(solrDocument.get("archived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setDeleted(Optional.ofNullable(solrDocument.get("deleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setClassCanonicalName(Optional.ofNullable(solrDocument.get("classCanonicalName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setClassSimpleName(Optional.ofNullable(solrDocument.get("classSimpleName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)solrDocument.get("classCanonicalNames_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oBaseModel.setPk(Optional.ofNullable(doc.get("pk_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setInheritPk(Optional.ofNullable(doc.get("inheritPk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setCreated(Optional.ofNullable(doc.get("created_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setModified(Optional.ofNullable(doc.get("modified_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setArchived(Optional.ofNullable(doc.get("archived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setDeleted(Optional.ofNullable(doc.get("deleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setClassCanonicalName(Optional.ofNullable(doc.get("classCanonicalName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setClassSimpleName(Optional.ofNullable(doc.get("classSimpleName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)doc.get("classCanonicalNames_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oBaseModel.addClassCanonicalNames(v.toString());
 		});
-		oBaseModel.setSessionId(Optional.ofNullable(solrDocument.get("sessionId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setUserKey(Optional.ofNullable(solrDocument.get("userKey_docvalues_long")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)solrDocument.get("saves_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oBaseModel.setSessionId(Optional.ofNullable(doc.get("sessionId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setUserKey(Optional.ofNullable(doc.get("userKey_docvalues_long")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)doc.get("saves_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oBaseModel.addSaves(v.toString());
 		});
-		oBaseModel.setObjectTitle(Optional.ofNullable(solrDocument.get("objectTitle_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setObjectId(Optional.ofNullable(solrDocument.get("objectId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		String objectSuggest = (String)solrDocument.get("objectSuggest_suggested");
+		oBaseModel.setObjectTitle(Optional.ofNullable(doc.get("objectTitle_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setObjectId(Optional.ofNullable(doc.get("objectId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		String objectSuggest = (String)doc.get("objectSuggest_suggested");
 		oBaseModel.setObjectSuggest(objectSuggest);
-		oBaseModel.setObjectText(Optional.ofNullable(solrDocument.get("objectText_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlId(Optional.ofNullable(solrDocument.get("pageUrlId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlPk(Optional.ofNullable(solrDocument.get("pageUrlPk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oBaseModel.setPageUrlApi(Optional.ofNullable(solrDocument.get("pageUrlApi_docvalues_string")).map(v -> v.toString()).orElse(null));
-		String id = (String)solrDocument.get("id");
+		oBaseModel.setObjectText(Optional.ofNullable(doc.get("objectText_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlId(Optional.ofNullable(doc.get("pageUrlId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlPk(Optional.ofNullable(doc.get("pageUrlPk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oBaseModel.setPageUrlApi(Optional.ofNullable(doc.get("pageUrlApi_docvalues_string")).map(v -> v.toString()).orElse(null));
+		String id = (String)doc.get("id");
 		oBaseModel.setId(id);
 	}
 
@@ -1847,7 +1923,7 @@ public abstract class BaseModelGen<DEV> extends Object {
 	//////////////////
 
 	public void apiRequestBaseModel() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof BaseModel) {
 			BaseModel original = (BaseModel)o;
@@ -1945,4 +2021,296 @@ public abstract class BaseModelGen<DEV> extends Object {
 	public static final String VAR_pageUrlPk = "pageUrlPk";
 	public static final String VAR_pageUrlApi = "pageUrlApi";
 	public static final String VAR_id = "id";
+
+	public static List<String> varsQForClass() {
+		return BaseModel.varsQBaseModel(new ArrayList<String>());
+	}
+	public static List<String> varsQBaseModel(List<String> vars) {
+		vars.add(VAR_objectSuggest);
+		vars.add(VAR_objectText);
+		return vars;
+	}
+
+	public static List<String> varsFqForClass() {
+		return BaseModel.varsFqBaseModel(new ArrayList<String>());
+	}
+	public static List<String> varsFqBaseModel(List<String> vars) {
+		vars.add(VAR_pk);
+		vars.add(VAR_inheritPk);
+		vars.add(VAR_created);
+		vars.add(VAR_modified);
+		vars.add(VAR_objectTitle);
+		vars.add(VAR_objectId);
+		vars.add(VAR_pageUrlId);
+		vars.add(VAR_pageUrlPk);
+		vars.add(VAR_pageUrlApi);
+		vars.add(VAR_id);
+		return vars;
+	}
+
+	public static List<String> varsRangeForClass() {
+		return BaseModel.varsRangeBaseModel(new ArrayList<String>());
+	}
+	public static List<String> varsRangeBaseModel(List<String> vars) {
+		vars.add(VAR_pk);
+		vars.add(VAR_created);
+		vars.add(VAR_modified);
+		return vars;
+	}
+
+	public static final String DISPLAY_NAME_siteRequest_ = "";
+	public static final String DISPLAY_NAME_pk = "primary key";
+	public static final String DISPLAY_NAME_inheritPk = "";
+	public static final String DISPLAY_NAME_created = "created";
+	public static final String DISPLAY_NAME_modified = "modified";
+	public static final String DISPLAY_NAME_archived = "archived";
+	public static final String DISPLAY_NAME_deleted = "deleted";
+	public static final String DISPLAY_NAME_classCanonicalName = "";
+	public static final String DISPLAY_NAME_classSimpleName = "";
+	public static final String DISPLAY_NAME_classCanonicalNames = "";
+	public static final String DISPLAY_NAME_sessionId = "";
+	public static final String DISPLAY_NAME_userKey = "";
+	public static final String DISPLAY_NAME_saves = "";
+	public static final String DISPLAY_NAME_objectTitle = "";
+	public static final String DISPLAY_NAME_objectId = "ID";
+	public static final String DISPLAY_NAME_objectNameVar = "";
+	public static final String DISPLAY_NAME_objectSuggest = "autosuggest";
+	public static final String DISPLAY_NAME_objectText = "text";
+	public static final String DISPLAY_NAME_pageUrlId = "";
+	public static final String DISPLAY_NAME_pageUrlPk = "";
+	public static final String DISPLAY_NAME_pageUrlApi = "";
+	public static final String DISPLAY_NAME_id = "";
+
+	public static String displayNameForClass(String var) {
+		return BaseModel.displayNameBaseModel(var);
+	}
+	public static String displayNameBaseModel(String var) {
+		switch(var) {
+		case VAR_siteRequest_:
+			return DISPLAY_NAME_siteRequest_;
+		case VAR_pk:
+			return DISPLAY_NAME_pk;
+		case VAR_inheritPk:
+			return DISPLAY_NAME_inheritPk;
+		case VAR_created:
+			return DISPLAY_NAME_created;
+		case VAR_modified:
+			return DISPLAY_NAME_modified;
+		case VAR_archived:
+			return DISPLAY_NAME_archived;
+		case VAR_deleted:
+			return DISPLAY_NAME_deleted;
+		case VAR_classCanonicalName:
+			return DISPLAY_NAME_classCanonicalName;
+		case VAR_classSimpleName:
+			return DISPLAY_NAME_classSimpleName;
+		case VAR_classCanonicalNames:
+			return DISPLAY_NAME_classCanonicalNames;
+		case VAR_sessionId:
+			return DISPLAY_NAME_sessionId;
+		case VAR_userKey:
+			return DISPLAY_NAME_userKey;
+		case VAR_saves:
+			return DISPLAY_NAME_saves;
+		case VAR_objectTitle:
+			return DISPLAY_NAME_objectTitle;
+		case VAR_objectId:
+			return DISPLAY_NAME_objectId;
+		case VAR_objectNameVar:
+			return DISPLAY_NAME_objectNameVar;
+		case VAR_objectSuggest:
+			return DISPLAY_NAME_objectSuggest;
+		case VAR_objectText:
+			return DISPLAY_NAME_objectText;
+		case VAR_pageUrlId:
+			return DISPLAY_NAME_pageUrlId;
+		case VAR_pageUrlPk:
+			return DISPLAY_NAME_pageUrlPk;
+		case VAR_pageUrlApi:
+			return DISPLAY_NAME_pageUrlApi;
+		case VAR_id:
+			return DISPLAY_NAME_id;
+		default:
+			return null;
+		}
+	}
+
+	public static String descriptionBaseModel(String var) {
+		switch(var) {
+		case VAR_siteRequest_:
+			return "The current request object";
+		case VAR_pk:
+			return "The primary key of this object in the database";
+		case VAR_inheritPk:
+			return "An optional inherited primary key from a legacy system for this object in the database";
+		case VAR_created:
+			return "A created timestamp for this record in the database";
+		case VAR_modified:
+			return "A modified timestamp for this record in the database";
+		case VAR_archived:
+			return "For archiving this record";
+		case VAR_deleted:
+			return "For deleting this record";
+		case VAR_classCanonicalName:
+			return "the canonical name of this Java class";
+		case VAR_classSimpleName:
+			return "The simple name of this Java class";
+		case VAR_classCanonicalNames:
+			return "All the inherited canonical names of this Java class";
+		case VAR_sessionId:
+			return "The session ID of the user that created this object";
+		case VAR_userKey:
+			return "The primary key of the user that created this record";
+		case VAR_saves:
+			return "A list of fields that are saved for this record in the database";
+		case VAR_objectTitle:
+			return "The title of this object";
+		case VAR_objectId:
+			return "A URL friendly unique ID for this object";
+		case VAR_objectNameVar:
+			return "The var that identifies this type of object in the API";
+		case VAR_objectSuggest:
+			return "The indexed field in the search engine for this record while using autosuggest";
+		case VAR_objectText:
+			return "The full text search field in the search engine for this record while using autosuggest";
+		case VAR_pageUrlId:
+			return "The link by name for this object in the UI";
+		case VAR_pageUrlPk:
+			return "The link by primary key for this object in the UI";
+		case VAR_pageUrlApi:
+			return "The link to this object in the API";
+		case VAR_id:
+			return "The unique key for this record in the search engine";
+			default:
+				return null;
+		}
+	}
+
+	public static String classSimpleNameBaseModel(String var) {
+		switch(var) {
+		case VAR_siteRequest_:
+			return "SiteRequestEnUS";
+		case VAR_pk:
+			return "Long";
+		case VAR_inheritPk:
+			return "String";
+		case VAR_created:
+			return "ZonedDateTime";
+		case VAR_modified:
+			return "ZonedDateTime";
+		case VAR_archived:
+			return "Boolean";
+		case VAR_deleted:
+			return "Boolean";
+		case VAR_classCanonicalName:
+			return "String";
+		case VAR_classSimpleName:
+			return "String";
+		case VAR_classCanonicalNames:
+			return "List";
+		case VAR_sessionId:
+			return "String";
+		case VAR_userKey:
+			return "Long";
+		case VAR_saves:
+			return "List";
+		case VAR_objectTitle:
+			return "String";
+		case VAR_objectId:
+			return "String";
+		case VAR_objectNameVar:
+			return "String";
+		case VAR_objectSuggest:
+			return "String";
+		case VAR_objectText:
+			return "String";
+		case VAR_pageUrlId:
+			return "String";
+		case VAR_pageUrlPk:
+			return "String";
+		case VAR_pageUrlApi:
+			return "String";
+		case VAR_id:
+			return "String";
+			default:
+				return null;
+		}
+	}
+
+	public static Integer htmlColumnBaseModel(String var) {
+		switch(var) {
+		case VAR_created:
+			return 1;
+		case VAR_objectTitle:
+			return 2;
+			default:
+				return null;
+		}
+	}
+
+	public static Integer htmlRowBaseModel(String var) {
+		switch(var) {
+		case VAR_pk:
+			return 1;
+		case VAR_created:
+			return 1;
+		case VAR_modified:
+			return 1;
+		case VAR_archived:
+			return 2;
+		case VAR_deleted:
+			return 2;
+		case VAR_objectId:
+			return 1;
+			default:
+				return null;
+		}
+	}
+
+	public static Integer htmlCellBaseModel(String var) {
+		switch(var) {
+		case VAR_pk:
+			return 1;
+		case VAR_created:
+			return 2;
+		case VAR_modified:
+			return 3;
+		case VAR_archived:
+			return 1;
+		case VAR_deleted:
+			return 2;
+		case VAR_objectId:
+			return 4;
+			default:
+				return null;
+		}
+	}
+
+	public static Integer lengthMinBaseModel(String var) {
+		switch(var) {
+			default:
+				return null;
+		}
+	}
+
+	public static Integer lengthMaxBaseModel(String var) {
+		switch(var) {
+			default:
+				return null;
+		}
+	}
+
+	public static Integer maxBaseModel(String var) {
+		switch(var) {
+			default:
+				return null;
+		}
+	}
+
+	public static Integer minBaseModel(String var) {
+		switch(var) {
+			default:
+				return null;
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelGenPageGen.java
@@ -3,47 +3,47 @@ package org.curriki.api.enus.model.base;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
+import org.computate.search.response.solr.SolrResponse.FacetCounts;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import java.lang.Long;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
-import java.math.RoundingMode;
 import org.curriki.api.enus.model.base.BaseModel;
-import org.curriki.api.enus.search.SearchList;
+import java.math.RoundingMode;
 import org.slf4j.Logger;
 import org.curriki.api.enus.page.PageLayout;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
+import org.computate.vertx.search.list.SearchList;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModelGenPage.class);
@@ -59,10 +59,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<BaseModel> searchListBaseModel_;
 
-	/**	<br/> The entity searchListBaseModel_
+	/**	<br> The entity searchListBaseModel_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListBaseModel_">Find the entity searchListBaseModel_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListBaseModel_">Find the entity searchListBaseModel_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListBaseModel_(Wrap<SearchList<BaseModel>> w);
@@ -86,21 +86,136 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
+	//////////////////
+	// pageResponse //
+	//////////////////
+
+	/**	 The entity pageResponse
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String pageResponse;
+
+	/**	<br> The entity pageResponse
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _pageResponse(Wrap<String> w);
+
+	public String getPageResponse() {
+		return pageResponse;
+	}
+	public void setPageResponse(String o) {
+		this.pageResponse = BaseModelGenPage.staticSetPageResponse(siteRequest_, o);
+	}
+	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected BaseModelGenPage pageResponseInit() {
+		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
+		if(pageResponse == null) {
+			_pageResponse(pageResponseWrap);
+			setPageResponse(pageResponseWrap.o);
+		}
+		return (BaseModelGenPage)this;
+	}
+
+	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSearchStrPageResponse(siteRequest_, BaseModelGenPage.staticSearchPageResponse(siteRequest_, BaseModelGenPage.staticSetPageResponse(siteRequest_, o)));
+	}
+
+	//////////////////////
+	// defaultPivotVars //
+	//////////////////////
+
+	/**	 The entity defaultPivotVars
+	 *	 It is constructed before being initialized with the constructor by default. 
+	 */
+	@JsonProperty
+	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
+	@JsonInclude(Include.NON_NULL)
+	protected List<String> defaultPivotVars = new ArrayList<String>();
+
+	/**	<br> The entity defaultPivotVars
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultPivotVars">Find the entity defaultPivotVars in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
+	 **/
+	protected abstract void _defaultPivotVars(List<String> l);
+
+	public List<String> getDefaultPivotVars() {
+		return defaultPivotVars;
+	}
+
+	public void setDefaultPivotVars(List<String> defaultPivotVars) {
+		this.defaultPivotVars = defaultPivotVars;
+	}
+	public static String staticSetDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	public BaseModelGenPage addDefaultPivotVars(String...objets) {
+		for(String o : objets) {
+			addDefaultPivotVars(o);
+		}
+		return (BaseModelGenPage)this;
+	}
+	public BaseModelGenPage addDefaultPivotVars(String o) {
+		if(o != null)
+			this.defaultPivotVars.add(o);
+		return (BaseModelGenPage)this;
+	}
+	@JsonIgnore
+	public void setDefaultPivotVars(JsonArray objets) {
+		defaultPivotVars.clear();
+		for(int i = 0; i < objets.size(); i++) {
+			String o = objets.getString(i);
+			addDefaultPivotVars(o);
+		}
+	}
+	protected BaseModelGenPage defaultPivotVarsInit() {
+		_defaultPivotVars(defaultPivotVars);
+		return (BaseModelGenPage)this;
+	}
+
+	public static String staticSearchDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSearchStrDefaultPivotVars(siteRequest_, BaseModelGenPage.staticSearchDefaultPivotVars(siteRequest_, BaseModelGenPage.staticSetDefaultPivotVars(siteRequest_, o)));
+	}
+
 	///////////////////
 	// listBaseModel //
 	///////////////////
 
 	/**	 The entity listBaseModel
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listBaseModel = new JsonArray();
 
-	/**	<br/> The entity listBaseModel
-	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listBaseModel">Find the entity listBaseModel in Solr</a>
-	 * <br/>
-	 * @param listBaseModel is the entity already constructed. 
+	/**	<br> The entity listBaseModel
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listBaseModel">Find the entity listBaseModel in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _listBaseModel(JsonArray l);
 
@@ -119,6 +234,44 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
+	/////////////////
+	// facetCounts //
+	/////////////////
+
+	/**	 The entity facetCounts
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected FacetCounts facetCounts;
+
+	/**	<br> The entity facetCounts
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _facetCounts(Wrap<FacetCounts> w);
+
+	public FacetCounts getFacetCounts() {
+		return facetCounts;
+	}
+
+	public void setFacetCounts(FacetCounts facetCounts) {
+		this.facetCounts = facetCounts;
+	}
+	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected BaseModelGenPage facetCountsInit() {
+		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
+		if(facetCounts == null) {
+			_facetCounts(facetCountsWrap);
+			setFacetCounts(facetCountsWrap.o);
+		}
+		return (BaseModelGenPage)this;
+	}
+
 	////////////////////
 	// baseModelCount //
 	////////////////////
@@ -131,10 +284,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer baseModelCount;
 
-	/**	<br/> The entity baseModelCount
+	/**	<br> The entity baseModelCount
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModelCount">Find the entity baseModelCount in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModelCount">Find the entity baseModelCount in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _baseModelCount(Wrap<Integer> w);
@@ -164,16 +317,16 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
-	public static Integer staticSolrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqBaseModelCount(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSolrStrBaseModelCount(siteRequest_, BaseModelGenPage.staticSolrBaseModelCount(siteRequest_, BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o)));
+	public static String staticSearchFqBaseModelCount(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSearchStrBaseModelCount(siteRequest_, BaseModelGenPage.staticSearchBaseModelCount(siteRequest_, BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o)));
 	}
 
 	////////////////
@@ -187,10 +340,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected BaseModel baseModel_;
 
-	/**	<br/> The entity baseModel_
+	/**	<br> The entity baseModel_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModel_">Find the entity baseModel_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModel_">Find the entity baseModel_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _baseModel_(Wrap<BaseModel> w);
@@ -226,10 +379,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br/> The entity pk
+	/**	<br> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -259,16 +412,65 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
-	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSolrStrPk(siteRequest_, BaseModelGenPage.staticSolrPk(siteRequest_, BaseModelGenPage.staticSetPk(siteRequest_, o)));
+	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSearchStrPk(siteRequest_, BaseModelGenPage.staticSearchPk(siteRequest_, BaseModelGenPage.staticSetPk(siteRequest_, o)));
+	}
+
+	////////
+	// id //
+	////////
+
+	/**	 The entity id
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String id;
+
+	/**	<br> The entity id
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _id(Wrap<String> w);
+
+	public String getId() {
+		return id;
+	}
+	public void setId(String o) {
+		this.id = BaseModelGenPage.staticSetId(siteRequest_, o);
+	}
+	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected BaseModelGenPage idInit() {
+		Wrap<String> idWrap = new Wrap<String>().var("id");
+		if(id == null) {
+			_id(idWrap);
+			setId(idWrap.o);
+		}
+		return (BaseModelGenPage)this;
+	}
+
+	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSearchStrId(siteRequest_, BaseModelGenPage.staticSearchId(siteRequest_, BaseModelGenPage.staticSetId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -301,10 +503,14 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListBaseModel_Init();
+				pageResponseInit();
+				defaultPivotVarsInit();
 				listBaseModelInit();
+				facetCountsInit();
 				baseModelCountInit();
 				baseModel_Init();
 				pkInit();
+				idInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -360,14 +566,22 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		switch(var) {
 			case "searchListBaseModel_":
 				return oBaseModelGenPage.searchListBaseModel_;
+			case "pageResponse":
+				return oBaseModelGenPage.pageResponse;
+			case "defaultPivotVars":
+				return oBaseModelGenPage.defaultPivotVars;
 			case "listBaseModel":
 				return oBaseModelGenPage.listBaseModel;
+			case "facetCounts":
+				return oBaseModelGenPage.facetCounts;
 			case "baseModelCount":
 				return oBaseModelGenPage.baseModelCount;
 			case "baseModel_":
 				return oBaseModelGenPage.baseModel_;
 			case "pk":
 				return oBaseModelGenPage.pk;
+			case "id":
+				return oBaseModelGenPage.id;
 			default:
 				return super.obtainPageLayout(var);
 		}
@@ -407,105 +621,90 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	}
 	public static Object staticSetBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return BaseModelGenPage.staticSetPageResponse(siteRequest_, o);
+		case "defaultPivotVars":
+			return BaseModelGenPage.staticSetDefaultPivotVars(siteRequest_, o);
 		case "baseModelCount":
 			return BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o);
 		case "pk":
 			return BaseModelGenPage.staticSetPk(siteRequest_, o);
+		case "id":
+			return BaseModelGenPage.staticSetId(siteRequest_, o);
 			default:
 				return PageLayout.staticSetPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return BaseModelGenPage.staticSearchPageResponse(siteRequest_, (String)o);
+		case "defaultPivotVars":
+			return BaseModelGenPage.staticSearchDefaultPivotVars(siteRequest_, (String)o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSolrBaseModelCount(siteRequest_, (Integer)o);
+			return BaseModelGenPage.staticSearchBaseModelCount(siteRequest_, (Integer)o);
 		case "pk":
-			return BaseModelGenPage.staticSolrPk(siteRequest_, (Long)o);
+			return BaseModelGenPage.staticSearchPk(siteRequest_, (Long)o);
+		case "id":
+			return BaseModelGenPage.staticSearchId(siteRequest_, (String)o);
 			default:
-				return PageLayout.staticSolrPageLayout(entityVar,  siteRequest_, o);
+				return PageLayout.staticSearchPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return BaseModelGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
+		case "defaultPivotVars":
+			return BaseModelGenPage.staticSearchStrDefaultPivotVars(siteRequest_, (String)o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSolrStrBaseModelCount(siteRequest_, (Integer)o);
+			return BaseModelGenPage.staticSearchStrBaseModelCount(siteRequest_, (Integer)o);
 		case "pk":
-			return BaseModelGenPage.staticSolrStrPk(siteRequest_, (Long)o);
+			return BaseModelGenPage.staticSearchStrPk(siteRequest_, (Long)o);
+		case "id":
+			return BaseModelGenPage.staticSearchStrId(siteRequest_, (String)o);
 			default:
-				return PageLayout.staticSolrStrPageLayout(entityVar,  siteRequest_, o);
+				return PageLayout.staticSearchStrPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return BaseModelGenPage.staticSearchFqPageResponse(siteRequest_, o);
+		case "defaultPivotVars":
+			return BaseModelGenPage.staticSearchFqDefaultPivotVars(siteRequest_, o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSolrFqBaseModelCount(siteRequest_, o);
+			return BaseModelGenPage.staticSearchFqBaseModelCount(siteRequest_, o);
 		case "pk":
-			return BaseModelGenPage.staticSolrFqPk(siteRequest_, o);
+			return BaseModelGenPage.staticSearchFqPk(siteRequest_, o);
+		case "id":
+			return BaseModelGenPage.staticSearchFqId(siteRequest_, o);
 			default:
-				return PageLayout.staticSolrFqPageLayout(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineBaseModelGenPage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineBaseModelGenPage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.definePageLayout(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestBaseModelGenPage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof BaseModelGenPage) {
-			BaseModelGenPage original = (BaseModelGenPage)o;
-			super.apiRequestPageLayout();
+				return PageLayout.staticSearchFqPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -520,8 +719,50 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	}
 
 	public static final String VAR_searchListBaseModel_ = "searchListBaseModel_";
+	public static final String VAR_pageResponse = "pageResponse";
+	public static final String VAR_defaultPivotVars = "defaultPivotVars";
 	public static final String VAR_listBaseModel = "listBaseModel";
+	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_baseModelCount = "baseModelCount";
 	public static final String VAR_baseModel_ = "baseModel_";
 	public static final String VAR_pk = "pk";
+	public static final String VAR_id = "id";
+
+	public static final String DISPLAY_NAME_searchListBaseModel_ = "";
+	public static final String DISPLAY_NAME_pageResponse = "";
+	public static final String DISPLAY_NAME_defaultPivotVars = "";
+	public static final String DISPLAY_NAME_listBaseModel = "";
+	public static final String DISPLAY_NAME_facetCounts = "";
+	public static final String DISPLAY_NAME_baseModelCount = "";
+	public static final String DISPLAY_NAME_baseModel_ = "";
+	public static final String DISPLAY_NAME_pk = "";
+	public static final String DISPLAY_NAME_id = "";
+
+	public static String displayNameForClass(String var) {
+		return BaseModelGenPage.displayNameBaseModelGenPage(var);
+	}
+	public static String displayNameBaseModelGenPage(String var) {
+		switch(var) {
+		case VAR_searchListBaseModel_:
+			return DISPLAY_NAME_searchListBaseModel_;
+		case VAR_pageResponse:
+			return DISPLAY_NAME_pageResponse;
+		case VAR_defaultPivotVars:
+			return DISPLAY_NAME_defaultPivotVars;
+		case VAR_listBaseModel:
+			return DISPLAY_NAME_listBaseModel;
+		case VAR_facetCounts:
+			return DISPLAY_NAME_facetCounts;
+		case VAR_baseModelCount:
+			return DISPLAY_NAME_baseModelCount;
+		case VAR_baseModel_:
+			return DISPLAY_NAME_baseModel_;
+		case VAR_pk:
+			return DISPLAY_NAME_pk;
+		case VAR_id:
+			return DISPLAY_NAME_id;
+		default:
+			return PageLayout.displayNamePageLayout(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelGenPageGen.java
@@ -1,54 +1,49 @@
 package org.curriki.api.enus.model.base;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import org.curriki.api.enus.page.PageLayout;
-import org.computate.vertx.search.list.SearchList;
-import java.lang.String;
-import io.vertx.core.json.JsonArray;
-import org.computate.search.response.solr.SolrResponse.FacetCounts;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
-import org.computate.search.wrap.Wrap;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import java.lang.Long;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import java.math.RoundingMode;
+import org.curriki.api.enus.model.base.BaseModel;
+import org.curriki.api.enus.search.SearchList;
+import org.slf4j.Logger;
+import org.curriki.api.enus.page.PageLayout;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
+import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage">Find the class BaseModelGenPage in Solr. </a>
- * <br><br>Delete the class BaseModelGenPage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.base in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.base&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModelGenPage.class);
@@ -64,10 +59,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<BaseModel> searchListBaseModel_;
 
-	/**	<br> The entity searchListBaseModel_
+	/**	<br/> The entity searchListBaseModel_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:searchListBaseModel_">Find the entity searchListBaseModel_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListBaseModel_">Find the entity searchListBaseModel_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListBaseModel_(Wrap<SearchList<BaseModel>> w);
@@ -91,136 +86,21 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
-	//////////////////
-	// pageResponse //
-	//////////////////
-
-	/**	 The entity pageResponse
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String pageResponse;
-
-	/**	<br> The entity pageResponse
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _pageResponse(Wrap<String> w);
-
-	public String getPageResponse() {
-		return pageResponse;
-	}
-	public void setPageResponse(String o) {
-		this.pageResponse = BaseModelGenPage.staticSetPageResponse(siteRequest_, o);
-	}
-	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected BaseModelGenPage pageResponseInit() {
-		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
-		if(pageResponse == null) {
-			_pageResponse(pageResponseWrap);
-			setPageResponse(pageResponseWrap.o);
-		}
-		return (BaseModelGenPage)this;
-	}
-
-	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSearchStrPageResponse(siteRequest_, BaseModelGenPage.staticSearchPageResponse(siteRequest_, BaseModelGenPage.staticSetPageResponse(siteRequest_, o)));
-	}
-
-	//////////////////////
-	// defaultPivotVars //
-	//////////////////////
-
-	/**	 The entity defaultPivotVars
-	 *	 It is constructed before being initialized with the constructor by default. 
-	 */
-	@JsonProperty
-	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
-	@JsonInclude(Include.NON_NULL)
-	protected List<String> defaultPivotVars = new ArrayList<String>();
-
-	/**	<br> The entity defaultPivotVars
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:defaultPivotVars">Find the entity defaultPivotVars in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
-	 **/
-	protected abstract void _defaultPivotVars(List<String> l);
-
-	public List<String> getDefaultPivotVars() {
-		return defaultPivotVars;
-	}
-
-	public void setDefaultPivotVars(List<String> defaultPivotVars) {
-		this.defaultPivotVars = defaultPivotVars;
-	}
-	public static String staticSetDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	public BaseModelGenPage addDefaultPivotVars(String...objets) {
-		for(String o : objets) {
-			addDefaultPivotVars(o);
-		}
-		return (BaseModelGenPage)this;
-	}
-	public BaseModelGenPage addDefaultPivotVars(String o) {
-		if(o != null)
-			this.defaultPivotVars.add(o);
-		return (BaseModelGenPage)this;
-	}
-	@JsonIgnore
-	public void setDefaultPivotVars(JsonArray objets) {
-		defaultPivotVars.clear();
-		for(int i = 0; i < objets.size(); i++) {
-			String o = objets.getString(i);
-			addDefaultPivotVars(o);
-		}
-	}
-	protected BaseModelGenPage defaultPivotVarsInit() {
-		_defaultPivotVars(defaultPivotVars);
-		return (BaseModelGenPage)this;
-	}
-
-	public static String staticSearchDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultPivotVars(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSearchStrDefaultPivotVars(siteRequest_, BaseModelGenPage.staticSearchDefaultPivotVars(siteRequest_, BaseModelGenPage.staticSetDefaultPivotVars(siteRequest_, o)));
-	}
-
 	///////////////////
 	// listBaseModel //
 	///////////////////
 
 	/**	 The entity listBaseModel
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listBaseModel = new JsonArray();
 
-	/**	<br> The entity listBaseModel
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:listBaseModel">Find the entity listBaseModel in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity listBaseModel
+	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listBaseModel">Find the entity listBaseModel in Solr</a>
+	 * <br/>
+	 * @param listBaseModel is the entity already constructed. 
 	 **/
 	protected abstract void _listBaseModel(JsonArray l);
 
@@ -239,44 +119,6 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
-	/////////////////
-	// facetCounts //
-	/////////////////
-
-	/**	 The entity facetCounts
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected FacetCounts facetCounts;
-
-	/**	<br> The entity facetCounts
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _facetCounts(Wrap<FacetCounts> w);
-
-	public FacetCounts getFacetCounts() {
-		return facetCounts;
-	}
-
-	public void setFacetCounts(FacetCounts facetCounts) {
-		this.facetCounts = facetCounts;
-	}
-	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected BaseModelGenPage facetCountsInit() {
-		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
-		if(facetCounts == null) {
-			_facetCounts(facetCountsWrap);
-			setFacetCounts(facetCountsWrap.o);
-		}
-		return (BaseModelGenPage)this;
-	}
-
 	////////////////////
 	// baseModelCount //
 	////////////////////
@@ -289,10 +131,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer baseModelCount;
 
-	/**	<br> The entity baseModelCount
+	/**	<br/> The entity baseModelCount
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:baseModelCount">Find the entity baseModelCount in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModelCount">Find the entity baseModelCount in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _baseModelCount(Wrap<Integer> w);
@@ -322,16 +164,16 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return (BaseModelGenPage)this;
 	}
 
-	public static Integer staticSearchBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrBaseModelCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqBaseModelCount(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSearchStrBaseModelCount(siteRequest_, BaseModelGenPage.staticSearchBaseModelCount(siteRequest_, BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o)));
+	public static String staticSolrFqBaseModelCount(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSolrStrBaseModelCount(siteRequest_, BaseModelGenPage.staticSolrBaseModelCount(siteRequest_, BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o)));
 	}
 
 	////////////////
@@ -345,10 +187,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	@JsonInclude(Include.NON_NULL)
 	protected BaseModel baseModel_;
 
-	/**	<br> The entity baseModel_
+	/**	<br/> The entity baseModel_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:baseModel_">Find the entity baseModel_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:baseModel_">Find the entity baseModel_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _baseModel_(Wrap<BaseModel> w);
@@ -373,52 +215,60 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	}
 
 	////////
-	// id //
+	// pk //
 	////////
 
-	/**	 The entity id
+	/**	 The entity pk
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
 	@JsonInclude(Include.NON_NULL)
-	protected String id;
+	protected Long pk;
 
-	/**	<br> The entity id
+	/**	<br/> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
-	protected abstract void _id(Wrap<String> w);
+	protected abstract void _pk(Wrap<Long> w);
 
-	public String getId() {
-		return id;
+	public Long getPk() {
+		return pk;
 	}
-	public void setId(String o) {
-		this.id = BaseModelGenPage.staticSetId(siteRequest_, o);
+
+	public void setPk(Long pk) {
+		this.pk = pk;
 	}
-	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
+	@JsonIgnore
+	public void setPk(String o) {
+		this.pk = BaseModelGenPage.staticSetPk(siteRequest_, o);
 	}
-	protected BaseModelGenPage idInit() {
-		Wrap<String> idWrap = new Wrap<String>().var("id");
-		if(id == null) {
-			_id(idWrap);
-			setId(idWrap.o);
+	public static Long staticSetPk(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Long.parseLong(o);
+		return null;
+	}
+	protected BaseModelGenPage pkInit() {
+		Wrap<Long> pkWrap = new Wrap<Long>().var("pk");
+		if(pk == null) {
+			_pk(pkWrap);
+			setPk(pkWrap.o);
 		}
 		return (BaseModelGenPage)this;
 	}
 
-	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
+	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
-		return BaseModelGenPage.staticSearchStrId(siteRequest_, BaseModelGenPage.staticSearchId(siteRequest_, BaseModelGenPage.staticSetId(siteRequest_, o)));
+	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return BaseModelGenPage.staticSolrStrPk(siteRequest_, BaseModelGenPage.staticSolrPk(siteRequest_, BaseModelGenPage.staticSetPk(siteRequest_, o)));
 	}
 
 	//////////////
@@ -451,13 +301,10 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListBaseModel_Init();
-				pageResponseInit();
-				defaultPivotVarsInit();
 				listBaseModelInit();
-				facetCountsInit();
 				baseModelCountInit();
 				baseModel_Init();
-				idInit();
+				pkInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -513,20 +360,14 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		switch(var) {
 			case "searchListBaseModel_":
 				return oBaseModelGenPage.searchListBaseModel_;
-			case "pageResponse":
-				return oBaseModelGenPage.pageResponse;
-			case "defaultPivotVars":
-				return oBaseModelGenPage.defaultPivotVars;
 			case "listBaseModel":
 				return oBaseModelGenPage.listBaseModel;
-			case "facetCounts":
-				return oBaseModelGenPage.facetCounts;
 			case "baseModelCount":
 				return oBaseModelGenPage.baseModelCount;
 			case "baseModel_":
 				return oBaseModelGenPage.baseModel_;
-			case "id":
-				return oBaseModelGenPage.id;
+			case "pk":
+				return oBaseModelGenPage.pk;
 			default:
 				return super.obtainPageLayout(var);
 		}
@@ -566,82 +407,105 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 	}
 	public static Object staticSetBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return BaseModelGenPage.staticSetPageResponse(siteRequest_, o);
-		case "defaultPivotVars":
-			return BaseModelGenPage.staticSetDefaultPivotVars(siteRequest_, o);
 		case "baseModelCount":
 			return BaseModelGenPage.staticSetBaseModelCount(siteRequest_, o);
-		case "id":
-			return BaseModelGenPage.staticSetId(siteRequest_, o);
+		case "pk":
+			return BaseModelGenPage.staticSetPk(siteRequest_, o);
 			default:
 				return PageLayout.staticSetPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return BaseModelGenPage.staticSearchPageResponse(siteRequest_, (String)o);
-		case "defaultPivotVars":
-			return BaseModelGenPage.staticSearchDefaultPivotVars(siteRequest_, (String)o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSearchBaseModelCount(siteRequest_, (Integer)o);
-		case "id":
-			return BaseModelGenPage.staticSearchId(siteRequest_, (String)o);
+			return BaseModelGenPage.staticSolrBaseModelCount(siteRequest_, (Integer)o);
+		case "pk":
+			return BaseModelGenPage.staticSolrPk(siteRequest_, (Long)o);
 			default:
-				return PageLayout.staticSearchPageLayout(entityVar,  siteRequest_, o);
+				return PageLayout.staticSolrPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return BaseModelGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
-		case "defaultPivotVars":
-			return BaseModelGenPage.staticSearchStrDefaultPivotVars(siteRequest_, (String)o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSearchStrBaseModelCount(siteRequest_, (Integer)o);
-		case "id":
-			return BaseModelGenPage.staticSearchStrId(siteRequest_, (String)o);
+			return BaseModelGenPage.staticSolrStrBaseModelCount(siteRequest_, (Integer)o);
+		case "pk":
+			return BaseModelGenPage.staticSolrStrPk(siteRequest_, (Long)o);
 			default:
-				return PageLayout.staticSearchStrPageLayout(entityVar,  siteRequest_, o);
+				return PageLayout.staticSolrStrPageLayout(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqBaseModelGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqBaseModelGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqBaseModelGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return BaseModelGenPage.staticSearchFqPageResponse(siteRequest_, o);
-		case "defaultPivotVars":
-			return BaseModelGenPage.staticSearchFqDefaultPivotVars(siteRequest_, o);
 		case "baseModelCount":
-			return BaseModelGenPage.staticSearchFqBaseModelCount(siteRequest_, o);
-		case "id":
-			return BaseModelGenPage.staticSearchFqId(siteRequest_, o);
+			return BaseModelGenPage.staticSolrFqBaseModelCount(siteRequest_, o);
+		case "pk":
+			return BaseModelGenPage.staticSolrFqPk(siteRequest_, o);
 			default:
-				return PageLayout.staticSearchFqPageLayout(entityVar,  siteRequest_, o);
+				return PageLayout.staticSolrFqPageLayout(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineBaseModelGenPage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineBaseModelGenPage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.definePageLayout(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestBaseModelGenPage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof BaseModelGenPage) {
+			BaseModelGenPage original = (BaseModelGenPage)o;
+			super.apiRequestPageLayout();
 		}
 	}
 
@@ -655,48 +519,9 @@ public abstract class BaseModelGenPageGen<DEV> extends PageLayout {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "BaseModelGenPage";
 	public static final String VAR_searchListBaseModel_ = "searchListBaseModel_";
-	public static final String VAR_pageResponse = "pageResponse";
-	public static final String VAR_defaultPivotVars = "defaultPivotVars";
 	public static final String VAR_listBaseModel = "listBaseModel";
-	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_baseModelCount = "baseModelCount";
 	public static final String VAR_baseModel_ = "baseModel_";
-	public static final String VAR_id = "id";
-
-	public static final String DISPLAY_NAME_searchListBaseModel_ = "";
-	public static final String DISPLAY_NAME_pageResponse = "";
-	public static final String DISPLAY_NAME_defaultPivotVars = "";
-	public static final String DISPLAY_NAME_listBaseModel = "";
-	public static final String DISPLAY_NAME_facetCounts = "";
-	public static final String DISPLAY_NAME_baseModelCount = "";
-	public static final String DISPLAY_NAME_baseModel_ = "";
-	public static final String DISPLAY_NAME_id = "";
-
-	public static String displayNameForClass(String var) {
-		return BaseModelGenPage.displayNameBaseModelGenPage(var);
-	}
-	public static String displayNameBaseModelGenPage(String var) {
-		switch(var) {
-		case VAR_searchListBaseModel_:
-			return DISPLAY_NAME_searchListBaseModel_;
-		case VAR_pageResponse:
-			return DISPLAY_NAME_pageResponse;
-		case VAR_defaultPivotVars:
-			return DISPLAY_NAME_defaultPivotVars;
-		case VAR_listBaseModel:
-			return DISPLAY_NAME_listBaseModel;
-		case VAR_facetCounts:
-			return DISPLAY_NAME_facetCounts;
-		case VAR_baseModelCount:
-			return DISPLAY_NAME_baseModelCount;
-		case VAR_baseModel_:
-			return DISPLAY_NAME_baseModel_;
-		case VAR_id:
-			return DISPLAY_NAME_id;
-		default:
-			return PageLayout.displayNamePageLayout(var);
-		}
-	}
+	public static final String VAR_pk = "pk";
 }

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelPageGen.java
@@ -3,42 +3,42 @@ package org.curriki.api.enus.model.base;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
+import org.computate.vertx.api.ApiRequest;
 import org.curriki.api.enus.model.base.BaseModelGenPage;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModelPage.class);
@@ -170,83 +170,44 @@ public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrBaseModelPage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSolrBaseModelGenPage(entityVar,  siteRequest_, o);
+				return BaseModelGenPage.staticSearchBaseModelGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSolrStrBaseModelGenPage(entityVar,  siteRequest_, o);
+				return BaseModelGenPage.staticSearchStrBaseModelGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSolrFqBaseModelGenPage(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineBaseModelPage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineBaseModelPage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.defineBaseModelGenPage(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestBaseModelPage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof BaseModelPage) {
-			BaseModelPage original = (BaseModelPage)o;
-			super.apiRequestBaseModelGenPage();
+				return BaseModelGenPage.staticSearchFqBaseModelGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -260,4 +221,15 @@ public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 		return sb.toString();
 	}
 
+
+
+	public static String displayNameForClass(String var) {
+		return BaseModelPage.displayNameBaseModelPage(var);
+	}
+	public static String displayNameBaseModelPage(String var) {
+		switch(var) {
+		default:
+			return BaseModelGenPage.displayNameBaseModelGenPage(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/base/BaseModelPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/base/BaseModelPageGen.java
@@ -1,50 +1,44 @@
 package org.curriki.api.enus.model.base;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
 import org.curriki.api.enus.model.base.BaseModelGenPage;
-import org.computate.search.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.math.RoundingMode;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelPage">Find the class BaseModelPage in Solr. </a>
- * <br><br>Delete the class BaseModelPage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelPage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.base in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.base&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.base.BaseModelPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(BaseModelPage.class);
@@ -176,44 +170,83 @@ public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchBaseModelPage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSearchBaseModelGenPage(entityVar,  siteRequest_, o);
+				return BaseModelGenPage.staticSolrBaseModelGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSearchStrBaseModelGenPage(entityVar,  siteRequest_, o);
+				return BaseModelGenPage.staticSolrStrBaseModelGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqBaseModelPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return BaseModelGenPage.staticSearchFqBaseModelGenPage(entityVar,  siteRequest_, o);
+				return BaseModelGenPage.staticSolrFqBaseModelGenPage(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineBaseModelPage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineBaseModelPage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.defineBaseModelGenPage(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestBaseModelPage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof BaseModelPage) {
+			BaseModelPage original = (BaseModelPage)o;
+			super.apiRequestBaseModelGenPage();
 		}
 	}
 
@@ -227,16 +260,4 @@ public abstract class BaseModelPageGen<DEV> extends BaseModelGenPage {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "BaseModelPage";
-
-
-	public static String displayNameForClass(String var) {
-		return BaseModelPage.displayNameBaseModelPage(var);
-	}
-	public static String displayNameBaseModelPage(String var) {
-		switch(var) {
-		default:
-			return BaseModelGenPage.displayNameBaseModelGenPage(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
@@ -5140,9 +5140,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
 	@JsonInclude(Include.NON_NULL)
-	protected Integer subjectAreaDisplayName;
+	protected String subjectAreaDisplayName;
 
 	/**	<br/> The entity subjectAreaDisplayName
 	 *  is defined as null before being initialized. 
@@ -5150,26 +5149,19 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
-	protected abstract void _subjectAreaDisplayName(Wrap<Integer> w);
+	protected abstract void _subjectAreaDisplayName(Wrap<String> w);
 
-	public Integer getSubjectAreaDisplayName() {
+	public String getSubjectAreaDisplayName() {
 		return subjectAreaDisplayName;
 	}
-
-	public void setSubjectAreaDisplayName(Integer subjectAreaDisplayName) {
-		this.subjectAreaDisplayName = subjectAreaDisplayName;
-	}
-	@JsonIgnore
 	public void setSubjectAreaDisplayName(String o) {
 		this.subjectAreaDisplayName = CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o);
 	}
-	public static Integer staticSetSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
+	public static String staticSetSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
 	}
 	protected CurrikiResource subjectAreaDisplayNameInit() {
-		Wrap<Integer> subjectAreaDisplayNameWrap = new Wrap<Integer>().var("subjectAreaDisplayName");
+		Wrap<String> subjectAreaDisplayNameWrap = new Wrap<String>().var("subjectAreaDisplayName");
 		if(subjectAreaDisplayName == null) {
 			_subjectAreaDisplayName(subjectAreaDisplayNameWrap);
 			setSubjectAreaDisplayName(subjectAreaDisplayNameWrap.o);
@@ -5177,11 +5169,11 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
@@ -5197,9 +5189,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
 	@JsonInclude(Include.NON_NULL)
-	protected Integer instructionTypeDisplayName;
+	protected String instructionTypeDisplayName;
 
 	/**	<br/> The entity instructionTypeDisplayName
 	 *  is defined as null before being initialized. 
@@ -5207,26 +5198,19 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
-	protected abstract void _instructionTypeDisplayName(Wrap<Integer> w);
+	protected abstract void _instructionTypeDisplayName(Wrap<String> w);
 
-	public Integer getInstructionTypeDisplayName() {
+	public String getInstructionTypeDisplayName() {
 		return instructionTypeDisplayName;
 	}
-
-	public void setInstructionTypeDisplayName(Integer instructionTypeDisplayName) {
-		this.instructionTypeDisplayName = instructionTypeDisplayName;
-	}
-	@JsonIgnore
 	public void setInstructionTypeDisplayName(String o) {
 		this.instructionTypeDisplayName = CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o);
 	}
-	public static Integer staticSetInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
+	public static String staticSetInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
 	}
 	protected CurrikiResource instructionTypeDisplayNameInit() {
-		Wrap<Integer> instructionTypeDisplayNameWrap = new Wrap<Integer>().var("instructionTypeDisplayName");
+		Wrap<String> instructionTypeDisplayNameWrap = new Wrap<String>().var("instructionTypeDisplayName");
 		if(instructionTypeDisplayName == null) {
 			_instructionTypeDisplayName(instructionTypeDisplayNameWrap);
 			setInstructionTypeDisplayName(instructionTypeDisplayNameWrap.o);
@@ -5234,11 +5218,11 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
@@ -6111,9 +6095,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		case "subjectArea":
 			return CurrikiResource.staticSolrSubjectArea(siteRequest_, (String)o);
 		case "subjectAreaDisplayName":
-			return CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, (String)o);
 		case "instructionTypeDisplayName":
-			return CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, (String)o);
 		case "name":
 			return CurrikiResource.staticSolrName(siteRequest_, (String)o);
 			default:
@@ -6321,9 +6305,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		case "subjectArea":
 			return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, (String)o);
 		case "subjectAreaDisplayName":
-			return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, (String)o);
 		case "instructionTypeDisplayName":
-			return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, (String)o);
 		case "name":
 			return CurrikiResource.staticSolrStrName(siteRequest_, (String)o);
 			default:
@@ -6874,10 +6858,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			document.addField("subjectArea_docvalues_string", subjectArea);
 		}
 		if(subjectAreaDisplayName != null) {
-			document.addField("subjectAreaDisplayName_docvalues_int", subjectAreaDisplayName);
+			document.addField("subjectAreaDisplayName_docvalues_string", subjectAreaDisplayName);
 		}
 		if(instructionTypeDisplayName != null) {
-			document.addField("instructionTypeDisplayName_docvalues_int", instructionTypeDisplayName);
+			document.addField("instructionTypeDisplayName_docvalues_string", instructionTypeDisplayName);
 		}
 		if(name != null) {
 			document.addField("name_docvalues_string", name);
@@ -7067,9 +7051,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			case "subjectArea":
 				return "subjectArea_docvalues_string";
 			case "subjectAreaDisplayName":
-				return "subjectAreaDisplayName_docvalues_int";
+				return "subjectAreaDisplayName_docvalues_string";
 			case "instructionTypeDisplayName":
-				return "instructionTypeDisplayName_docvalues_int";
+				return "instructionTypeDisplayName_docvalues_string";
 			case "name":
 				return "name_docvalues_string";
 			default:
@@ -7196,8 +7180,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		oCurrikiResource.setIdentifier(Optional.ofNullable(solrDocument.get("identifier_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setEducationLevelDisplayName(Optional.ofNullable(solrDocument.get("educationLevelDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setSubjectArea(Optional.ofNullable(solrDocument.get("subjectArea_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectAreaDisplayName(Optional.ofNullable(solrDocument.get("subjectAreaDisplayName_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionTypeDisplayName(Optional.ofNullable(solrDocument.get("instructionTypeDisplayName_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectAreaDisplayName(Optional.ofNullable(solrDocument.get("subjectAreaDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionTypeDisplayName(Optional.ofNullable(solrDocument.get("instructionTypeDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setName(Optional.ofNullable(solrDocument.get("name_docvalues_string")).map(v -> v.toString()).orElse(null));
 
 		super.storeBaseModel(solrDocument);
@@ -7502,8 +7486,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(identifier).map(v -> "identifier: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(educationLevelDisplayName).map(v -> "educationLevelDisplayName: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(subjectArea).map(v -> "subjectArea: \"" + v + "\"\n" ).orElse(""));
-		sb.append(Optional.ofNullable(subjectAreaDisplayName).map(v -> "subjectAreaDisplayName: " + v + "\n").orElse(""));
-		sb.append(Optional.ofNullable(instructionTypeDisplayName).map(v -> "instructionTypeDisplayName: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(subjectAreaDisplayName).map(v -> "subjectAreaDisplayName: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(instructionTypeDisplayName).map(v -> "instructionTypeDisplayName: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(name).map(v -> "name: \"" + v + "\"\n" ).orElse(""));
 		return sb.toString();
 	}

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
@@ -2,67 +2,60 @@ package org.curriki.api.enus.model.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
-import org.curriki.api.enus.base.BaseModel;
 import java.util.Date;
 import java.time.ZonedDateTime;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
+import org.computate.search.response.solr.SolrResponse;
 import java.math.BigDecimal;
 import java.lang.Long;
 import java.util.Locale;
 import java.util.Map;
 import io.vertx.core.json.JsonObject;
 import java.time.ZoneOffset;
-import java.math.RoundingMode;
 import org.curriki.api.enus.model.base.BaseModel;
+import java.math.RoundingMode;
 import java.math.MathContext;
 import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.Instant;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.time.ZoneId;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import java.util.List;
 import java.time.OffsetDateTime;
-import org.apache.solr.client.solrj.SolrQuery;
+import org.computate.search.wrap.Wrap;
 import java.util.Optional;
-import org.apache.solr.client.solrj.util.ClientUtils;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.solr.common.SolrInputDocument;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.request.api.ApiRequest;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
 import org.slf4j.Logger;
 import io.vertx.core.Promise;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.apache.solr.client.solrj.SolrClient;
 import io.vertx.core.json.JsonArray;
-import org.apache.solr.common.SolrDocument;
 import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
 import org.apache.commons.lang3.math.NumberUtils;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResource.class);
@@ -100,10 +93,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceId;
 
-	/**	<br/> The entity resourceId
+	/**	<br> The entity resourceId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceId">Find the entity resourceId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceId">Find the entity resourceId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceId(Wrap<String> w);
@@ -126,16 +119,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrResourceId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchResourceId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrResourceId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceId(siteRequest_, CurrikiResource.staticSolrResourceId(siteRequest_, CurrikiResource.staticSetResourceId(siteRequest_, o)));
+	public static String staticSearchFqResourceId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceId(siteRequest_, CurrikiResource.staticSearchResourceId(siteRequest_, CurrikiResource.staticSetResourceId(siteRequest_, o)));
+	}
+
+	public String sqlResourceId() {
+		return resourceId;
 	}
 
 	///////////////
@@ -149,10 +146,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String licenseId;
 
-	/**	<br/> The entity licenseId
+	/**	<br> The entity licenseId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:licenseId">Find the entity licenseId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:licenseId">Find the entity licenseId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _licenseId(Wrap<String> w);
@@ -175,16 +172,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrLicenseId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchLicenseId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrLicenseId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrLicenseId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLicenseId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLicenseId(siteRequest_, CurrikiResource.staticSolrLicenseId(siteRequest_, CurrikiResource.staticSetLicenseId(siteRequest_, o)));
+	public static String staticSearchFqLicenseId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLicenseId(siteRequest_, CurrikiResource.staticSearchLicenseId(siteRequest_, CurrikiResource.staticSetLicenseId(siteRequest_, o)));
+	}
+
+	public String sqlLicenseId() {
+		return licenseId;
 	}
 
 	///////////////////
@@ -199,10 +200,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long contributorId;
 
-	/**	<br/> The entity contributorId
+	/**	<br> The entity contributorId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributorId">Find the entity contributorId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributorId">Find the entity contributorId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contributorId(Wrap<Long> w);
@@ -232,16 +233,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSolrContributorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchContributorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrContributorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrContributorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContributorId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrContributorId(siteRequest_, CurrikiResource.staticSolrContributorId(siteRequest_, CurrikiResource.staticSetContributorId(siteRequest_, o)));
+	public static String staticSearchFqContributorId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrContributorId(siteRequest_, CurrikiResource.staticSearchContributorId(siteRequest_, CurrikiResource.staticSetContributorId(siteRequest_, o)));
+	}
+
+	public Long sqlContributorId() {
+		return contributorId;
 	}
 
 	//////////////////////
@@ -252,16 +257,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime contributionDate;
 
-	/**	<br/> The entity contributionDate
+	/**	<br> The entity contributionDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributionDate">Find the entity contributionDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributionDate">Find the entity contributionDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contributionDate(Wrap<ZonedDateTime> w);
@@ -283,6 +288,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.contributionDate = CurrikiResource.staticSetContributionDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetContributionDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -301,16 +308,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrContributionDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchContributionDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrContributionDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrContributionDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqContributionDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrContributionDate(siteRequest_, CurrikiResource.staticSolrContributionDate(siteRequest_, CurrikiResource.staticSetContributionDate(siteRequest_, o)));
+	public static String staticSearchFqContributionDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrContributionDate(siteRequest_, CurrikiResource.staticSearchContributionDate(siteRequest_, CurrikiResource.staticSetContributionDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlContributionDate() {
+		return contributionDate == null ? null : contributionDate.toOffsetDateTime();
 	}
 
 	/////////////////
@@ -324,10 +335,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String description;
 
-	/**	<br/> The entity description
+	/**	<br> The entity description
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:description">Find the entity description in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:description">Find the entity description in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _description(Wrap<String> w);
@@ -350,16 +361,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDescription(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDescription(siteRequest_, CurrikiResource.staticSolrDescription(siteRequest_, CurrikiResource.staticSetDescription(siteRequest_, o)));
+	public static String staticSearchFqDescription(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrDescription(siteRequest_, CurrikiResource.staticSearchDescription(siteRequest_, CurrikiResource.staticSetDescription(siteRequest_, o)));
+	}
+
+	public String sqlDescription() {
+		return description;
 	}
 
 	///////////
@@ -373,10 +388,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String title;
 
-	/**	<br/> The entity title
+	/**	<br> The entity title
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:title">Find the entity title in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:title">Find the entity title in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _title(Wrap<String> w);
@@ -399,16 +414,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTitle(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTitle(siteRequest_, CurrikiResource.staticSolrTitle(siteRequest_, CurrikiResource.staticSetTitle(siteRequest_, o)));
+	public static String staticSearchFqTitle(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTitle(siteRequest_, CurrikiResource.staticSearchTitle(siteRequest_, CurrikiResource.staticSetTitle(siteRequest_, o)));
+	}
+
+	public String sqlTitle() {
+		return title;
 	}
 
 	/////////////////
@@ -422,10 +441,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String keywordsStr;
 
-	/**	<br/> The entity keywordsStr
+	/**	<br> The entity keywordsStr
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywordsStr">Find the entity keywordsStr in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywordsStr">Find the entity keywordsStr in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _keywordsStr(Wrap<String> w);
@@ -448,16 +467,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrKeywordsStr(siteRequest_, CurrikiResource.staticSolrKeywordsStr(siteRequest_, CurrikiResource.staticSetKeywordsStr(siteRequest_, o)));
+	public static String staticSearchFqKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrKeywordsStr(siteRequest_, CurrikiResource.staticSearchKeywordsStr(siteRequest_, CurrikiResource.staticSetKeywordsStr(siteRequest_, o)));
+	}
+
+	public String sqlKeywordsStr() {
+		return keywordsStr;
 	}
 
 	//////////////
@@ -465,18 +488,18 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	//////////////
 
 	/**	 The entity keywords
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> keywords = new ArrayList<String>();
 
-	/**	<br/> The entity keywords
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywords">Find the entity keywords in Solr</a>
-	 * <br/>
-	 * @param keywords is the entity already constructed. 
+	/**	<br> The entity keywords
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywords">Find the entity keywords in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _keywords(List<String> l);
 
@@ -514,16 +537,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqKeywords(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrKeywords(siteRequest_, CurrikiResource.staticSolrKeywords(siteRequest_, CurrikiResource.staticSetKeywords(siteRequest_, o)));
+	public static String staticSearchFqKeywords(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrKeywords(siteRequest_, CurrikiResource.staticSearchKeywords(siteRequest_, CurrikiResource.staticSetKeywords(siteRequest_, o)));
 	}
 
 	//////////////////////////
@@ -537,10 +560,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String generatedKeywordsStr;
 
-	/**	<br/> The entity generatedKeywordsStr
+	/**	<br> The entity generatedKeywordsStr
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywordsStr">Find the entity generatedKeywordsStr in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywordsStr">Find the entity generatedKeywordsStr in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _generatedKeywordsStr(Wrap<String> w);
@@ -563,16 +586,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSolrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSetGeneratedKeywordsStr(siteRequest_, o)));
+	public static String staticSearchFqGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSearchGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSetGeneratedKeywordsStr(siteRequest_, o)));
+	}
+
+	public String sqlGeneratedKeywordsStr() {
+		return generatedKeywordsStr;
 	}
 
 	///////////////////////
@@ -580,18 +607,18 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	///////////////////////
 
 	/**	 The entity generatedKeywords
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> generatedKeywords = new ArrayList<String>();
 
-	/**	<br/> The entity generatedKeywords
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywords">Find the entity generatedKeywords in Solr</a>
-	 * <br/>
-	 * @param generatedKeywords is the entity already constructed. 
+	/**	<br> The entity generatedKeywords
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywords">Find the entity generatedKeywords in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _generatedKeywords(List<String> l);
 
@@ -629,16 +656,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrGeneratedKeywords(siteRequest_, CurrikiResource.staticSolrGeneratedKeywords(siteRequest_, CurrikiResource.staticSetGeneratedKeywords(siteRequest_, o)));
+	public static String staticSearchFqGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrGeneratedKeywords(siteRequest_, CurrikiResource.staticSearchGeneratedKeywords(siteRequest_, CurrikiResource.staticSetGeneratedKeywords(siteRequest_, o)));
 	}
 
 	//////////////
@@ -652,10 +679,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String language;
 
-	/**	<br/> The entity language
+	/**	<br> The entity language
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:language">Find the entity language in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:language">Find the entity language in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _language(Wrap<String> w);
@@ -678,16 +705,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrLanguage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchLanguage(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrLanguage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrLanguage(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLanguage(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLanguage(siteRequest_, CurrikiResource.staticSolrLanguage(siteRequest_, CurrikiResource.staticSetLanguage(siteRequest_, o)));
+	public static String staticSearchFqLanguage(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLanguage(siteRequest_, CurrikiResource.staticSearchLanguage(siteRequest_, CurrikiResource.staticSetLanguage(siteRequest_, o)));
+	}
+
+	public String sqlLanguage() {
+		return language;
 	}
 
 	//////////////////
@@ -702,10 +733,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long lastEditorId;
 
-	/**	<br/> The entity lastEditorId
+	/**	<br> The entity lastEditorId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditorId">Find the entity lastEditorId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditorId">Find the entity lastEditorId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastEditorId(Wrap<Long> w);
@@ -735,16 +766,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSolrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLastEditorId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLastEditorId(siteRequest_, CurrikiResource.staticSolrLastEditorId(siteRequest_, CurrikiResource.staticSetLastEditorId(siteRequest_, o)));
+	public static String staticSearchFqLastEditorId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLastEditorId(siteRequest_, CurrikiResource.staticSearchLastEditorId(siteRequest_, CurrikiResource.staticSetLastEditorId(siteRequest_, o)));
+	}
+
+	public Long sqlLastEditorId() {
+		return lastEditorId;
 	}
 
 	//////////////////
@@ -755,16 +790,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastEditDate;
 
-	/**	<br/> The entity lastEditDate
+	/**	<br> The entity lastEditDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditDate">Find the entity lastEditDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditDate">Find the entity lastEditDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastEditDate(Wrap<ZonedDateTime> w);
@@ -786,6 +821,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastEditDate = CurrikiResource.staticSetLastEditDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastEditDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -804,16 +841,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrLastEditDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchLastEditDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrLastEditDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrLastEditDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqLastEditDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLastEditDate(siteRequest_, CurrikiResource.staticSolrLastEditDate(siteRequest_, CurrikiResource.staticSetLastEditDate(siteRequest_, o)));
+	public static String staticSearchFqLastEditDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLastEditDate(siteRequest_, CurrikiResource.staticSearchLastEditDate(siteRequest_, CurrikiResource.staticSetLastEditDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlLastEditDate() {
+		return lastEditDate == null ? null : lastEditDate.toOffsetDateTime();
 	}
 
 	////////////////////
@@ -827,10 +868,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String currikiLicense;
 
-	/**	<br/> The entity currikiLicense
+	/**	<br> The entity currikiLicense
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiLicense">Find the entity currikiLicense in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiLicense">Find the entity currikiLicense in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiLicense(Wrap<String> w);
@@ -853,16 +894,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrCurrikiLicense(siteRequest_, CurrikiResource.staticSolrCurrikiLicense(siteRequest_, CurrikiResource.staticSetCurrikiLicense(siteRequest_, o)));
+	public static String staticSearchFqCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrCurrikiLicense(siteRequest_, CurrikiResource.staticSearchCurrikiLicense(siteRequest_, CurrikiResource.staticSetCurrikiLicense(siteRequest_, o)));
+	}
+
+	public String sqlCurrikiLicense() {
+		return currikiLicense;
 	}
 
 	/////////////////
@@ -876,10 +921,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String externalUrl;
 
-	/**	<br/> The entity externalUrl
+	/**	<br> The entity externalUrl
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:externalUrl">Find the entity externalUrl in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:externalUrl">Find the entity externalUrl in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _externalUrl(Wrap<String> w);
@@ -902,16 +947,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchExternalUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqExternalUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrExternalUrl(siteRequest_, CurrikiResource.staticSolrExternalUrl(siteRequest_, CurrikiResource.staticSetExternalUrl(siteRequest_, o)));
+	public static String staticSearchFqExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrExternalUrl(siteRequest_, CurrikiResource.staticSearchExternalUrl(siteRequest_, CurrikiResource.staticSetExternalUrl(siteRequest_, o)));
+	}
+
+	public String sqlExternalUrl() {
+		return externalUrl;
 	}
 
 	/////////////////////
@@ -925,10 +974,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceChecked;
 
-	/**	<br/> The entity resourceChecked
+	/**	<br> The entity resourceChecked
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceChecked">Find the entity resourceChecked in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceChecked">Find the entity resourceChecked in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceChecked(Wrap<String> w);
@@ -951,16 +1000,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchResourceChecked(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceChecked(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceChecked(siteRequest_, CurrikiResource.staticSolrResourceChecked(siteRequest_, CurrikiResource.staticSetResourceChecked(siteRequest_, o)));
+	public static String staticSearchFqResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceChecked(siteRequest_, CurrikiResource.staticSearchResourceChecked(siteRequest_, CurrikiResource.staticSetResourceChecked(siteRequest_, o)));
+	}
+
+	public String sqlResourceChecked() {
+		return resourceChecked;
 	}
 
 	/////////////
@@ -974,10 +1027,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String content;
 
-	/**	<br/> The entity content
+	/**	<br> The entity content
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:content">Find the entity content in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:content">Find the entity content in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _content(Wrap<String> w);
@@ -1000,16 +1053,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrContent(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchContent(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrContent(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrContent(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContent(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrContent(siteRequest_, CurrikiResource.staticSolrContent(siteRequest_, CurrikiResource.staticSetContent(siteRequest_, o)));
+	public static String staticSearchFqContent(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrContent(siteRequest_, CurrikiResource.staticSearchContent(siteRequest_, CurrikiResource.staticSetContent(siteRequest_, o)));
+	}
+
+	public String sqlContent() {
+		return content;
 	}
 
 	//////////////////////////////
@@ -1023,10 +1080,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceCheckRequestNote;
 
-	/**	<br/> The entity resourceCheckRequestNote
+	/**	<br> The entity resourceCheckRequestNote
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckRequestNote">Find the entity resourceCheckRequestNote in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckRequestNote">Find the entity resourceCheckRequestNote in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckRequestNote(Wrap<String> w);
@@ -1049,16 +1106,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSolrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSetResourceCheckRequestNote(siteRequest_, o)));
+	public static String staticSearchFqResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSearchResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSetResourceCheckRequestNote(siteRequest_, o)));
+	}
+
+	public String sqlResourceCheckRequestNote() {
+		return resourceCheckRequestNote;
 	}
 
 	///////////////////////
@@ -1069,16 +1130,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime resourceCheckDate;
 
-	/**	<br/> The entity resourceCheckDate
+	/**	<br> The entity resourceCheckDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckDate">Find the entity resourceCheckDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckDate">Find the entity resourceCheckDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckDate(Wrap<ZonedDateTime> w);
@@ -1100,6 +1161,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.resourceCheckDate = CurrikiResource.staticSetResourceCheckDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -1118,16 +1181,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrResourceCheckDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchResourceCheckDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrResourceCheckDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrResourceCheckDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceCheckDate(siteRequest_, CurrikiResource.staticSolrResourceCheckDate(siteRequest_, CurrikiResource.staticSetResourceCheckDate(siteRequest_, o)));
+	public static String staticSearchFqResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceCheckDate(siteRequest_, CurrikiResource.staticSearchResourceCheckDate(siteRequest_, CurrikiResource.staticSetResourceCheckDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlResourceCheckDate() {
+		return resourceCheckDate == null ? null : resourceCheckDate.toOffsetDateTime();
 	}
 
 	/////////////////////
@@ -1142,10 +1209,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long resourceCheckId;
 
-	/**	<br/> The entity resourceCheckId
+	/**	<br> The entity resourceCheckId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckId">Find the entity resourceCheckId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckId">Find the entity resourceCheckId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckId(Wrap<Long> w);
@@ -1175,16 +1242,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSolrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceCheckId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceCheckId(siteRequest_, CurrikiResource.staticSolrResourceCheckId(siteRequest_, CurrikiResource.staticSetResourceCheckId(siteRequest_, o)));
+	public static String staticSearchFqResourceCheckId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceCheckId(siteRequest_, CurrikiResource.staticSearchResourceCheckId(siteRequest_, CurrikiResource.staticSetResourceCheckId(siteRequest_, o)));
+	}
+
+	public Long sqlResourceCheckId() {
+		return resourceCheckId;
 	}
 
 	///////////////////////
@@ -1198,10 +1269,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceCheckNote;
 
-	/**	<br/> The entity resourceCheckNote
+	/**	<br> The entity resourceCheckNote
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckNote">Find the entity resourceCheckNote in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckNote">Find the entity resourceCheckNote in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckNote(Wrap<String> w);
@@ -1224,16 +1295,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceCheckNote(siteRequest_, CurrikiResource.staticSolrResourceCheckNote(siteRequest_, CurrikiResource.staticSetResourceCheckNote(siteRequest_, o)));
+	public static String staticSearchFqResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceCheckNote(siteRequest_, CurrikiResource.staticSearchResourceCheckNote(siteRequest_, CurrikiResource.staticSetResourceCheckNote(siteRequest_, o)));
+	}
+
+	public String sqlResourceCheckNote() {
+		return resourceCheckNote;
 	}
 
 	///////////////////
@@ -1247,10 +1322,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String studentFacing;
 
-	/**	<br/> The entity studentFacing
+	/**	<br> The entity studentFacing
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:studentFacing">Find the entity studentFacing in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:studentFacing">Find the entity studentFacing in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _studentFacing(Wrap<String> w);
@@ -1273,16 +1348,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStudentFacing(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqStudentFacing(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrStudentFacing(siteRequest_, CurrikiResource.staticSolrStudentFacing(siteRequest_, CurrikiResource.staticSetStudentFacing(siteRequest_, o)));
+	public static String staticSearchFqStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrStudentFacing(siteRequest_, CurrikiResource.staticSearchStudentFacing(siteRequest_, CurrikiResource.staticSetStudentFacing(siteRequest_, o)));
+	}
+
+	public String sqlStudentFacing() {
+		return studentFacing;
 	}
 
 	////////////
@@ -1296,10 +1375,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String source;
 
-	/**	<br/> The entity source
+	/**	<br> The entity source
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:source">Find the entity source in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:source">Find the entity source in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _source(Wrap<String> w);
@@ -1322,16 +1401,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSource(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSource(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSource(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSource(siteRequest_, CurrikiResource.staticSolrSource(siteRequest_, CurrikiResource.staticSetSource(siteRequest_, o)));
+	public static String staticSearchFqSource(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSource(siteRequest_, CurrikiResource.staticSearchSource(siteRequest_, CurrikiResource.staticSetSource(siteRequest_, o)));
+	}
+
+	public String sqlSource() {
+		return source;
 	}
 
 	//////////////////
@@ -1345,10 +1428,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String reviewStatus;
 
-	/**	<br/> The entity reviewStatus
+	/**	<br> The entity reviewStatus
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewStatus">Find the entity reviewStatus in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewStatus">Find the entity reviewStatus in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewStatus(Wrap<String> w);
@@ -1371,16 +1454,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchReviewStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqReviewStatus(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrReviewStatus(siteRequest_, CurrikiResource.staticSolrReviewStatus(siteRequest_, CurrikiResource.staticSetReviewStatus(siteRequest_, o)));
+	public static String staticSearchFqReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrReviewStatus(siteRequest_, CurrikiResource.staticSearchReviewStatus(siteRequest_, CurrikiResource.staticSetReviewStatus(siteRequest_, o)));
+	}
+
+	public String sqlReviewStatus() {
+		return reviewStatus;
 	}
 
 	////////////////////
@@ -1391,16 +1478,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastReviewDate;
 
-	/**	<br/> The entity lastReviewDate
+	/**	<br> The entity lastReviewDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastReviewDate">Find the entity lastReviewDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastReviewDate">Find the entity lastReviewDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastReviewDate(Wrap<ZonedDateTime> w);
@@ -1422,6 +1509,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastReviewDate = CurrikiResource.staticSetLastReviewDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -1440,16 +1529,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrLastReviewDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchLastReviewDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrLastReviewDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrLastReviewDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLastReviewDate(siteRequest_, CurrikiResource.staticSolrLastReviewDate(siteRequest_, CurrikiResource.staticSetLastReviewDate(siteRequest_, o)));
+	public static String staticSearchFqLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLastReviewDate(siteRequest_, CurrikiResource.staticSearchLastReviewDate(siteRequest_, CurrikiResource.staticSetLastReviewDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlLastReviewDate() {
+		return lastReviewDate == null ? null : lastReviewDate.toOffsetDateTime();
 	}
 
 	////////////////
@@ -1464,10 +1557,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long reviewByID;
 
-	/**	<br/> The entity reviewByID
+	/**	<br> The entity reviewByID
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewByID">Find the entity reviewByID in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewByID">Find the entity reviewByID in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewByID(Wrap<Long> w);
@@ -1497,16 +1590,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSolrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchReviewByID(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqReviewByID(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrReviewByID(siteRequest_, CurrikiResource.staticSolrReviewByID(siteRequest_, CurrikiResource.staticSetReviewByID(siteRequest_, o)));
+	public static String staticSearchFqReviewByID(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrReviewByID(siteRequest_, CurrikiResource.staticSearchReviewByID(siteRequest_, CurrikiResource.staticSetReviewByID(siteRequest_, o)));
+	}
+
+	public Long sqlReviewByID() {
+		return reviewByID;
 	}
 
 	//////////////////
@@ -1521,10 +1618,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected BigDecimal reviewRating;
 
-	/**	<br/> The entity reviewRating
+	/**	<br> The entity reviewRating
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewRating">Find the entity reviewRating in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewRating">Find the entity reviewRating in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewRating(Wrap<BigDecimal> w);
@@ -1563,16 +1660,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Double staticSolrReviewRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
+	public static Double staticSearchReviewRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
 		return o == null ? null : o.doubleValue();
 	}
 
-	public static String staticSolrStrReviewRating(SiteRequestEnUS siteRequest_, Double o) {
+	public static String staticSearchStrReviewRating(SiteRequestEnUS siteRequest_, Double o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqReviewRating(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrReviewRating(siteRequest_, CurrikiResource.staticSolrReviewRating(siteRequest_, CurrikiResource.staticSetReviewRating(siteRequest_, o)));
+	public static String staticSearchFqReviewRating(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrReviewRating(siteRequest_, CurrikiResource.staticSearchReviewRating(siteRequest_, CurrikiResource.staticSetReviewRating(siteRequest_, o)));
+	}
+
+	public BigDecimal sqlReviewRating() {
+		return reviewRating;
 	}
 
 	///////////////////////////
@@ -1587,10 +1688,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer technicalCompleteness;
 
-	/**	<br/> The entity technicalCompleteness
+	/**	<br> The entity technicalCompleteness
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:technicalCompleteness">Find the entity technicalCompleteness in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:technicalCompleteness">Find the entity technicalCompleteness in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _technicalCompleteness(Wrap<Integer> w);
@@ -1620,16 +1721,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTechnicalCompleteness(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSolrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSetTechnicalCompleteness(siteRequest_, o)));
+	public static String staticSearchFqTechnicalCompleteness(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSearchTechnicalCompleteness(siteRequest_, CurrikiResource.staticSetTechnicalCompleteness(siteRequest_, o)));
+	}
+
+	public Integer sqlTechnicalCompleteness() {
+		return technicalCompleteness;
 	}
 
 	/////////////////////
@@ -1644,10 +1749,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer contentAccuracy;
 
-	/**	<br/> The entity contentAccuracy
+	/**	<br> The entity contentAccuracy
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentAccuracy">Find the entity contentAccuracy in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentAccuracy">Find the entity contentAccuracy in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contentAccuracy(Wrap<Integer> w);
@@ -1677,16 +1782,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContentAccuracy(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrContentAccuracy(siteRequest_, CurrikiResource.staticSolrContentAccuracy(siteRequest_, CurrikiResource.staticSetContentAccuracy(siteRequest_, o)));
+	public static String staticSearchFqContentAccuracy(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrContentAccuracy(siteRequest_, CurrikiResource.staticSearchContentAccuracy(siteRequest_, CurrikiResource.staticSetContentAccuracy(siteRequest_, o)));
+	}
+
+	public Integer sqlContentAccuracy() {
+		return contentAccuracy;
 	}
 
 	//////////////
@@ -1701,10 +1810,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer pedagogy;
 
-	/**	<br/> The entity pedagogy
+	/**	<br> The entity pedagogy
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pedagogy">Find the entity pedagogy in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pedagogy">Find the entity pedagogy in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pedagogy(Wrap<Integer> w);
@@ -1734,16 +1843,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPedagogy(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPedagogy(siteRequest_, CurrikiResource.staticSolrPedagogy(siteRequest_, CurrikiResource.staticSetPedagogy(siteRequest_, o)));
+	public static String staticSearchFqPedagogy(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPedagogy(siteRequest_, CurrikiResource.staticSearchPedagogy(siteRequest_, CurrikiResource.staticSetPedagogy(siteRequest_, o)));
+	}
+
+	public Integer sqlPedagogy() {
+		return pedagogy;
 	}
 
 	///////////////////
@@ -1757,10 +1870,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String ratingComment;
 
-	/**	<br/> The entity ratingComment
+	/**	<br> The entity ratingComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ratingComment">Find the entity ratingComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ratingComment">Find the entity ratingComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _ratingComment(Wrap<String> w);
@@ -1783,16 +1896,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrRatingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRatingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRatingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRatingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRatingComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrRatingComment(siteRequest_, CurrikiResource.staticSolrRatingComment(siteRequest_, CurrikiResource.staticSetRatingComment(siteRequest_, o)));
+	public static String staticSearchFqRatingComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrRatingComment(siteRequest_, CurrikiResource.staticSearchRatingComment(siteRequest_, CurrikiResource.staticSetRatingComment(siteRequest_, o)));
+	}
+
+	public String sqlRatingComment() {
+		return ratingComment;
 	}
 
 	////////////////////////
@@ -1807,10 +1924,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer standardsAlignment;
 
-	/**	<br/> The entity standardsAlignment
+	/**	<br> The entity standardsAlignment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignment">Find the entity standardsAlignment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignment">Find the entity standardsAlignment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _standardsAlignment(Wrap<Integer> w);
@@ -1840,16 +1957,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqStandardsAlignment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrStandardsAlignment(siteRequest_, CurrikiResource.staticSolrStandardsAlignment(siteRequest_, CurrikiResource.staticSetStandardsAlignment(siteRequest_, o)));
+	public static String staticSearchFqStandardsAlignment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrStandardsAlignment(siteRequest_, CurrikiResource.staticSearchStandardsAlignment(siteRequest_, CurrikiResource.staticSetStandardsAlignment(siteRequest_, o)));
+	}
+
+	public Integer sqlStandardsAlignment() {
+		return standardsAlignment;
 	}
 
 	///////////////////////////////
@@ -1863,10 +1984,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String standardsAlignmentComment;
 
-	/**	<br/> The entity standardsAlignmentComment
+	/**	<br> The entity standardsAlignmentComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignmentComment">Find the entity standardsAlignmentComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignmentComment">Find the entity standardsAlignmentComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _standardsAlignmentComment(Wrap<String> w);
@@ -1889,16 +2010,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSolrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSetStandardsAlignmentComment(siteRequest_, o)));
+	public static String staticSearchFqStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSearchStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSetStandardsAlignmentComment(siteRequest_, o)));
+	}
+
+	public String sqlStandardsAlignmentComment() {
+		return standardsAlignmentComment;
 	}
 
 	///////////////////
@@ -1913,10 +2038,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer subjectMatter;
 
-	/**	<br/> The entity subjectMatter
+	/**	<br> The entity subjectMatter
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatter">Find the entity subjectMatter in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatter">Find the entity subjectMatter in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectMatter(Wrap<Integer> w);
@@ -1946,16 +2071,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSubjectMatter(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSubjectMatter(siteRequest_, CurrikiResource.staticSolrSubjectMatter(siteRequest_, CurrikiResource.staticSetSubjectMatter(siteRequest_, o)));
+	public static String staticSearchFqSubjectMatter(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSubjectMatter(siteRequest_, CurrikiResource.staticSearchSubjectMatter(siteRequest_, CurrikiResource.staticSetSubjectMatter(siteRequest_, o)));
+	}
+
+	public Integer sqlSubjectMatter() {
+		return subjectMatter;
 	}
 
 	//////////////////////////
@@ -1969,10 +2098,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String subjectMatterComment;
 
-	/**	<br/> The entity subjectMatterComment
+	/**	<br> The entity subjectMatterComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatterComment">Find the entity subjectMatterComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatterComment">Find the entity subjectMatterComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectMatterComment(Wrap<String> w);
@@ -1995,16 +2124,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSubjectMatterComment(siteRequest_, CurrikiResource.staticSolrSubjectMatterComment(siteRequest_, CurrikiResource.staticSetSubjectMatterComment(siteRequest_, o)));
+	public static String staticSearchFqSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSubjectMatterComment(siteRequest_, CurrikiResource.staticSearchSubjectMatterComment(siteRequest_, CurrikiResource.staticSetSubjectMatterComment(siteRequest_, o)));
+	}
+
+	public String sqlSubjectMatterComment() {
+		return subjectMatterComment;
 	}
 
 	//////////////////////
@@ -2019,10 +2152,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer supportsTeaching;
 
-	/**	<br/> The entity supportsTeaching
+	/**	<br> The entity supportsTeaching
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeaching">Find the entity supportsTeaching in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeaching">Find the entity supportsTeaching in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _supportsTeaching(Wrap<Integer> w);
@@ -2052,16 +2185,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSupportsTeaching(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSupportsTeaching(siteRequest_, CurrikiResource.staticSolrSupportsTeaching(siteRequest_, CurrikiResource.staticSetSupportsTeaching(siteRequest_, o)));
+	public static String staticSearchFqSupportsTeaching(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSupportsTeaching(siteRequest_, CurrikiResource.staticSearchSupportsTeaching(siteRequest_, CurrikiResource.staticSetSupportsTeaching(siteRequest_, o)));
+	}
+
+	public Integer sqlSupportsTeaching() {
+		return supportsTeaching;
 	}
 
 	/////////////////////////////
@@ -2075,10 +2212,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String supportsTeachingComment;
 
-	/**	<br/> The entity supportsTeachingComment
+	/**	<br> The entity supportsTeachingComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeachingComment">Find the entity supportsTeachingComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeachingComment">Find the entity supportsTeachingComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _supportsTeachingComment(Wrap<String> w);
@@ -2101,16 +2238,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSolrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSetSupportsTeachingComment(siteRequest_, o)));
+	public static String staticSearchFqSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSearchSupportsTeachingComment(siteRequest_, CurrikiResource.staticSetSupportsTeachingComment(siteRequest_, o)));
+	}
+
+	public String sqlSupportsTeachingComment() {
+		return supportsTeachingComment;
 	}
 
 	////////////////////////
@@ -2125,10 +2266,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer assessmentsQuality;
 
-	/**	<br/> The entity assessmentsQuality
+	/**	<br> The entity assessmentsQuality
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQuality">Find the entity assessmentsQuality in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQuality">Find the entity assessmentsQuality in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _assessmentsQuality(Wrap<Integer> w);
@@ -2158,16 +2299,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqAssessmentsQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrAssessmentsQuality(siteRequest_, CurrikiResource.staticSolrAssessmentsQuality(siteRequest_, CurrikiResource.staticSetAssessmentsQuality(siteRequest_, o)));
+	public static String staticSearchFqAssessmentsQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrAssessmentsQuality(siteRequest_, CurrikiResource.staticSearchAssessmentsQuality(siteRequest_, CurrikiResource.staticSetAssessmentsQuality(siteRequest_, o)));
+	}
+
+	public Integer sqlAssessmentsQuality() {
+		return assessmentsQuality;
 	}
 
 	///////////////////////////////
@@ -2181,10 +2326,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String assessmentsQualityComment;
 
-	/**	<br/> The entity assessmentsQualityComment
+	/**	<br> The entity assessmentsQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQualityComment">Find the entity assessmentsQualityComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQualityComment">Find the entity assessmentsQualityComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _assessmentsQualityComment(Wrap<String> w);
@@ -2207,16 +2352,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSolrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSetAssessmentsQualityComment(siteRequest_, o)));
+	public static String staticSearchFqAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSearchAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSetAssessmentsQualityComment(siteRequest_, o)));
+	}
+
+	public String sqlAssessmentsQualityComment() {
+		return assessmentsQualityComment;
 	}
 
 	//////////////////////////
@@ -2231,10 +2380,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer interactivityQuality;
 
-	/**	<br/> The entity interactivityQuality
+	/**	<br> The entity interactivityQuality
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQuality">Find the entity interactivityQuality in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQuality">Find the entity interactivityQuality in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _interactivityQuality(Wrap<Integer> w);
@@ -2264,16 +2413,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInteractivityQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrInteractivityQuality(siteRequest_, CurrikiResource.staticSolrInteractivityQuality(siteRequest_, CurrikiResource.staticSetInteractivityQuality(siteRequest_, o)));
+	public static String staticSearchFqInteractivityQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrInteractivityQuality(siteRequest_, CurrikiResource.staticSearchInteractivityQuality(siteRequest_, CurrikiResource.staticSetInteractivityQuality(siteRequest_, o)));
+	}
+
+	public Integer sqlInteractivityQuality() {
+		return interactivityQuality;
 	}
 
 	/////////////////////////////////
@@ -2287,10 +2440,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String interactivityQualityComment;
 
-	/**	<br/> The entity interactivityQualityComment
+	/**	<br> The entity interactivityQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQualityComment">Find the entity interactivityQualityComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQualityComment">Find the entity interactivityQualityComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _interactivityQualityComment(Wrap<String> w);
@@ -2313,16 +2466,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSolrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSetInteractivityQualityComment(siteRequest_, o)));
+	public static String staticSearchFqInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSearchInteractivityQualityComment(siteRequest_, CurrikiResource.staticSetInteractivityQualityComment(siteRequest_, o)));
+	}
+
+	public String sqlInteractivityQualityComment() {
+		return interactivityQualityComment;
 	}
 
 	//////////////////////////
@@ -2337,10 +2494,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer instructionalQuality;
 
-	/**	<br/> The entity instructionalQuality
+	/**	<br> The entity instructionalQuality
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQuality">Find the entity instructionalQuality in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQuality">Find the entity instructionalQuality in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _instructionalQuality(Wrap<Integer> w);
@@ -2370,16 +2527,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInstructionalQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrInstructionalQuality(siteRequest_, CurrikiResource.staticSolrInstructionalQuality(siteRequest_, CurrikiResource.staticSetInstructionalQuality(siteRequest_, o)));
+	public static String staticSearchFqInstructionalQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrInstructionalQuality(siteRequest_, CurrikiResource.staticSearchInstructionalQuality(siteRequest_, CurrikiResource.staticSetInstructionalQuality(siteRequest_, o)));
+	}
+
+	public Integer sqlInstructionalQuality() {
+		return instructionalQuality;
 	}
 
 	/////////////////////////////////
@@ -2393,10 +2554,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String instructionalQualityComment;
 
-	/**	<br/> The entity instructionalQualityComment
+	/**	<br> The entity instructionalQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQualityComment">Find the entity instructionalQualityComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQualityComment">Find the entity instructionalQualityComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _instructionalQualityComment(Wrap<String> w);
@@ -2419,16 +2580,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSolrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSetInstructionalQualityComment(siteRequest_, o)));
+	public static String staticSearchFqInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSearchInstructionalQualityComment(siteRequest_, CurrikiResource.staticSetInstructionalQualityComment(siteRequest_, o)));
+	}
+
+	public String sqlInstructionalQualityComment() {
+		return instructionalQualityComment;
 	}
 
 	////////////////////
@@ -2443,10 +2608,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer deeperLearning;
 
-	/**	<br/> The entity deeperLearning
+	/**	<br> The entity deeperLearning
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearning">Find the entity deeperLearning in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearning">Find the entity deeperLearning in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deeperLearning(Wrap<Integer> w);
@@ -2476,16 +2641,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDeeperLearning(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDeeperLearning(siteRequest_, CurrikiResource.staticSolrDeeperLearning(siteRequest_, CurrikiResource.staticSetDeeperLearning(siteRequest_, o)));
+	public static String staticSearchFqDeeperLearning(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrDeeperLearning(siteRequest_, CurrikiResource.staticSearchDeeperLearning(siteRequest_, CurrikiResource.staticSetDeeperLearning(siteRequest_, o)));
+	}
+
+	public Integer sqlDeeperLearning() {
+		return deeperLearning;
 	}
 
 	///////////////////////////
@@ -2499,10 +2668,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String deeperLearningComment;
 
-	/**	<br/> The entity deeperLearningComment
+	/**	<br> The entity deeperLearningComment
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearningComment">Find the entity deeperLearningComment in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearningComment">Find the entity deeperLearningComment in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deeperLearningComment(Wrap<String> w);
@@ -2525,16 +2694,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDeeperLearningComment(siteRequest_, CurrikiResource.staticSolrDeeperLearningComment(siteRequest_, CurrikiResource.staticSetDeeperLearningComment(siteRequest_, o)));
+	public static String staticSearchFqDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrDeeperLearningComment(siteRequest_, CurrikiResource.staticSearchDeeperLearningComment(siteRequest_, CurrikiResource.staticSetDeeperLearningComment(siteRequest_, o)));
+	}
+
+	public String sqlDeeperLearningComment() {
+		return deeperLearningComment;
 	}
 
 	/////////////
@@ -2548,10 +2721,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String partner;
 
-	/**	<br/> The entity partner
+	/**	<br> The entity partner
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partner">Find the entity partner in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partner">Find the entity partner in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _partner(Wrap<String> w);
@@ -2574,16 +2747,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrPartner(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPartner(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPartner(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPartner(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPartner(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPartner(siteRequest_, CurrikiResource.staticSolrPartner(siteRequest_, CurrikiResource.staticSetPartner(siteRequest_, o)));
+	public static String staticSearchFqPartner(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPartner(siteRequest_, CurrikiResource.staticSearchPartner(siteRequest_, CurrikiResource.staticSetPartner(siteRequest_, o)));
+	}
+
+	public String sqlPartner() {
+		return partner;
 	}
 
 	////////////////
@@ -2594,16 +2771,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime createDate;
 
-	/**	<br/> The entity createDate
+	/**	<br> The entity createDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:createDate">Find the entity createDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:createDate">Find the entity createDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _createDate(Wrap<ZonedDateTime> w);
@@ -2625,6 +2802,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.createDate = CurrikiResource.staticSetCreateDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetCreateDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -2643,16 +2822,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrCreateDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchCreateDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrCreateDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrCreateDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqCreateDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrCreateDate(siteRequest_, CurrikiResource.staticSolrCreateDate(siteRequest_, CurrikiResource.staticSetCreateDate(siteRequest_, o)));
+	public static String staticSearchFqCreateDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrCreateDate(siteRequest_, CurrikiResource.staticSearchCreateDate(siteRequest_, CurrikiResource.staticSetCreateDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlCreateDate() {
+		return createDate == null ? null : createDate.toOffsetDateTime();
 	}
 
 	//////////
@@ -2666,10 +2849,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String type;
 
-	/**	<br/> The entity type
+	/**	<br> The entity type
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:type">Find the entity type in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:type">Find the entity type in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _type(Wrap<String> w);
@@ -2692,16 +2875,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchType(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrType(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqType(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrType(siteRequest_, CurrikiResource.staticSolrType(siteRequest_, CurrikiResource.staticSetType(siteRequest_, o)));
+	public static String staticSearchFqType(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrType(siteRequest_, CurrikiResource.staticSearchType(siteRequest_, CurrikiResource.staticSetType(siteRequest_, o)));
+	}
+
+	public String sqlType() {
+		return type;
 	}
 
 	//////////////
@@ -2715,10 +2902,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String featured;
 
-	/**	<br/> The entity featured
+	/**	<br> The entity featured
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:featured">Find the entity featured in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:featured">Find the entity featured in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _featured(Wrap<String> w);
@@ -2741,16 +2928,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrFeatured(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFeatured(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrFeatured(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrFeatured(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqFeatured(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrFeatured(siteRequest_, CurrikiResource.staticSolrFeatured(siteRequest_, CurrikiResource.staticSetFeatured(siteRequest_, o)));
+	public static String staticSearchFqFeatured(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrFeatured(siteRequest_, CurrikiResource.staticSearchFeatured(siteRequest_, CurrikiResource.staticSetFeatured(siteRequest_, o)));
+	}
+
+	public String sqlFeatured() {
+		return featured;
 	}
 
 	//////////
@@ -2764,10 +2955,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String page;
 
-	/**	<br/> The entity page
+	/**	<br> The entity page
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:page">Find the entity page in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:page">Find the entity page in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _page(Wrap<String> w);
@@ -2790,16 +2981,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrPage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPage(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPage(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPage(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPage(siteRequest_, CurrikiResource.staticSolrPage(siteRequest_, CurrikiResource.staticSetPage(siteRequest_, o)));
+	public static String staticSearchFqPage(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPage(siteRequest_, CurrikiResource.staticSearchPage(siteRequest_, CurrikiResource.staticSetPage(siteRequest_, o)));
+	}
+
+	public String sqlPage() {
+		return page;
 	}
 
 	////////////
@@ -2813,10 +3008,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String active;
 
-	/**	<br/> The entity active
+	/**	<br> The entity active
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:active">Find the entity active in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:active">Find the entity active in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _active(Wrap<String> w);
@@ -2839,16 +3034,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchActive(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrActive(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqActive(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrActive(siteRequest_, CurrikiResource.staticSolrActive(siteRequest_, CurrikiResource.staticSetActive(siteRequest_, o)));
+	public static String staticSearchFqActive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrActive(siteRequest_, CurrikiResource.staticSearchActive(siteRequest_, CurrikiResource.staticSetActive(siteRequest_, o)));
+	}
+
+	public String sqlActive() {
+		return active;
 	}
 
 	////////////
@@ -2862,10 +3061,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String Public;
 
-	/**	<br/> The entity Public
+	/**	<br> The entity Public
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:Public">Find the entity Public in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:Public">Find the entity Public in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _Public(Wrap<String> w);
@@ -2888,16 +3087,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrPublic(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPublic(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPublic(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPublic(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPublic(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPublic(siteRequest_, CurrikiResource.staticSolrPublic(siteRequest_, CurrikiResource.staticSetPublic(siteRequest_, o)));
+	public static String staticSearchFqPublic(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPublic(siteRequest_, CurrikiResource.staticSearchPublic(siteRequest_, CurrikiResource.staticSetPublic(siteRequest_, o)));
+	}
+
+	public String sqlPublic() {
+		return Public;
 	}
 
 	////////////
@@ -2912,10 +3115,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer xwd_id;
 
-	/**	<br/> The entity xwd_id
+	/**	<br> The entity xwd_id
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:xwd_id">Find the entity xwd_id in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:xwd_id">Find the entity xwd_id in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _xwd_id(Wrap<Integer> w);
@@ -2945,16 +3148,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqXwd_id(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrXwd_id(siteRequest_, CurrikiResource.staticSolrXwd_id(siteRequest_, CurrikiResource.staticSetXwd_id(siteRequest_, o)));
+	public static String staticSearchFqXwd_id(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrXwd_id(siteRequest_, CurrikiResource.staticSearchXwd_id(siteRequest_, CurrikiResource.staticSetXwd_id(siteRequest_, o)));
+	}
+
+	public Integer sqlXwd_id() {
+		return xwd_id;
 	}
 
 	///////////////
@@ -2968,10 +3175,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String mediaType;
 
-	/**	<br/> The entity mediaType
+	/**	<br> The entity mediaType
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:mediaType">Find the entity mediaType in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:mediaType">Find the entity mediaType in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _mediaType(Wrap<String> w);
@@ -2994,16 +3201,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrMediaType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchMediaType(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrMediaType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrMediaType(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqMediaType(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrMediaType(siteRequest_, CurrikiResource.staticSolrMediaType(siteRequest_, CurrikiResource.staticSetMediaType(siteRequest_, o)));
+	public static String staticSearchFqMediaType(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrMediaType(siteRequest_, CurrikiResource.staticSearchMediaType(siteRequest_, CurrikiResource.staticSetMediaType(siteRequest_, o)));
+	}
+
+	public String sqlMediaType() {
+		return mediaType;
 	}
 
 	////////////
@@ -3017,10 +3228,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String access;
 
-	/**	<br/> The entity access
+	/**	<br> The entity access
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:access">Find the entity access in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:access">Find the entity access in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _access(Wrap<String> w);
@@ -3043,16 +3254,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrAccess(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchAccess(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrAccess(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrAccess(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqAccess(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrAccess(siteRequest_, CurrikiResource.staticSolrAccess(siteRequest_, CurrikiResource.staticSetAccess(siteRequest_, o)));
+	public static String staticSearchFqAccess(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrAccess(siteRequest_, CurrikiResource.staticSearchAccess(siteRequest_, CurrikiResource.staticSetAccess(siteRequest_, o)));
+	}
+
+	public String sqlAccess() {
+		return access;
 	}
 
 	//////////////////
@@ -3067,10 +3282,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected BigDecimal memberRating;
 
-	/**	<br/> The entity memberRating
+	/**	<br> The entity memberRating
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:memberRating">Find the entity memberRating in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:memberRating">Find the entity memberRating in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _memberRating(Wrap<BigDecimal> w);
@@ -3109,16 +3324,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Double staticSolrMemberRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
+	public static Double staticSearchMemberRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
 		return o == null ? null : o.doubleValue();
 	}
 
-	public static String staticSolrStrMemberRating(SiteRequestEnUS siteRequest_, Double o) {
+	public static String staticSearchStrMemberRating(SiteRequestEnUS siteRequest_, Double o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqMemberRating(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrMemberRating(siteRequest_, CurrikiResource.staticSolrMemberRating(siteRequest_, CurrikiResource.staticSetMemberRating(siteRequest_, o)));
+	public static String staticSearchFqMemberRating(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrMemberRating(siteRequest_, CurrikiResource.staticSearchMemberRating(siteRequest_, CurrikiResource.staticSetMemberRating(siteRequest_, o)));
+	}
+
+	public BigDecimal sqlMemberRating() {
+		return memberRating;
 	}
 
 	/////////////
@@ -3132,10 +3351,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String aligned;
 
-	/**	<br/> The entity aligned
+	/**	<br> The entity aligned
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:aligned">Find the entity aligned in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:aligned">Find the entity aligned in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _aligned(Wrap<String> w);
@@ -3158,16 +3377,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrAligned(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchAligned(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrAligned(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrAligned(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqAligned(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrAligned(siteRequest_, CurrikiResource.staticSolrAligned(siteRequest_, CurrikiResource.staticSetAligned(siteRequest_, o)));
+	public static String staticSearchFqAligned(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrAligned(siteRequest_, CurrikiResource.staticSearchAligned(siteRequest_, CurrikiResource.staticSetAligned(siteRequest_, o)));
+	}
+
+	public String sqlAligned() {
+		return aligned;
 	}
 
 	/////////////
@@ -3181,10 +3404,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrl;
 
-	/**	<br/> The entity pageUrl
+	/**	<br> The entity pageUrl
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrl">Find the entity pageUrl in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrl">Find the entity pageUrl in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrl(Wrap<String> w);
@@ -3207,16 +3430,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrPageUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPageUrl(siteRequest_, CurrikiResource.staticSolrPageUrl(siteRequest_, CurrikiResource.staticSetPageUrl(siteRequest_, o)));
+	public static String staticSearchFqPageUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPageUrl(siteRequest_, CurrikiResource.staticSearchPageUrl(siteRequest_, CurrikiResource.staticSetPageUrl(siteRequest_, o)));
+	}
+
+	public String sqlPageUrl() {
+		return pageUrl;
 	}
 
 	/////////////
@@ -3230,10 +3457,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String indexed;
 
-	/**	<br/> The entity indexed
+	/**	<br> The entity indexed
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexed">Find the entity indexed in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexed">Find the entity indexed in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexed(Wrap<String> w);
@@ -3256,16 +3483,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrIndexed(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchIndexed(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrIndexed(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrIndexed(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqIndexed(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrIndexed(siteRequest_, CurrikiResource.staticSolrIndexed(siteRequest_, CurrikiResource.staticSetIndexed(siteRequest_, o)));
+	public static String staticSearchFqIndexed(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrIndexed(siteRequest_, CurrikiResource.staticSearchIndexed(siteRequest_, CurrikiResource.staticSetIndexed(siteRequest_, o)));
+	}
+
+	public String sqlIndexed() {
+		return indexed;
 	}
 
 	///////////////////
@@ -3276,16 +3507,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastIndexDate;
 
-	/**	<br/> The entity lastIndexDate
+	/**	<br> The entity lastIndexDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastIndexDate">Find the entity lastIndexDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastIndexDate">Find the entity lastIndexDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastIndexDate(Wrap<ZonedDateTime> w);
@@ -3307,6 +3538,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastIndexDate = CurrikiResource.staticSetLastIndexDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -3325,16 +3558,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrLastIndexDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchLastIndexDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrLastIndexDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrLastIndexDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLastIndexDate(siteRequest_, CurrikiResource.staticSolrLastIndexDate(siteRequest_, CurrikiResource.staticSetLastIndexDate(siteRequest_, o)));
+	public static String staticSearchFqLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLastIndexDate(siteRequest_, CurrikiResource.staticSearchLastIndexDate(siteRequest_, CurrikiResource.staticSetLastIndexDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlLastIndexDate() {
+		return lastIndexDate == null ? null : lastIndexDate.toOffsetDateTime();
 	}
 
 	///////////////////
@@ -3348,10 +3585,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String indexRequired;
 
-	/**	<br/> The entity indexRequired
+	/**	<br> The entity indexRequired
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequired">Find the entity indexRequired in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequired">Find the entity indexRequired in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexRequired(Wrap<String> w);
@@ -3374,16 +3611,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchIndexRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqIndexRequired(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrIndexRequired(siteRequest_, CurrikiResource.staticSolrIndexRequired(siteRequest_, CurrikiResource.staticSetIndexRequired(siteRequest_, o)));
+	public static String staticSearchFqIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrIndexRequired(siteRequest_, CurrikiResource.staticSearchIndexRequired(siteRequest_, CurrikiResource.staticSetIndexRequired(siteRequest_, o)));
+	}
+
+	public String sqlIndexRequired() {
+		return indexRequired;
 	}
 
 	///////////////////////
@@ -3394,16 +3635,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime indexRequiredDate;
 
-	/**	<br/> The entity indexRequiredDate
+	/**	<br> The entity indexRequiredDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequiredDate">Find the entity indexRequiredDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequiredDate">Find the entity indexRequiredDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexRequiredDate(Wrap<ZonedDateTime> w);
@@ -3425,6 +3666,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.indexRequiredDate = CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -3443,16 +3686,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrIndexRequiredDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchIndexRequiredDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrIndexRequiredDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrIndexRequiredDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrIndexRequiredDate(siteRequest_, CurrikiResource.staticSolrIndexRequiredDate(siteRequest_, CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o)));
+	public static String staticSearchFqIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrIndexRequiredDate(siteRequest_, CurrikiResource.staticSearchIndexRequiredDate(siteRequest_, CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlIndexRequiredDate() {
+		return indexRequiredDate == null ? null : indexRequiredDate.toOffsetDateTime();
 	}
 
 	//////////////
@@ -3466,10 +3713,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String rescrape;
 
-	/**	<br/> The entity rescrape
+	/**	<br> The entity rescrape
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rescrape">Find the entity rescrape in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rescrape">Find the entity rescrape in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _rescrape(Wrap<String> w);
@@ -3492,16 +3739,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrRescrape(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRescrape(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRescrape(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRescrape(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRescrape(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrRescrape(siteRequest_, CurrikiResource.staticSolrRescrape(siteRequest_, CurrikiResource.staticSetRescrape(siteRequest_, o)));
+	public static String staticSearchFqRescrape(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrRescrape(siteRequest_, CurrikiResource.staticSearchRescrape(siteRequest_, CurrikiResource.staticSetRescrape(siteRequest_, o)));
+	}
+
+	public String sqlRescrape() {
+		return rescrape;
 	}
 
 	//////////////
@@ -3515,10 +3766,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String goButton;
 
-	/**	<br/> The entity goButton
+	/**	<br> The entity goButton
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:goButton">Find the entity goButton in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:goButton">Find the entity goButton in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _goButton(Wrap<String> w);
@@ -3541,16 +3792,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrGoButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchGoButton(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrGoButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrGoButton(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqGoButton(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrGoButton(siteRequest_, CurrikiResource.staticSolrGoButton(siteRequest_, CurrikiResource.staticSetGoButton(siteRequest_, o)));
+	public static String staticSearchFqGoButton(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrGoButton(siteRequest_, CurrikiResource.staticSearchGoButton(siteRequest_, CurrikiResource.staticSetGoButton(siteRequest_, o)));
+	}
+
+	public String sqlGoButton() {
+		return goButton;
 	}
 
 	////////////////////
@@ -3564,10 +3819,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String downloadButton;
 
-	/**	<br/> The entity downloadButton
+	/**	<br> The entity downloadButton
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:downloadButton">Find the entity downloadButton in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:downloadButton">Find the entity downloadButton in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _downloadButton(Wrap<String> w);
@@ -3590,16 +3845,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchDownloadButton(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDownloadButton(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDownloadButton(siteRequest_, CurrikiResource.staticSolrDownloadButton(siteRequest_, CurrikiResource.staticSetDownloadButton(siteRequest_, o)));
+	public static String staticSearchFqDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrDownloadButton(siteRequest_, CurrikiResource.staticSearchDownloadButton(siteRequest_, CurrikiResource.staticSetDownloadButton(siteRequest_, o)));
+	}
+
+	public String sqlDownloadButton() {
+		return downloadButton;
 	}
 
 	/////////////////
@@ -3613,10 +3872,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String topOfSearch;
 
-	/**	<br/> The entity topOfSearch
+	/**	<br> The entity topOfSearch
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearch">Find the entity topOfSearch in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearch">Find the entity topOfSearch in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _topOfSearch(Wrap<String> w);
@@ -3639,16 +3898,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTopOfSearch(siteRequest_, CurrikiResource.staticSolrTopOfSearch(siteRequest_, CurrikiResource.staticSetTopOfSearch(siteRequest_, o)));
+	public static String staticSearchFqTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTopOfSearch(siteRequest_, CurrikiResource.staticSearchTopOfSearch(siteRequest_, CurrikiResource.staticSetTopOfSearch(siteRequest_, o)));
+	}
+
+	public String sqlTopOfSearch() {
+		return topOfSearch;
 	}
 
 	////////////
@@ -3662,10 +3925,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String remove;
 
-	/**	<br/> The entity remove
+	/**	<br> The entity remove
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:remove">Find the entity remove in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:remove">Find the entity remove in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _remove(Wrap<String> w);
@@ -3688,16 +3951,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrRemove(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRemove(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRemove(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRemove(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRemove(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrRemove(siteRequest_, CurrikiResource.staticSolrRemove(siteRequest_, CurrikiResource.staticSetRemove(siteRequest_, o)));
+	public static String staticSearchFqRemove(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrRemove(siteRequest_, CurrikiResource.staticSearchRemove(siteRequest_, CurrikiResource.staticSetRemove(siteRequest_, o)));
+	}
+
+	public String sqlRemove() {
+		return remove;
 	}
 
 	//////////
@@ -3711,10 +3978,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String spam;
 
-	/**	<br/> The entity spam
+	/**	<br> The entity spam
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spam">Find the entity spam in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spam">Find the entity spam in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _spam(Wrap<String> w);
@@ -3737,16 +4004,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSpam(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSpam(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSpam(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSpam(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSpam(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSpam(siteRequest_, CurrikiResource.staticSolrSpam(siteRequest_, CurrikiResource.staticSetSpam(siteRequest_, o)));
+	public static String staticSearchFqSpam(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSpam(siteRequest_, CurrikiResource.staticSearchSpam(siteRequest_, CurrikiResource.staticSetSpam(siteRequest_, o)));
+	}
+
+	public String sqlSpam() {
+		return spam;
 	}
 
 	////////////////////
@@ -3761,10 +4032,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer topOfSearchInt;
 
-	/**	<br/> The entity topOfSearchInt
+	/**	<br> The entity topOfSearchInt
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearchInt">Find the entity topOfSearchInt in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearchInt">Find the entity topOfSearchInt in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _topOfSearchInt(Wrap<Integer> w);
@@ -3794,16 +4065,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTopOfSearchInt(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTopOfSearchInt(siteRequest_, CurrikiResource.staticSolrTopOfSearchInt(siteRequest_, CurrikiResource.staticSetTopOfSearchInt(siteRequest_, o)));
+	public static String staticSearchFqTopOfSearchInt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTopOfSearchInt(siteRequest_, CurrikiResource.staticSearchTopOfSearchInt(siteRequest_, CurrikiResource.staticSetTopOfSearchInt(siteRequest_, o)));
+	}
+
+	public Integer sqlTopOfSearchInt() {
+		return topOfSearchInt;
 	}
 
 	////////////////
@@ -3818,10 +4093,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer partnerInt;
 
-	/**	<br/> The entity partnerInt
+	/**	<br> The entity partnerInt
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partnerInt">Find the entity partnerInt in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partnerInt">Find the entity partnerInt in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _partnerInt(Wrap<Integer> w);
@@ -3851,16 +4126,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPartnerInt(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrPartnerInt(siteRequest_, CurrikiResource.staticSolrPartnerInt(siteRequest_, CurrikiResource.staticSetPartnerInt(siteRequest_, o)));
+	public static String staticSearchFqPartnerInt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrPartnerInt(siteRequest_, CurrikiResource.staticSearchPartnerInt(siteRequest_, CurrikiResource.staticSetPartnerInt(siteRequest_, o)));
+	}
+
+	public Integer sqlPartnerInt() {
+		return partnerInt;
 	}
 
 	////////////////////
@@ -3874,10 +4153,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String reviewResource;
 
-	/**	<br/> The entity reviewResource
+	/**	<br> The entity reviewResource
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewResource">Find the entity reviewResource in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewResource">Find the entity reviewResource in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewResource(Wrap<String> w);
@@ -3900,16 +4179,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrReviewResource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchReviewResource(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrReviewResource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrReviewResource(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqReviewResource(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrReviewResource(siteRequest_, CurrikiResource.staticSolrReviewResource(siteRequest_, CurrikiResource.staticSetReviewResource(siteRequest_, o)));
+	public static String staticSearchFqReviewResource(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrReviewResource(siteRequest_, CurrikiResource.staticSearchReviewResource(siteRequest_, CurrikiResource.staticSetReviewResource(siteRequest_, o)));
+	}
+
+	public String sqlReviewResource() {
+		return reviewResource;
 	}
 
 	////////////
@@ -3923,10 +4206,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String oldUrl;
 
-	/**	<br/> The entity oldUrl
+	/**	<br> The entity oldUrl
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:oldUrl">Find the entity oldUrl in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:oldUrl">Find the entity oldUrl in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _oldUrl(Wrap<String> w);
@@ -3949,16 +4232,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrOldUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchOldUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrOldUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrOldUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqOldUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrOldUrl(siteRequest_, CurrikiResource.staticSolrOldUrl(siteRequest_, CurrikiResource.staticSetOldUrl(siteRequest_, o)));
+	public static String staticSearchFqOldUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrOldUrl(siteRequest_, CurrikiResource.staticSearchOldUrl(siteRequest_, CurrikiResource.staticSetOldUrl(siteRequest_, o)));
+	}
+
+	public String sqlOldUrl() {
+		return oldUrl;
 	}
 
 	//////////////////////
@@ -3972,10 +4259,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String contentDisplayOk;
 
-	/**	<br/> The entity contentDisplayOk
+	/**	<br> The entity contentDisplayOk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentDisplayOk">Find the entity contentDisplayOk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentDisplayOk">Find the entity contentDisplayOk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contentDisplayOk(Wrap<String> w);
@@ -3998,16 +4285,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrContentDisplayOk(siteRequest_, CurrikiResource.staticSolrContentDisplayOk(siteRequest_, CurrikiResource.staticSetContentDisplayOk(siteRequest_, o)));
+	public static String staticSearchFqContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrContentDisplayOk(siteRequest_, CurrikiResource.staticSearchContentDisplayOk(siteRequest_, CurrikiResource.staticSetContentDisplayOk(siteRequest_, o)));
+	}
+
+	public String sqlContentDisplayOk() {
+		return contentDisplayOk;
 	}
 
 	//////////////
@@ -4021,10 +4312,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String metadata;
 
-	/**	<br/> The entity metadata
+	/**	<br> The entity metadata
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:metadata">Find the entity metadata in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:metadata">Find the entity metadata in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _metadata(Wrap<String> w);
@@ -4047,16 +4338,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrMetadata(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchMetadata(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrMetadata(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrMetadata(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqMetadata(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrMetadata(siteRequest_, CurrikiResource.staticSolrMetadata(siteRequest_, CurrikiResource.staticSetMetadata(siteRequest_, o)));
+	public static String staticSearchFqMetadata(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrMetadata(siteRequest_, CurrikiResource.staticSearchMetadata(siteRequest_, CurrikiResource.staticSetMetadata(siteRequest_, o)));
+	}
+
+	public String sqlMetadata() {
+		return metadata;
 	}
 
 	////////////////////
@@ -4070,10 +4365,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String approvalStatus;
 
-	/**	<br/> The entity approvalStatus
+	/**	<br> The entity approvalStatus
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatus">Find the entity approvalStatus in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatus">Find the entity approvalStatus in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _approvalStatus(Wrap<String> w);
@@ -4096,16 +4391,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrApprovalStatus(siteRequest_, CurrikiResource.staticSolrApprovalStatus(siteRequest_, CurrikiResource.staticSetApprovalStatus(siteRequest_, o)));
+	public static String staticSearchFqApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrApprovalStatus(siteRequest_, CurrikiResource.staticSearchApprovalStatus(siteRequest_, CurrikiResource.staticSetApprovalStatus(siteRequest_, o)));
+	}
+
+	public String sqlApprovalStatus() {
+		return approvalStatus;
 	}
 
 	////////////////////////
@@ -4116,16 +4415,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime approvalStatusDate;
 
-	/**	<br/> The entity approvalStatusDate
+	/**	<br> The entity approvalStatusDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatusDate">Find the entity approvalStatusDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatusDate">Find the entity approvalStatusDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _approvalStatusDate(Wrap<ZonedDateTime> w);
@@ -4147,6 +4446,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.approvalStatusDate = CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -4165,16 +4466,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSolrApprovalStatusDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSearchApprovalStatusDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSolrStrApprovalStatusDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSearchStrApprovalStatusDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSolrFqApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrApprovalStatusDate(siteRequest_, CurrikiResource.staticSolrApprovalStatusDate(siteRequest_, CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o)));
+	public static String staticSearchFqApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrApprovalStatusDate(siteRequest_, CurrikiResource.staticSearchApprovalStatusDate(siteRequest_, CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o)));
+	}
+
+	public OffsetDateTime sqlApprovalStatusDate() {
+		return approvalStatusDate == null ? null : approvalStatusDate.toOffsetDateTime();
 	}
 
 	//////////////
@@ -4188,10 +4493,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String spamUser;
 
-	/**	<br/> The entity spamUser
+	/**	<br> The entity spamUser
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spamUser">Find the entity spamUser in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spamUser">Find the entity spamUser in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _spamUser(Wrap<String> w);
@@ -4214,16 +4519,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSpamUser(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSpamUser(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSpamUser(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSpamUser(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSpamUser(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSpamUser(siteRequest_, CurrikiResource.staticSolrSpamUser(siteRequest_, CurrikiResource.staticSetSpamUser(siteRequest_, o)));
+	public static String staticSearchFqSpamUser(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSpamUser(siteRequest_, CurrikiResource.staticSearchSpamUser(siteRequest_, CurrikiResource.staticSetSpamUser(siteRequest_, o)));
+	}
+
+	public String sqlSpamUser() {
+		return spamUser;
 	}
 
 	/////////
@@ -4237,10 +4546,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String url;
 
-	/**	<br/> The entity url
+	/**	<br> The entity url
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:url">Find the entity url in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:url">Find the entity url in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _url(Wrap<String> w);
@@ -4263,16 +4572,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrUrl(siteRequest_, CurrikiResource.staticSolrUrl(siteRequest_, CurrikiResource.staticSetUrl(siteRequest_, o)));
+	public static String staticSearchFqUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrUrl(siteRequest_, CurrikiResource.staticSearchUrl(siteRequest_, CurrikiResource.staticSetUrl(siteRequest_, o)));
+	}
+
+	public String sqlUrl() {
+		return url;
 	}
 
 	//////////////////
@@ -4287,10 +4600,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer displaySeqNo;
 
-	/**	<br/> The entity displaySeqNo
+	/**	<br> The entity displaySeqNo
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:displaySeqNo">Find the entity displaySeqNo in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:displaySeqNo">Find the entity displaySeqNo in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _displaySeqNo(Wrap<Integer> w);
@@ -4320,16 +4633,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDisplaySeqNo(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDisplaySeqNo(siteRequest_, CurrikiResource.staticSolrDisplaySeqNo(siteRequest_, CurrikiResource.staticSetDisplaySeqNo(siteRequest_, o)));
+	public static String staticSearchFqDisplaySeqNo(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrDisplaySeqNo(siteRequest_, CurrikiResource.staticSearchDisplaySeqNo(siteRequest_, CurrikiResource.staticSetDisplaySeqNo(siteRequest_, o)));
+	}
+
+	public Integer sqlDisplaySeqNo() {
+		return displaySeqNo;
 	}
 
 	////////////
@@ -4344,10 +4661,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer fileId;
 
-	/**	<br/> The entity fileId
+	/**	<br> The entity fileId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileId">Find the entity fileId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileId">Find the entity fileId in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _fileId(Wrap<Integer> w);
@@ -4377,16 +4694,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrFileId(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchFileId(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrFileId(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrFileId(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqFileId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrFileId(siteRequest_, CurrikiResource.staticSolrFileId(siteRequest_, CurrikiResource.staticSetFileId(siteRequest_, o)));
+	public static String staticSearchFqFileId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrFileId(siteRequest_, CurrikiResource.staticSearchFileId(siteRequest_, CurrikiResource.staticSetFileId(siteRequest_, o)));
+	}
+
+	public Integer sqlFileId() {
+		return fileId;
 	}
 
 	//////////////
@@ -4400,10 +4721,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String fileName;
 
-	/**	<br/> The entity fileName
+	/**	<br> The entity fileName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileName">Find the entity fileName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileName">Find the entity fileName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _fileName(Wrap<String> w);
@@ -4426,16 +4747,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrFileName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFileName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrFileName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrFileName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqFileName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrFileName(siteRequest_, CurrikiResource.staticSolrFileName(siteRequest_, CurrikiResource.staticSetFileName(siteRequest_, o)));
+	public static String staticSearchFqFileName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrFileName(siteRequest_, CurrikiResource.staticSearchFileName(siteRequest_, CurrikiResource.staticSetFileName(siteRequest_, o)));
+	}
+
+	public String sqlFileName() {
+		return fileName;
 	}
 
 	////////////////
@@ -4449,10 +4774,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String uploadDate;
 
-	/**	<br/> The entity uploadDate
+	/**	<br> The entity uploadDate
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uploadDate">Find the entity uploadDate in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uploadDate">Find the entity uploadDate in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _uploadDate(Wrap<String> w);
@@ -4475,16 +4800,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrUploadDate(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUploadDate(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUploadDate(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUploadDate(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUploadDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrUploadDate(siteRequest_, CurrikiResource.staticSolrUploadDate(siteRequest_, CurrikiResource.staticSetUploadDate(siteRequest_, o)));
+	public static String staticSearchFqUploadDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrUploadDate(siteRequest_, CurrikiResource.staticSearchUploadDate(siteRequest_, CurrikiResource.staticSetUploadDate(siteRequest_, o)));
+	}
+
+	public String sqlUploadDate() {
+		return uploadDate;
 	}
 
 	//////////////
@@ -4499,10 +4828,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer sequence;
 
-	/**	<br/> The entity sequence
+	/**	<br> The entity sequence
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sequence">Find the entity sequence in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sequence">Find the entity sequence in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sequence(Wrap<Integer> w);
@@ -4532,16 +4861,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSolrSequence(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchSequence(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrSequence(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrSequence(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSequence(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSequence(siteRequest_, CurrikiResource.staticSolrSequence(siteRequest_, CurrikiResource.staticSetSequence(siteRequest_, o)));
+	public static String staticSearchFqSequence(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSequence(siteRequest_, CurrikiResource.staticSearchSequence(siteRequest_, CurrikiResource.staticSetSequence(siteRequest_, o)));
+	}
+
+	public Integer sqlSequence() {
+		return sequence;
 	}
 
 	////////////////
@@ -4555,10 +4888,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String uniqueName;
 
-	/**	<br/> The entity uniqueName
+	/**	<br> The entity uniqueName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uniqueName">Find the entity uniqueName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uniqueName">Find the entity uniqueName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _uniqueName(Wrap<String> w);
@@ -4581,16 +4914,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrUniqueName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUniqueName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUniqueName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUniqueName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUniqueName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrUniqueName(siteRequest_, CurrikiResource.staticSolrUniqueName(siteRequest_, CurrikiResource.staticSetUniqueName(siteRequest_, o)));
+	public static String staticSearchFqUniqueName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrUniqueName(siteRequest_, CurrikiResource.staticSearchUniqueName(siteRequest_, CurrikiResource.staticSetUniqueName(siteRequest_, o)));
+	}
+
+	public String sqlUniqueName() {
+		return uniqueName;
 	}
 
 	/////////
@@ -4604,10 +4941,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String ext;
 
-	/**	<br/> The entity ext
+	/**	<br> The entity ext
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ext">Find the entity ext in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ext">Find the entity ext in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _ext(Wrap<String> w);
@@ -4630,16 +4967,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrExt(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchExt(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrExt(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrExt(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqExt(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrExt(siteRequest_, CurrikiResource.staticSolrExt(siteRequest_, CurrikiResource.staticSetExt(siteRequest_, o)));
+	public static String staticSearchFqExt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrExt(siteRequest_, CurrikiResource.staticSearchExt(siteRequest_, CurrikiResource.staticSetExt(siteRequest_, o)));
+	}
+
+	public String sqlExt() {
+		return ext;
 	}
 
 	/////////////////////////
@@ -4653,10 +4994,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceFilesActive;
 
-	/**	<br/> The entity resourceFilesActive
+	/**	<br> The entity resourceFilesActive
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceFilesActive">Find the entity resourceFilesActive in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceFilesActive">Find the entity resourceFilesActive in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceFilesActive(Wrap<String> w);
@@ -4679,16 +5020,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrResourceFilesActive(siteRequest_, CurrikiResource.staticSolrResourceFilesActive(siteRequest_, CurrikiResource.staticSetResourceFilesActive(siteRequest_, o)));
+	public static String staticSearchFqResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrResourceFilesActive(siteRequest_, CurrikiResource.staticSearchResourceFilesActive(siteRequest_, CurrikiResource.staticSetResourceFilesActive(siteRequest_, o)));
+	}
+
+	public String sqlResourceFilesActive() {
+		return resourceFilesActive;
 	}
 
 	////////////////
@@ -4702,10 +5047,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String tempactive;
 
-	/**	<br/> The entity tempactive
+	/**	<br> The entity tempactive
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:tempactive">Find the entity tempactive in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:tempactive">Find the entity tempactive in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _tempactive(Wrap<String> w);
@@ -4728,16 +5073,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrTempactive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchTempactive(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrTempactive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrTempactive(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTempactive(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTempactive(siteRequest_, CurrikiResource.staticSolrTempactive(siteRequest_, CurrikiResource.staticSetTempactive(siteRequest_, o)));
+	public static String staticSearchFqTempactive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTempactive(siteRequest_, CurrikiResource.staticSearchTempactive(siteRequest_, CurrikiResource.staticSetTempactive(siteRequest_, o)));
+	}
+
+	public String sqlTempactive() {
+		return tempactive;
 	}
 
 	////////////
@@ -4751,10 +5100,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String s3path;
 
-	/**	<br/> The entity s3path
+	/**	<br> The entity s3path
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:s3path">Find the entity s3path in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:s3path">Find the entity s3path in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _s3path(Wrap<String> w);
@@ -4777,16 +5126,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrS3path(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchS3path(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrS3path(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrS3path(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqS3path(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrS3path(siteRequest_, CurrikiResource.staticSolrS3path(siteRequest_, CurrikiResource.staticSetS3path(siteRequest_, o)));
+	public static String staticSearchFqS3path(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrS3path(siteRequest_, CurrikiResource.staticSearchS3path(siteRequest_, CurrikiResource.staticSetS3path(siteRequest_, o)));
+	}
+
+	public String sqlS3path() {
+		return s3path;
 	}
 
 	///////////////
@@ -4800,10 +5153,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String sdfStatus;
 
-	/**	<br/> The entity sdfStatus
+	/**	<br> The entity sdfStatus
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sdfStatus">Find the entity sdfStatus in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sdfStatus">Find the entity sdfStatus in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sdfStatus(Wrap<String> w);
@@ -4826,16 +5179,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSdfStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSdfStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSdfStatus(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSdfStatus(siteRequest_, CurrikiResource.staticSolrSdfStatus(siteRequest_, CurrikiResource.staticSetSdfStatus(siteRequest_, o)));
+	public static String staticSearchFqSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSdfStatus(siteRequest_, CurrikiResource.staticSearchSdfStatus(siteRequest_, CurrikiResource.staticSetSdfStatus(siteRequest_, o)));
+	}
+
+	public String sqlSdfStatus() {
+		return sdfStatus;
 	}
 
 	////////////////
@@ -4849,10 +5206,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String transcoded;
 
-	/**	<br/> The entity transcoded
+	/**	<br> The entity transcoded
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:transcoded">Find the entity transcoded in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:transcoded">Find the entity transcoded in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _transcoded(Wrap<String> w);
@@ -4875,16 +5232,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrTranscoded(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchTranscoded(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrTranscoded(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrTranscoded(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqTranscoded(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrTranscoded(siteRequest_, CurrikiResource.staticSolrTranscoded(siteRequest_, CurrikiResource.staticSetTranscoded(siteRequest_, o)));
+	public static String staticSearchFqTranscoded(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrTranscoded(siteRequest_, CurrikiResource.staticSearchTranscoded(siteRequest_, CurrikiResource.staticSetTranscoded(siteRequest_, o)));
+	}
+
+	public String sqlTranscoded() {
+		return transcoded;
 	}
 
 	//////////////
@@ -4898,10 +5259,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String lodestar;
 
-	/**	<br/> The entity lodestar
+	/**	<br> The entity lodestar
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lodestar">Find the entity lodestar in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lodestar">Find the entity lodestar in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lodestar(Wrap<String> w);
@@ -4924,16 +5285,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrLodestar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchLodestar(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrLodestar(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrLodestar(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLodestar(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrLodestar(siteRequest_, CurrikiResource.staticSolrLodestar(siteRequest_, CurrikiResource.staticSetLodestar(siteRequest_, o)));
+	public static String staticSearchFqLodestar(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrLodestar(siteRequest_, CurrikiResource.staticSearchLodestar(siteRequest_, CurrikiResource.staticSetLodestar(siteRequest_, o)));
+	}
+
+	public String sqlLodestar() {
+		return lodestar;
 	}
 
 	/////////////
@@ -4947,10 +5312,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String archive;
 
-	/**	<br/> The entity archive
+	/**	<br> The entity archive
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archive">Find the entity archive in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archive">Find the entity archive in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _archive(Wrap<String> w);
@@ -4973,16 +5338,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrArchive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchArchive(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrArchive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrArchive(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqArchive(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrArchive(siteRequest_, CurrikiResource.staticSolrArchive(siteRequest_, CurrikiResource.staticSetArchive(siteRequest_, o)));
+	public static String staticSearchFqArchive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrArchive(siteRequest_, CurrikiResource.staticSearchArchive(siteRequest_, CurrikiResource.staticSetArchive(siteRequest_, o)));
+	}
+
+	public String sqlArchive() {
+		return archive;
 	}
 
 	////////////////
@@ -4996,10 +5365,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String identifier;
 
-	/**	<br/> The entity identifier
+	/**	<br> The entity identifier
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:identifier">Find the entity identifier in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:identifier">Find the entity identifier in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _identifier(Wrap<String> w);
@@ -5022,16 +5391,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrIdentifier(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchIdentifier(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrIdentifier(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrIdentifier(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqIdentifier(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrIdentifier(siteRequest_, CurrikiResource.staticSolrIdentifier(siteRequest_, CurrikiResource.staticSetIdentifier(siteRequest_, o)));
+	public static String staticSearchFqIdentifier(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrIdentifier(siteRequest_, CurrikiResource.staticSearchIdentifier(siteRequest_, CurrikiResource.staticSetIdentifier(siteRequest_, o)));
+	}
+
+	public String sqlIdentifier() {
+		return identifier;
 	}
 
 	///////////////////////////////
@@ -5045,10 +5418,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String educationLevelDisplayName;
 
-	/**	<br/> The entity educationLevelDisplayName
+	/**	<br> The entity educationLevelDisplayName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:educationLevelDisplayName">Find the entity educationLevelDisplayName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:educationLevelDisplayName">Find the entity educationLevelDisplayName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _educationLevelDisplayName(Wrap<String> w);
@@ -5071,16 +5444,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSolrEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSetEducationLevelDisplayName(siteRequest_, o)));
+	public static String staticSearchFqEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSearchEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSetEducationLevelDisplayName(siteRequest_, o)));
+	}
+
+	public String sqlEducationLevelDisplayName() {
+		return educationLevelDisplayName;
 	}
 
 	/////////////////
@@ -5094,10 +5471,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String subjectArea;
 
-	/**	<br/> The entity subjectArea
+	/**	<br> The entity subjectArea
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectArea">Find the entity subjectArea in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectArea">Find the entity subjectArea in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectArea(Wrap<String> w);
@@ -5120,16 +5497,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSubjectArea(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSubjectArea(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSubjectArea(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, CurrikiResource.staticSolrSubjectArea(siteRequest_, CurrikiResource.staticSetSubjectArea(siteRequest_, o)));
+	public static String staticSearchFqSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSubjectArea(siteRequest_, CurrikiResource.staticSearchSubjectArea(siteRequest_, CurrikiResource.staticSetSubjectArea(siteRequest_, o)));
+	}
+
+	public String sqlSubjectArea() {
+		return subjectArea;
 	}
 
 	////////////////////////////
@@ -5143,10 +5524,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String subjectAreaDisplayName;
 
-	/**	<br/> The entity subjectAreaDisplayName
+	/**	<br> The entity subjectAreaDisplayName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectAreaDisplayName">Find the entity subjectAreaDisplayName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectAreaDisplayName">Find the entity subjectAreaDisplayName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectAreaDisplayName(Wrap<String> w);
@@ -5169,16 +5550,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o)));
+	public static String staticSearchFqSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSearchSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o)));
+	}
+
+	public String sqlSubjectAreaDisplayName() {
+		return subjectAreaDisplayName;
 	}
 
 	////////////////////////////////
@@ -5192,10 +5577,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String instructionTypeDisplayName;
 
-	/**	<br/> The entity instructionTypeDisplayName
+	/**	<br> The entity instructionTypeDisplayName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionTypeDisplayName">Find the entity instructionTypeDisplayName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionTypeDisplayName">Find the entity instructionTypeDisplayName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _instructionTypeDisplayName(Wrap<String> w);
@@ -5218,16 +5603,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o)));
+	public static String staticSearchFqInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSearchInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o)));
+	}
+
+	public String sqlInstructionTypeDisplayName() {
+		return instructionTypeDisplayName;
 	}
 
 	//////////
@@ -5241,10 +5630,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String name;
 
-	/**	<br/> The entity name
+	/**	<br> The entity name
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:name">Find the entity name in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:name">Find the entity name in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _name(Wrap<String> w);
@@ -5267,16 +5656,20 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrName(siteRequest_, CurrikiResource.staticSolrName(siteRequest_, CurrikiResource.staticSetName(siteRequest_, o)));
+	public static String staticSearchFqName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSearchStrName(siteRequest_, CurrikiResource.staticSearchName(siteRequest_, CurrikiResource.staticSetName(siteRequest_, o)));
+	}
+
+	public String sqlName() {
+		return name;
 	}
 
 	//////////////
@@ -5896,658 +6289,1214 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrCurrikiResource(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSolrResourceId(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchResourceId(siteRequest_, (String)o);
 		case "licenseId":
-			return CurrikiResource.staticSolrLicenseId(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchLicenseId(siteRequest_, (String)o);
 		case "contributorId":
-			return CurrikiResource.staticSolrContributorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchContributorId(siteRequest_, (Long)o);
 		case "contributionDate":
-			return CurrikiResource.staticSolrContributionDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchContributionDate(siteRequest_, (ZonedDateTime)o);
 		case "description":
-			return CurrikiResource.staticSolrDescription(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchDescription(siteRequest_, (String)o);
 		case "title":
-			return CurrikiResource.staticSolrTitle(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchTitle(siteRequest_, (String)o);
 		case "keywordsStr":
-			return CurrikiResource.staticSolrKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchKeywordsStr(siteRequest_, (String)o);
 		case "keywords":
-			return CurrikiResource.staticSolrKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchKeywords(siteRequest_, (String)o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSolrGeneratedKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchGeneratedKeywordsStr(siteRequest_, (String)o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSolrGeneratedKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchGeneratedKeywords(siteRequest_, (String)o);
 		case "language":
-			return CurrikiResource.staticSolrLanguage(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchLanguage(siteRequest_, (String)o);
 		case "lastEditorId":
-			return CurrikiResource.staticSolrLastEditorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchLastEditorId(siteRequest_, (Long)o);
 		case "lastEditDate":
-			return CurrikiResource.staticSolrLastEditDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchLastEditDate(siteRequest_, (ZonedDateTime)o);
 		case "currikiLicense":
-			return CurrikiResource.staticSolrCurrikiLicense(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchCurrikiLicense(siteRequest_, (String)o);
 		case "externalUrl":
-			return CurrikiResource.staticSolrExternalUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchExternalUrl(siteRequest_, (String)o);
 		case "resourceChecked":
-			return CurrikiResource.staticSolrResourceChecked(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchResourceChecked(siteRequest_, (String)o);
 		case "content":
-			return CurrikiResource.staticSolrContent(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchContent(siteRequest_, (String)o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSolrResourceCheckRequestNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchResourceCheckRequestNote(siteRequest_, (String)o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSolrResourceCheckDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchResourceCheckDate(siteRequest_, (ZonedDateTime)o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSolrResourceCheckId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchResourceCheckId(siteRequest_, (Long)o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSolrResourceCheckNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchResourceCheckNote(siteRequest_, (String)o);
 		case "studentFacing":
-			return CurrikiResource.staticSolrStudentFacing(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStudentFacing(siteRequest_, (String)o);
 		case "source":
-			return CurrikiResource.staticSolrSource(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSource(siteRequest_, (String)o);
 		case "reviewStatus":
-			return CurrikiResource.staticSolrReviewStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchReviewStatus(siteRequest_, (String)o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSolrLastReviewDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchLastReviewDate(siteRequest_, (ZonedDateTime)o);
 		case "reviewByID":
-			return CurrikiResource.staticSolrReviewByID(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchReviewByID(siteRequest_, (Long)o);
 		case "reviewRating":
-			return CurrikiResource.staticSolrReviewRating(siteRequest_, (BigDecimal)o);
+			return CurrikiResource.staticSearchReviewRating(siteRequest_, (BigDecimal)o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSolrTechnicalCompleteness(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchTechnicalCompleteness(siteRequest_, (Integer)o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSolrContentAccuracy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchContentAccuracy(siteRequest_, (Integer)o);
 		case "pedagogy":
-			return CurrikiResource.staticSolrPedagogy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchPedagogy(siteRequest_, (Integer)o);
 		case "ratingComment":
-			return CurrikiResource.staticSolrRatingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchRatingComment(siteRequest_, (String)o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSolrStandardsAlignment(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStandardsAlignment(siteRequest_, (Integer)o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSolrStandardsAlignmentComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStandardsAlignmentComment(siteRequest_, (String)o);
 		case "subjectMatter":
-			return CurrikiResource.staticSolrSubjectMatter(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchSubjectMatter(siteRequest_, (Integer)o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSolrSubjectMatterComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSubjectMatterComment(siteRequest_, (String)o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSolrSupportsTeaching(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchSupportsTeaching(siteRequest_, (Integer)o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSolrSupportsTeachingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSupportsTeachingComment(siteRequest_, (String)o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSolrAssessmentsQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchAssessmentsQuality(siteRequest_, (Integer)o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSolrAssessmentsQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchAssessmentsQualityComment(siteRequest_, (String)o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSolrInteractivityQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchInteractivityQuality(siteRequest_, (Integer)o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSolrInteractivityQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchInteractivityQualityComment(siteRequest_, (String)o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSolrInstructionalQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchInstructionalQuality(siteRequest_, (Integer)o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSolrInstructionalQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchInstructionalQualityComment(siteRequest_, (String)o);
 		case "deeperLearning":
-			return CurrikiResource.staticSolrDeeperLearning(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchDeeperLearning(siteRequest_, (Integer)o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSolrDeeperLearningComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchDeeperLearningComment(siteRequest_, (String)o);
 		case "partner":
-			return CurrikiResource.staticSolrPartner(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchPartner(siteRequest_, (String)o);
 		case "createDate":
-			return CurrikiResource.staticSolrCreateDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchCreateDate(siteRequest_, (ZonedDateTime)o);
 		case "type":
-			return CurrikiResource.staticSolrType(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchType(siteRequest_, (String)o);
 		case "featured":
-			return CurrikiResource.staticSolrFeatured(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchFeatured(siteRequest_, (String)o);
 		case "page":
-			return CurrikiResource.staticSolrPage(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchPage(siteRequest_, (String)o);
 		case "active":
-			return CurrikiResource.staticSolrActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchActive(siteRequest_, (String)o);
 		case "Public":
-			return CurrikiResource.staticSolrPublic(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchPublic(siteRequest_, (String)o);
 		case "xwd_id":
-			return CurrikiResource.staticSolrXwd_id(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchXwd_id(siteRequest_, (Integer)o);
 		case "mediaType":
-			return CurrikiResource.staticSolrMediaType(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchMediaType(siteRequest_, (String)o);
 		case "access":
-			return CurrikiResource.staticSolrAccess(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchAccess(siteRequest_, (String)o);
 		case "memberRating":
-			return CurrikiResource.staticSolrMemberRating(siteRequest_, (BigDecimal)o);
+			return CurrikiResource.staticSearchMemberRating(siteRequest_, (BigDecimal)o);
 		case "aligned":
-			return CurrikiResource.staticSolrAligned(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchAligned(siteRequest_, (String)o);
 		case "pageUrl":
-			return CurrikiResource.staticSolrPageUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchPageUrl(siteRequest_, (String)o);
 		case "indexed":
-			return CurrikiResource.staticSolrIndexed(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchIndexed(siteRequest_, (String)o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSolrLastIndexDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchLastIndexDate(siteRequest_, (ZonedDateTime)o);
 		case "indexRequired":
-			return CurrikiResource.staticSolrIndexRequired(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchIndexRequired(siteRequest_, (String)o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSolrIndexRequiredDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchIndexRequiredDate(siteRequest_, (ZonedDateTime)o);
 		case "rescrape":
-			return CurrikiResource.staticSolrRescrape(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchRescrape(siteRequest_, (String)o);
 		case "goButton":
-			return CurrikiResource.staticSolrGoButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchGoButton(siteRequest_, (String)o);
 		case "downloadButton":
-			return CurrikiResource.staticSolrDownloadButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchDownloadButton(siteRequest_, (String)o);
 		case "topOfSearch":
-			return CurrikiResource.staticSolrTopOfSearch(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchTopOfSearch(siteRequest_, (String)o);
 		case "remove":
-			return CurrikiResource.staticSolrRemove(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchRemove(siteRequest_, (String)o);
 		case "spam":
-			return CurrikiResource.staticSolrSpam(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSpam(siteRequest_, (String)o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSolrTopOfSearchInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchTopOfSearchInt(siteRequest_, (Integer)o);
 		case "partnerInt":
-			return CurrikiResource.staticSolrPartnerInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchPartnerInt(siteRequest_, (Integer)o);
 		case "reviewResource":
-			return CurrikiResource.staticSolrReviewResource(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchReviewResource(siteRequest_, (String)o);
 		case "oldUrl":
-			return CurrikiResource.staticSolrOldUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchOldUrl(siteRequest_, (String)o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSolrContentDisplayOk(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchContentDisplayOk(siteRequest_, (String)o);
 		case "metadata":
-			return CurrikiResource.staticSolrMetadata(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchMetadata(siteRequest_, (String)o);
 		case "approvalStatus":
-			return CurrikiResource.staticSolrApprovalStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchApprovalStatus(siteRequest_, (String)o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSolrApprovalStatusDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSearchApprovalStatusDate(siteRequest_, (ZonedDateTime)o);
 		case "spamUser":
-			return CurrikiResource.staticSolrSpamUser(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSpamUser(siteRequest_, (String)o);
 		case "url":
-			return CurrikiResource.staticSolrUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchUrl(siteRequest_, (String)o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSolrDisplaySeqNo(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchDisplaySeqNo(siteRequest_, (Integer)o);
 		case "fileId":
-			return CurrikiResource.staticSolrFileId(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchFileId(siteRequest_, (Integer)o);
 		case "fileName":
-			return CurrikiResource.staticSolrFileName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchFileName(siteRequest_, (String)o);
 		case "uploadDate":
-			return CurrikiResource.staticSolrUploadDate(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchUploadDate(siteRequest_, (String)o);
 		case "sequence":
-			return CurrikiResource.staticSolrSequence(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchSequence(siteRequest_, (Integer)o);
 		case "uniqueName":
-			return CurrikiResource.staticSolrUniqueName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchUniqueName(siteRequest_, (String)o);
 		case "ext":
-			return CurrikiResource.staticSolrExt(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchExt(siteRequest_, (String)o);
 		case "resourceFilesActive":
-			return CurrikiResource.staticSolrResourceFilesActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchResourceFilesActive(siteRequest_, (String)o);
 		case "tempactive":
-			return CurrikiResource.staticSolrTempactive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchTempactive(siteRequest_, (String)o);
 		case "s3path":
-			return CurrikiResource.staticSolrS3path(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchS3path(siteRequest_, (String)o);
 		case "sdfStatus":
-			return CurrikiResource.staticSolrSdfStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSdfStatus(siteRequest_, (String)o);
 		case "transcoded":
-			return CurrikiResource.staticSolrTranscoded(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchTranscoded(siteRequest_, (String)o);
 		case "lodestar":
-			return CurrikiResource.staticSolrLodestar(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchLodestar(siteRequest_, (String)o);
 		case "archive":
-			return CurrikiResource.staticSolrArchive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchArchive(siteRequest_, (String)o);
 		case "identifier":
-			return CurrikiResource.staticSolrIdentifier(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchIdentifier(siteRequest_, (String)o);
 		case "educationLevelDisplayName":
-			return CurrikiResource.staticSolrEducationLevelDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchEducationLevelDisplayName(siteRequest_, (String)o);
 		case "subjectArea":
-			return CurrikiResource.staticSolrSubjectArea(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSubjectArea(siteRequest_, (String)o);
 		case "subjectAreaDisplayName":
-			return CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchSubjectAreaDisplayName(siteRequest_, (String)o);
 		case "instructionTypeDisplayName":
-			return CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchInstructionTypeDisplayName(siteRequest_, (String)o);
 		case "name":
-			return CurrikiResource.staticSolrName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchName(siteRequest_, (String)o);
 			default:
-				return BaseModel.staticSolrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrCurrikiResource(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSolrStrResourceId(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrResourceId(siteRequest_, (String)o);
 		case "licenseId":
-			return CurrikiResource.staticSolrStrLicenseId(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrLicenseId(siteRequest_, (String)o);
 		case "contributorId":
-			return CurrikiResource.staticSolrStrContributorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchStrContributorId(siteRequest_, (Long)o);
 		case "contributionDate":
-			return CurrikiResource.staticSolrStrContributionDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrContributionDate(siteRequest_, (Date)o);
 		case "description":
-			return CurrikiResource.staticSolrStrDescription(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrDescription(siteRequest_, (String)o);
 		case "title":
-			return CurrikiResource.staticSolrStrTitle(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrTitle(siteRequest_, (String)o);
 		case "keywordsStr":
-			return CurrikiResource.staticSolrStrKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrKeywordsStr(siteRequest_, (String)o);
 		case "keywords":
-			return CurrikiResource.staticSolrStrKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrKeywords(siteRequest_, (String)o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSolrStrGeneratedKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrGeneratedKeywordsStr(siteRequest_, (String)o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSolrStrGeneratedKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrGeneratedKeywords(siteRequest_, (String)o);
 		case "language":
-			return CurrikiResource.staticSolrStrLanguage(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrLanguage(siteRequest_, (String)o);
 		case "lastEditorId":
-			return CurrikiResource.staticSolrStrLastEditorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchStrLastEditorId(siteRequest_, (Long)o);
 		case "lastEditDate":
-			return CurrikiResource.staticSolrStrLastEditDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrLastEditDate(siteRequest_, (Date)o);
 		case "currikiLicense":
-			return CurrikiResource.staticSolrStrCurrikiLicense(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrCurrikiLicense(siteRequest_, (String)o);
 		case "externalUrl":
-			return CurrikiResource.staticSolrStrExternalUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrExternalUrl(siteRequest_, (String)o);
 		case "resourceChecked":
-			return CurrikiResource.staticSolrStrResourceChecked(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrResourceChecked(siteRequest_, (String)o);
 		case "content":
-			return CurrikiResource.staticSolrStrContent(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrContent(siteRequest_, (String)o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSolrStrResourceCheckRequestNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrResourceCheckRequestNote(siteRequest_, (String)o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSolrStrResourceCheckDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrResourceCheckDate(siteRequest_, (Date)o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSolrStrResourceCheckId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchStrResourceCheckId(siteRequest_, (Long)o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSolrStrResourceCheckNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrResourceCheckNote(siteRequest_, (String)o);
 		case "studentFacing":
-			return CurrikiResource.staticSolrStrStudentFacing(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrStudentFacing(siteRequest_, (String)o);
 		case "source":
-			return CurrikiResource.staticSolrStrSource(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSource(siteRequest_, (String)o);
 		case "reviewStatus":
-			return CurrikiResource.staticSolrStrReviewStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrReviewStatus(siteRequest_, (String)o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSolrStrLastReviewDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrLastReviewDate(siteRequest_, (Date)o);
 		case "reviewByID":
-			return CurrikiResource.staticSolrStrReviewByID(siteRequest_, (Long)o);
+			return CurrikiResource.staticSearchStrReviewByID(siteRequest_, (Long)o);
 		case "reviewRating":
-			return CurrikiResource.staticSolrStrReviewRating(siteRequest_, (Double)o);
+			return CurrikiResource.staticSearchStrReviewRating(siteRequest_, (Double)o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSolrStrTechnicalCompleteness(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrTechnicalCompleteness(siteRequest_, (Integer)o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSolrStrContentAccuracy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrContentAccuracy(siteRequest_, (Integer)o);
 		case "pedagogy":
-			return CurrikiResource.staticSolrStrPedagogy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrPedagogy(siteRequest_, (Integer)o);
 		case "ratingComment":
-			return CurrikiResource.staticSolrStrRatingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrRatingComment(siteRequest_, (String)o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSolrStrStandardsAlignment(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrStandardsAlignment(siteRequest_, (Integer)o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSolrStrStandardsAlignmentComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrStandardsAlignmentComment(siteRequest_, (String)o);
 		case "subjectMatter":
-			return CurrikiResource.staticSolrStrSubjectMatter(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrSubjectMatter(siteRequest_, (Integer)o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSolrStrSubjectMatterComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSubjectMatterComment(siteRequest_, (String)o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSolrStrSupportsTeaching(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrSupportsTeaching(siteRequest_, (Integer)o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSolrStrSupportsTeachingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSupportsTeachingComment(siteRequest_, (String)o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSolrStrAssessmentsQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrAssessmentsQuality(siteRequest_, (Integer)o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSolrStrAssessmentsQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrAssessmentsQualityComment(siteRequest_, (String)o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSolrStrInteractivityQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrInteractivityQuality(siteRequest_, (Integer)o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSolrStrInteractivityQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrInteractivityQualityComment(siteRequest_, (String)o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSolrStrInstructionalQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrInstructionalQuality(siteRequest_, (Integer)o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSolrStrInstructionalQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrInstructionalQualityComment(siteRequest_, (String)o);
 		case "deeperLearning":
-			return CurrikiResource.staticSolrStrDeeperLearning(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrDeeperLearning(siteRequest_, (Integer)o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSolrStrDeeperLearningComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrDeeperLearningComment(siteRequest_, (String)o);
 		case "partner":
-			return CurrikiResource.staticSolrStrPartner(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrPartner(siteRequest_, (String)o);
 		case "createDate":
-			return CurrikiResource.staticSolrStrCreateDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrCreateDate(siteRequest_, (Date)o);
 		case "type":
-			return CurrikiResource.staticSolrStrType(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrType(siteRequest_, (String)o);
 		case "featured":
-			return CurrikiResource.staticSolrStrFeatured(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrFeatured(siteRequest_, (String)o);
 		case "page":
-			return CurrikiResource.staticSolrStrPage(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrPage(siteRequest_, (String)o);
 		case "active":
-			return CurrikiResource.staticSolrStrActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrActive(siteRequest_, (String)o);
 		case "Public":
-			return CurrikiResource.staticSolrStrPublic(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrPublic(siteRequest_, (String)o);
 		case "xwd_id":
-			return CurrikiResource.staticSolrStrXwd_id(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrXwd_id(siteRequest_, (Integer)o);
 		case "mediaType":
-			return CurrikiResource.staticSolrStrMediaType(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrMediaType(siteRequest_, (String)o);
 		case "access":
-			return CurrikiResource.staticSolrStrAccess(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrAccess(siteRequest_, (String)o);
 		case "memberRating":
-			return CurrikiResource.staticSolrStrMemberRating(siteRequest_, (Double)o);
+			return CurrikiResource.staticSearchStrMemberRating(siteRequest_, (Double)o);
 		case "aligned":
-			return CurrikiResource.staticSolrStrAligned(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrAligned(siteRequest_, (String)o);
 		case "pageUrl":
-			return CurrikiResource.staticSolrStrPageUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrPageUrl(siteRequest_, (String)o);
 		case "indexed":
-			return CurrikiResource.staticSolrStrIndexed(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrIndexed(siteRequest_, (String)o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSolrStrLastIndexDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrLastIndexDate(siteRequest_, (Date)o);
 		case "indexRequired":
-			return CurrikiResource.staticSolrStrIndexRequired(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrIndexRequired(siteRequest_, (String)o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSolrStrIndexRequiredDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrIndexRequiredDate(siteRequest_, (Date)o);
 		case "rescrape":
-			return CurrikiResource.staticSolrStrRescrape(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrRescrape(siteRequest_, (String)o);
 		case "goButton":
-			return CurrikiResource.staticSolrStrGoButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrGoButton(siteRequest_, (String)o);
 		case "downloadButton":
-			return CurrikiResource.staticSolrStrDownloadButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrDownloadButton(siteRequest_, (String)o);
 		case "topOfSearch":
-			return CurrikiResource.staticSolrStrTopOfSearch(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrTopOfSearch(siteRequest_, (String)o);
 		case "remove":
-			return CurrikiResource.staticSolrStrRemove(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrRemove(siteRequest_, (String)o);
 		case "spam":
-			return CurrikiResource.staticSolrStrSpam(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSpam(siteRequest_, (String)o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSolrStrTopOfSearchInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrTopOfSearchInt(siteRequest_, (Integer)o);
 		case "partnerInt":
-			return CurrikiResource.staticSolrStrPartnerInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrPartnerInt(siteRequest_, (Integer)o);
 		case "reviewResource":
-			return CurrikiResource.staticSolrStrReviewResource(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrReviewResource(siteRequest_, (String)o);
 		case "oldUrl":
-			return CurrikiResource.staticSolrStrOldUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrOldUrl(siteRequest_, (String)o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSolrStrContentDisplayOk(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrContentDisplayOk(siteRequest_, (String)o);
 		case "metadata":
-			return CurrikiResource.staticSolrStrMetadata(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrMetadata(siteRequest_, (String)o);
 		case "approvalStatus":
-			return CurrikiResource.staticSolrStrApprovalStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrApprovalStatus(siteRequest_, (String)o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSolrStrApprovalStatusDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSearchStrApprovalStatusDate(siteRequest_, (Date)o);
 		case "spamUser":
-			return CurrikiResource.staticSolrStrSpamUser(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSpamUser(siteRequest_, (String)o);
 		case "url":
-			return CurrikiResource.staticSolrStrUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrUrl(siteRequest_, (String)o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSolrStrDisplaySeqNo(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrDisplaySeqNo(siteRequest_, (Integer)o);
 		case "fileId":
-			return CurrikiResource.staticSolrStrFileId(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrFileId(siteRequest_, (Integer)o);
 		case "fileName":
-			return CurrikiResource.staticSolrStrFileName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrFileName(siteRequest_, (String)o);
 		case "uploadDate":
-			return CurrikiResource.staticSolrStrUploadDate(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrUploadDate(siteRequest_, (String)o);
 		case "sequence":
-			return CurrikiResource.staticSolrStrSequence(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSearchStrSequence(siteRequest_, (Integer)o);
 		case "uniqueName":
-			return CurrikiResource.staticSolrStrUniqueName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrUniqueName(siteRequest_, (String)o);
 		case "ext":
-			return CurrikiResource.staticSolrStrExt(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrExt(siteRequest_, (String)o);
 		case "resourceFilesActive":
-			return CurrikiResource.staticSolrStrResourceFilesActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrResourceFilesActive(siteRequest_, (String)o);
 		case "tempactive":
-			return CurrikiResource.staticSolrStrTempactive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrTempactive(siteRequest_, (String)o);
 		case "s3path":
-			return CurrikiResource.staticSolrStrS3path(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrS3path(siteRequest_, (String)o);
 		case "sdfStatus":
-			return CurrikiResource.staticSolrStrSdfStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSdfStatus(siteRequest_, (String)o);
 		case "transcoded":
-			return CurrikiResource.staticSolrStrTranscoded(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrTranscoded(siteRequest_, (String)o);
 		case "lodestar":
-			return CurrikiResource.staticSolrStrLodestar(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrLodestar(siteRequest_, (String)o);
 		case "archive":
-			return CurrikiResource.staticSolrStrArchive(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrArchive(siteRequest_, (String)o);
 		case "identifier":
-			return CurrikiResource.staticSolrStrIdentifier(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrIdentifier(siteRequest_, (String)o);
 		case "educationLevelDisplayName":
-			return CurrikiResource.staticSolrStrEducationLevelDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrEducationLevelDisplayName(siteRequest_, (String)o);
 		case "subjectArea":
-			return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSubjectArea(siteRequest_, (String)o);
 		case "subjectAreaDisplayName":
-			return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrSubjectAreaDisplayName(siteRequest_, (String)o);
 		case "instructionTypeDisplayName":
-			return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrInstructionTypeDisplayName(siteRequest_, (String)o);
 		case "name":
-			return CurrikiResource.staticSolrStrName(siteRequest_, (String)o);
+			return CurrikiResource.staticSearchStrName(siteRequest_, (String)o);
 			default:
-				return BaseModel.staticSolrStrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchStrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqCurrikiResource(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSolrFqResourceId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceId(siteRequest_, o);
 		case "licenseId":
-			return CurrikiResource.staticSolrFqLicenseId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLicenseId(siteRequest_, o);
 		case "contributorId":
-			return CurrikiResource.staticSolrFqContributorId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqContributorId(siteRequest_, o);
 		case "contributionDate":
-			return CurrikiResource.staticSolrFqContributionDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqContributionDate(siteRequest_, o);
 		case "description":
-			return CurrikiResource.staticSolrFqDescription(siteRequest_, o);
+			return CurrikiResource.staticSearchFqDescription(siteRequest_, o);
 		case "title":
-			return CurrikiResource.staticSolrFqTitle(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTitle(siteRequest_, o);
 		case "keywordsStr":
-			return CurrikiResource.staticSolrFqKeywordsStr(siteRequest_, o);
+			return CurrikiResource.staticSearchFqKeywordsStr(siteRequest_, o);
 		case "keywords":
-			return CurrikiResource.staticSolrFqKeywords(siteRequest_, o);
+			return CurrikiResource.staticSearchFqKeywords(siteRequest_, o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSolrFqGeneratedKeywordsStr(siteRequest_, o);
+			return CurrikiResource.staticSearchFqGeneratedKeywordsStr(siteRequest_, o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSolrFqGeneratedKeywords(siteRequest_, o);
+			return CurrikiResource.staticSearchFqGeneratedKeywords(siteRequest_, o);
 		case "language":
-			return CurrikiResource.staticSolrFqLanguage(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLanguage(siteRequest_, o);
 		case "lastEditorId":
-			return CurrikiResource.staticSolrFqLastEditorId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLastEditorId(siteRequest_, o);
 		case "lastEditDate":
-			return CurrikiResource.staticSolrFqLastEditDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLastEditDate(siteRequest_, o);
 		case "currikiLicense":
-			return CurrikiResource.staticSolrFqCurrikiLicense(siteRequest_, o);
+			return CurrikiResource.staticSearchFqCurrikiLicense(siteRequest_, o);
 		case "externalUrl":
-			return CurrikiResource.staticSolrFqExternalUrl(siteRequest_, o);
+			return CurrikiResource.staticSearchFqExternalUrl(siteRequest_, o);
 		case "resourceChecked":
-			return CurrikiResource.staticSolrFqResourceChecked(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceChecked(siteRequest_, o);
 		case "content":
-			return CurrikiResource.staticSolrFqContent(siteRequest_, o);
+			return CurrikiResource.staticSearchFqContent(siteRequest_, o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSolrFqResourceCheckRequestNote(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceCheckRequestNote(siteRequest_, o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSolrFqResourceCheckDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceCheckDate(siteRequest_, o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSolrFqResourceCheckId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceCheckId(siteRequest_, o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSolrFqResourceCheckNote(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceCheckNote(siteRequest_, o);
 		case "studentFacing":
-			return CurrikiResource.staticSolrFqStudentFacing(siteRequest_, o);
+			return CurrikiResource.staticSearchFqStudentFacing(siteRequest_, o);
 		case "source":
-			return CurrikiResource.staticSolrFqSource(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSource(siteRequest_, o);
 		case "reviewStatus":
-			return CurrikiResource.staticSolrFqReviewStatus(siteRequest_, o);
+			return CurrikiResource.staticSearchFqReviewStatus(siteRequest_, o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSolrFqLastReviewDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLastReviewDate(siteRequest_, o);
 		case "reviewByID":
-			return CurrikiResource.staticSolrFqReviewByID(siteRequest_, o);
+			return CurrikiResource.staticSearchFqReviewByID(siteRequest_, o);
 		case "reviewRating":
-			return CurrikiResource.staticSolrFqReviewRating(siteRequest_, o);
+			return CurrikiResource.staticSearchFqReviewRating(siteRequest_, o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSolrFqTechnicalCompleteness(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTechnicalCompleteness(siteRequest_, o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSolrFqContentAccuracy(siteRequest_, o);
+			return CurrikiResource.staticSearchFqContentAccuracy(siteRequest_, o);
 		case "pedagogy":
-			return CurrikiResource.staticSolrFqPedagogy(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPedagogy(siteRequest_, o);
 		case "ratingComment":
-			return CurrikiResource.staticSolrFqRatingComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqRatingComment(siteRequest_, o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSolrFqStandardsAlignment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqStandardsAlignment(siteRequest_, o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSolrFqStandardsAlignmentComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqStandardsAlignmentComment(siteRequest_, o);
 		case "subjectMatter":
-			return CurrikiResource.staticSolrFqSubjectMatter(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSubjectMatter(siteRequest_, o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSolrFqSubjectMatterComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSubjectMatterComment(siteRequest_, o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSolrFqSupportsTeaching(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSupportsTeaching(siteRequest_, o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSolrFqSupportsTeachingComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSupportsTeachingComment(siteRequest_, o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSolrFqAssessmentsQuality(siteRequest_, o);
+			return CurrikiResource.staticSearchFqAssessmentsQuality(siteRequest_, o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSolrFqAssessmentsQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqAssessmentsQualityComment(siteRequest_, o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSolrFqInteractivityQuality(siteRequest_, o);
+			return CurrikiResource.staticSearchFqInteractivityQuality(siteRequest_, o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSolrFqInteractivityQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqInteractivityQualityComment(siteRequest_, o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSolrFqInstructionalQuality(siteRequest_, o);
+			return CurrikiResource.staticSearchFqInstructionalQuality(siteRequest_, o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSolrFqInstructionalQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqInstructionalQualityComment(siteRequest_, o);
 		case "deeperLearning":
-			return CurrikiResource.staticSolrFqDeeperLearning(siteRequest_, o);
+			return CurrikiResource.staticSearchFqDeeperLearning(siteRequest_, o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSolrFqDeeperLearningComment(siteRequest_, o);
+			return CurrikiResource.staticSearchFqDeeperLearningComment(siteRequest_, o);
 		case "partner":
-			return CurrikiResource.staticSolrFqPartner(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPartner(siteRequest_, o);
 		case "createDate":
-			return CurrikiResource.staticSolrFqCreateDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqCreateDate(siteRequest_, o);
 		case "type":
-			return CurrikiResource.staticSolrFqType(siteRequest_, o);
+			return CurrikiResource.staticSearchFqType(siteRequest_, o);
 		case "featured":
-			return CurrikiResource.staticSolrFqFeatured(siteRequest_, o);
+			return CurrikiResource.staticSearchFqFeatured(siteRequest_, o);
 		case "page":
-			return CurrikiResource.staticSolrFqPage(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPage(siteRequest_, o);
 		case "active":
-			return CurrikiResource.staticSolrFqActive(siteRequest_, o);
+			return CurrikiResource.staticSearchFqActive(siteRequest_, o);
 		case "Public":
-			return CurrikiResource.staticSolrFqPublic(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPublic(siteRequest_, o);
 		case "xwd_id":
-			return CurrikiResource.staticSolrFqXwd_id(siteRequest_, o);
+			return CurrikiResource.staticSearchFqXwd_id(siteRequest_, o);
 		case "mediaType":
-			return CurrikiResource.staticSolrFqMediaType(siteRequest_, o);
+			return CurrikiResource.staticSearchFqMediaType(siteRequest_, o);
 		case "access":
-			return CurrikiResource.staticSolrFqAccess(siteRequest_, o);
+			return CurrikiResource.staticSearchFqAccess(siteRequest_, o);
 		case "memberRating":
-			return CurrikiResource.staticSolrFqMemberRating(siteRequest_, o);
+			return CurrikiResource.staticSearchFqMemberRating(siteRequest_, o);
 		case "aligned":
-			return CurrikiResource.staticSolrFqAligned(siteRequest_, o);
+			return CurrikiResource.staticSearchFqAligned(siteRequest_, o);
 		case "pageUrl":
-			return CurrikiResource.staticSolrFqPageUrl(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPageUrl(siteRequest_, o);
 		case "indexed":
-			return CurrikiResource.staticSolrFqIndexed(siteRequest_, o);
+			return CurrikiResource.staticSearchFqIndexed(siteRequest_, o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSolrFqLastIndexDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLastIndexDate(siteRequest_, o);
 		case "indexRequired":
-			return CurrikiResource.staticSolrFqIndexRequired(siteRequest_, o);
+			return CurrikiResource.staticSearchFqIndexRequired(siteRequest_, o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSolrFqIndexRequiredDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqIndexRequiredDate(siteRequest_, o);
 		case "rescrape":
-			return CurrikiResource.staticSolrFqRescrape(siteRequest_, o);
+			return CurrikiResource.staticSearchFqRescrape(siteRequest_, o);
 		case "goButton":
-			return CurrikiResource.staticSolrFqGoButton(siteRequest_, o);
+			return CurrikiResource.staticSearchFqGoButton(siteRequest_, o);
 		case "downloadButton":
-			return CurrikiResource.staticSolrFqDownloadButton(siteRequest_, o);
+			return CurrikiResource.staticSearchFqDownloadButton(siteRequest_, o);
 		case "topOfSearch":
-			return CurrikiResource.staticSolrFqTopOfSearch(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTopOfSearch(siteRequest_, o);
 		case "remove":
-			return CurrikiResource.staticSolrFqRemove(siteRequest_, o);
+			return CurrikiResource.staticSearchFqRemove(siteRequest_, o);
 		case "spam":
-			return CurrikiResource.staticSolrFqSpam(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSpam(siteRequest_, o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSolrFqTopOfSearchInt(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTopOfSearchInt(siteRequest_, o);
 		case "partnerInt":
-			return CurrikiResource.staticSolrFqPartnerInt(siteRequest_, o);
+			return CurrikiResource.staticSearchFqPartnerInt(siteRequest_, o);
 		case "reviewResource":
-			return CurrikiResource.staticSolrFqReviewResource(siteRequest_, o);
+			return CurrikiResource.staticSearchFqReviewResource(siteRequest_, o);
 		case "oldUrl":
-			return CurrikiResource.staticSolrFqOldUrl(siteRequest_, o);
+			return CurrikiResource.staticSearchFqOldUrl(siteRequest_, o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSolrFqContentDisplayOk(siteRequest_, o);
+			return CurrikiResource.staticSearchFqContentDisplayOk(siteRequest_, o);
 		case "metadata":
-			return CurrikiResource.staticSolrFqMetadata(siteRequest_, o);
+			return CurrikiResource.staticSearchFqMetadata(siteRequest_, o);
 		case "approvalStatus":
-			return CurrikiResource.staticSolrFqApprovalStatus(siteRequest_, o);
+			return CurrikiResource.staticSearchFqApprovalStatus(siteRequest_, o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSolrFqApprovalStatusDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqApprovalStatusDate(siteRequest_, o);
 		case "spamUser":
-			return CurrikiResource.staticSolrFqSpamUser(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSpamUser(siteRequest_, o);
 		case "url":
-			return CurrikiResource.staticSolrFqUrl(siteRequest_, o);
+			return CurrikiResource.staticSearchFqUrl(siteRequest_, o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSolrFqDisplaySeqNo(siteRequest_, o);
+			return CurrikiResource.staticSearchFqDisplaySeqNo(siteRequest_, o);
 		case "fileId":
-			return CurrikiResource.staticSolrFqFileId(siteRequest_, o);
+			return CurrikiResource.staticSearchFqFileId(siteRequest_, o);
 		case "fileName":
-			return CurrikiResource.staticSolrFqFileName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqFileName(siteRequest_, o);
 		case "uploadDate":
-			return CurrikiResource.staticSolrFqUploadDate(siteRequest_, o);
+			return CurrikiResource.staticSearchFqUploadDate(siteRequest_, o);
 		case "sequence":
-			return CurrikiResource.staticSolrFqSequence(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSequence(siteRequest_, o);
 		case "uniqueName":
-			return CurrikiResource.staticSolrFqUniqueName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqUniqueName(siteRequest_, o);
 		case "ext":
-			return CurrikiResource.staticSolrFqExt(siteRequest_, o);
+			return CurrikiResource.staticSearchFqExt(siteRequest_, o);
 		case "resourceFilesActive":
-			return CurrikiResource.staticSolrFqResourceFilesActive(siteRequest_, o);
+			return CurrikiResource.staticSearchFqResourceFilesActive(siteRequest_, o);
 		case "tempactive":
-			return CurrikiResource.staticSolrFqTempactive(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTempactive(siteRequest_, o);
 		case "s3path":
-			return CurrikiResource.staticSolrFqS3path(siteRequest_, o);
+			return CurrikiResource.staticSearchFqS3path(siteRequest_, o);
 		case "sdfStatus":
-			return CurrikiResource.staticSolrFqSdfStatus(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSdfStatus(siteRequest_, o);
 		case "transcoded":
-			return CurrikiResource.staticSolrFqTranscoded(siteRequest_, o);
+			return CurrikiResource.staticSearchFqTranscoded(siteRequest_, o);
 		case "lodestar":
-			return CurrikiResource.staticSolrFqLodestar(siteRequest_, o);
+			return CurrikiResource.staticSearchFqLodestar(siteRequest_, o);
 		case "archive":
-			return CurrikiResource.staticSolrFqArchive(siteRequest_, o);
+			return CurrikiResource.staticSearchFqArchive(siteRequest_, o);
 		case "identifier":
-			return CurrikiResource.staticSolrFqIdentifier(siteRequest_, o);
+			return CurrikiResource.staticSearchFqIdentifier(siteRequest_, o);
 		case "educationLevelDisplayName":
-			return CurrikiResource.staticSolrFqEducationLevelDisplayName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqEducationLevelDisplayName(siteRequest_, o);
 		case "subjectArea":
-			return CurrikiResource.staticSolrFqSubjectArea(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSubjectArea(siteRequest_, o);
 		case "subjectAreaDisplayName":
-			return CurrikiResource.staticSolrFqSubjectAreaDisplayName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqSubjectAreaDisplayName(siteRequest_, o);
 		case "instructionTypeDisplayName":
-			return CurrikiResource.staticSolrFqInstructionTypeDisplayName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqInstructionTypeDisplayName(siteRequest_, o);
 		case "name":
-			return CurrikiResource.staticSolrFqName(siteRequest_, o);
+			return CurrikiResource.staticSearchFqName(siteRequest_, o);
 			default:
-				return BaseModel.staticSolrFqBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchFqBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	/////////////
-	// define //
+	// persist //
 	/////////////
 
-	@Override public boolean defineForClass(String var, Object val) {
+	@Override public boolean persistForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = defineCurrikiResource(v, val);
+					o = persistCurrikiResource(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
+					o = oBaseModel.persistForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object defineCurrikiResource(String var, Object val) {
+	public Object persistCurrikiResource(String var, Object val) {
 		switch(var.toLowerCase()) {
+			case "resourceid":
+				if(val instanceof String)
+					setResourceId((String)val);
+				saves.add("resourceId");
+				return val;
+			case "licenseid":
+				if(val instanceof String)
+					setLicenseId((String)val);
+				saves.add("licenseId");
+				return val;
+			case "contributorid":
+				if(val instanceof Long)
+					setContributorId((Long)val);
+				else if(val instanceof String)
+					setContributorId((String)val);
+				saves.add("contributorId");
+				return val;
+			case "contributiondate":
+				if(val instanceof ZonedDateTime)
+					setContributionDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setContributionDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setContributionDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("contributionDate");
+				return val;
+			case "description":
+				if(val instanceof String)
+					setDescription((String)val);
+				saves.add("description");
+				return val;
+			case "title":
+				if(val instanceof String)
+					setTitle((String)val);
+				saves.add("title");
+				return val;
+			case "keywordsstr":
+				if(val instanceof String)
+					setKeywordsStr((String)val);
+				saves.add("keywordsStr");
+				return val;
+			case "generatedkeywordsstr":
+				if(val instanceof String)
+					setGeneratedKeywordsStr((String)val);
+				saves.add("generatedKeywordsStr");
+				return val;
+			case "language":
+				if(val instanceof String)
+					setLanguage((String)val);
+				saves.add("language");
+				return val;
+			case "lasteditorid":
+				if(val instanceof Long)
+					setLastEditorId((Long)val);
+				else if(val instanceof String)
+					setLastEditorId((String)val);
+				saves.add("lastEditorId");
+				return val;
+			case "lasteditdate":
+				if(val instanceof ZonedDateTime)
+					setLastEditDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setLastEditDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setLastEditDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("lastEditDate");
+				return val;
+			case "currikilicense":
+				if(val instanceof String)
+					setCurrikiLicense((String)val);
+				saves.add("currikiLicense");
+				return val;
+			case "externalurl":
+				if(val instanceof String)
+					setExternalUrl((String)val);
+				saves.add("externalUrl");
+				return val;
+			case "resourcechecked":
+				if(val instanceof String)
+					setResourceChecked((String)val);
+				saves.add("resourceChecked");
+				return val;
+			case "content":
+				if(val instanceof String)
+					setContent((String)val);
+				saves.add("content");
+				return val;
+			case "resourcecheckrequestnote":
+				if(val instanceof String)
+					setResourceCheckRequestNote((String)val);
+				saves.add("resourceCheckRequestNote");
+				return val;
+			case "resourcecheckdate":
+				if(val instanceof ZonedDateTime)
+					setResourceCheckDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setResourceCheckDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setResourceCheckDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("resourceCheckDate");
+				return val;
+			case "resourcecheckid":
+				if(val instanceof Long)
+					setResourceCheckId((Long)val);
+				else if(val instanceof String)
+					setResourceCheckId((String)val);
+				saves.add("resourceCheckId");
+				return val;
+			case "resourcechecknote":
+				if(val instanceof String)
+					setResourceCheckNote((String)val);
+				saves.add("resourceCheckNote");
+				return val;
+			case "studentfacing":
+				if(val instanceof String)
+					setStudentFacing((String)val);
+				saves.add("studentFacing");
+				return val;
+			case "source":
+				if(val instanceof String)
+					setSource((String)val);
+				saves.add("source");
+				return val;
+			case "reviewstatus":
+				if(val instanceof String)
+					setReviewStatus((String)val);
+				saves.add("reviewStatus");
+				return val;
+			case "lastreviewdate":
+				if(val instanceof ZonedDateTime)
+					setLastReviewDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setLastReviewDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setLastReviewDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("lastReviewDate");
+				return val;
+			case "reviewbyid":
+				if(val instanceof Long)
+					setReviewByID((Long)val);
+				else if(val instanceof String)
+					setReviewByID((String)val);
+				saves.add("reviewByID");
+				return val;
+			case "reviewrating":
+				if(val instanceof String)
+					setReviewRating((String)val);
+				else if(val instanceof Number)
+					setReviewRating(new BigDecimal(((Number)val).doubleValue()));
+				saves.add("reviewRating");
+				return val;
+			case "technicalcompleteness":
+				if(val instanceof Integer)
+					setTechnicalCompleteness((Integer)val);
+				else if(val instanceof String)
+					setTechnicalCompleteness((String)val);
+				saves.add("technicalCompleteness");
+				return val;
+			case "contentaccuracy":
+				if(val instanceof Integer)
+					setContentAccuracy((Integer)val);
+				else if(val instanceof String)
+					setContentAccuracy((String)val);
+				saves.add("contentAccuracy");
+				return val;
+			case "pedagogy":
+				if(val instanceof Integer)
+					setPedagogy((Integer)val);
+				else if(val instanceof String)
+					setPedagogy((String)val);
+				saves.add("pedagogy");
+				return val;
+			case "ratingcomment":
+				if(val instanceof String)
+					setRatingComment((String)val);
+				saves.add("ratingComment");
+				return val;
+			case "standardsalignment":
+				if(val instanceof Integer)
+					setStandardsAlignment((Integer)val);
+				else if(val instanceof String)
+					setStandardsAlignment((String)val);
+				saves.add("standardsAlignment");
+				return val;
+			case "standardsalignmentcomment":
+				if(val instanceof String)
+					setStandardsAlignmentComment((String)val);
+				saves.add("standardsAlignmentComment");
+				return val;
+			case "subjectmatter":
+				if(val instanceof Integer)
+					setSubjectMatter((Integer)val);
+				else if(val instanceof String)
+					setSubjectMatter((String)val);
+				saves.add("subjectMatter");
+				return val;
+			case "subjectmattercomment":
+				if(val instanceof String)
+					setSubjectMatterComment((String)val);
+				saves.add("subjectMatterComment");
+				return val;
+			case "supportsteaching":
+				if(val instanceof Integer)
+					setSupportsTeaching((Integer)val);
+				else if(val instanceof String)
+					setSupportsTeaching((String)val);
+				saves.add("supportsTeaching");
+				return val;
+			case "supportsteachingcomment":
+				if(val instanceof String)
+					setSupportsTeachingComment((String)val);
+				saves.add("supportsTeachingComment");
+				return val;
+			case "assessmentsquality":
+				if(val instanceof Integer)
+					setAssessmentsQuality((Integer)val);
+				else if(val instanceof String)
+					setAssessmentsQuality((String)val);
+				saves.add("assessmentsQuality");
+				return val;
+			case "assessmentsqualitycomment":
+				if(val instanceof String)
+					setAssessmentsQualityComment((String)val);
+				saves.add("assessmentsQualityComment");
+				return val;
+			case "interactivityquality":
+				if(val instanceof Integer)
+					setInteractivityQuality((Integer)val);
+				else if(val instanceof String)
+					setInteractivityQuality((String)val);
+				saves.add("interactivityQuality");
+				return val;
+			case "interactivityqualitycomment":
+				if(val instanceof String)
+					setInteractivityQualityComment((String)val);
+				saves.add("interactivityQualityComment");
+				return val;
+			case "instructionalquality":
+				if(val instanceof Integer)
+					setInstructionalQuality((Integer)val);
+				else if(val instanceof String)
+					setInstructionalQuality((String)val);
+				saves.add("instructionalQuality");
+				return val;
+			case "instructionalqualitycomment":
+				if(val instanceof String)
+					setInstructionalQualityComment((String)val);
+				saves.add("instructionalQualityComment");
+				return val;
+			case "deeperlearning":
+				if(val instanceof Integer)
+					setDeeperLearning((Integer)val);
+				else if(val instanceof String)
+					setDeeperLearning((String)val);
+				saves.add("deeperLearning");
+				return val;
+			case "deeperlearningcomment":
+				if(val instanceof String)
+					setDeeperLearningComment((String)val);
+				saves.add("deeperLearningComment");
+				return val;
+			case "partner":
+				if(val instanceof String)
+					setPartner((String)val);
+				saves.add("partner");
+				return val;
+			case "createdate":
+				if(val instanceof ZonedDateTime)
+					setCreateDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setCreateDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setCreateDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("createDate");
+				return val;
+			case "type":
+				if(val instanceof String)
+					setType((String)val);
+				saves.add("type");
+				return val;
+			case "featured":
+				if(val instanceof String)
+					setFeatured((String)val);
+				saves.add("featured");
+				return val;
+			case "page":
+				if(val instanceof String)
+					setPage((String)val);
+				saves.add("page");
+				return val;
+			case "active":
+				if(val instanceof String)
+					setActive((String)val);
+				saves.add("active");
+				return val;
+			case "public":
+				if(val instanceof String)
+					setPublic((String)val);
+				saves.add("Public");
+				return val;
+			case "xwd_id":
+				if(val instanceof Integer)
+					setXwd_id((Integer)val);
+				else if(val instanceof String)
+					setXwd_id((String)val);
+				saves.add("xwd_id");
+				return val;
+			case "mediatype":
+				if(val instanceof String)
+					setMediaType((String)val);
+				saves.add("mediaType");
+				return val;
+			case "access":
+				if(val instanceof String)
+					setAccess((String)val);
+				saves.add("access");
+				return val;
+			case "memberrating":
+				if(val instanceof String)
+					setMemberRating((String)val);
+				else if(val instanceof Number)
+					setMemberRating(new BigDecimal(((Number)val).doubleValue()));
+				saves.add("memberRating");
+				return val;
+			case "aligned":
+				if(val instanceof String)
+					setAligned((String)val);
+				saves.add("aligned");
+				return val;
+			case "pageurl":
+				if(val instanceof String)
+					setPageUrl((String)val);
+				saves.add("pageUrl");
+				return val;
+			case "indexed":
+				if(val instanceof String)
+					setIndexed((String)val);
+				saves.add("indexed");
+				return val;
+			case "lastindexdate":
+				if(val instanceof ZonedDateTime)
+					setLastIndexDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setLastIndexDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setLastIndexDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("lastIndexDate");
+				return val;
+			case "indexrequired":
+				if(val instanceof String)
+					setIndexRequired((String)val);
+				saves.add("indexRequired");
+				return val;
+			case "indexrequireddate":
+				if(val instanceof ZonedDateTime)
+					setIndexRequiredDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setIndexRequiredDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setIndexRequiredDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("indexRequiredDate");
+				return val;
+			case "rescrape":
+				if(val instanceof String)
+					setRescrape((String)val);
+				saves.add("rescrape");
+				return val;
+			case "gobutton":
+				if(val instanceof String)
+					setGoButton((String)val);
+				saves.add("goButton");
+				return val;
+			case "downloadbutton":
+				if(val instanceof String)
+					setDownloadButton((String)val);
+				saves.add("downloadButton");
+				return val;
+			case "topofsearch":
+				if(val instanceof String)
+					setTopOfSearch((String)val);
+				saves.add("topOfSearch");
+				return val;
+			case "remove":
+				if(val instanceof String)
+					setRemove((String)val);
+				saves.add("remove");
+				return val;
+			case "spam":
+				if(val instanceof String)
+					setSpam((String)val);
+				saves.add("spam");
+				return val;
+			case "topofsearchint":
+				if(val instanceof Integer)
+					setTopOfSearchInt((Integer)val);
+				else if(val instanceof String)
+					setTopOfSearchInt((String)val);
+				saves.add("topOfSearchInt");
+				return val;
+			case "partnerint":
+				if(val instanceof Integer)
+					setPartnerInt((Integer)val);
+				else if(val instanceof String)
+					setPartnerInt((String)val);
+				saves.add("partnerInt");
+				return val;
+			case "reviewresource":
+				if(val instanceof String)
+					setReviewResource((String)val);
+				saves.add("reviewResource");
+				return val;
+			case "oldurl":
+				if(val instanceof String)
+					setOldUrl((String)val);
+				saves.add("oldUrl");
+				return val;
+			case "contentdisplayok":
+				if(val instanceof String)
+					setContentDisplayOk((String)val);
+				saves.add("contentDisplayOk");
+				return val;
+			case "metadata":
+				if(val instanceof String)
+					setMetadata((String)val);
+				saves.add("metadata");
+				return val;
+			case "approvalstatus":
+				if(val instanceof String)
+					setApprovalStatus((String)val);
+				saves.add("approvalStatus");
+				return val;
+			case "approvalstatusdate":
+				if(val instanceof ZonedDateTime)
+					setApprovalStatusDate((ZonedDateTime)val);
+				else if(val instanceof String)
+					setApprovalStatusDate((String)val);
+				else if(val instanceof OffsetDateTime)
+					setApprovalStatusDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
+				saves.add("approvalStatusDate");
+				return val;
+			case "spamuser":
+				if(val instanceof String)
+					setSpamUser((String)val);
+				saves.add("spamUser");
+				return val;
+			case "url":
+				if(val instanceof String)
+					setUrl((String)val);
+				saves.add("url");
+				return val;
+			case "displayseqno":
+				if(val instanceof Integer)
+					setDisplaySeqNo((Integer)val);
+				else if(val instanceof String)
+					setDisplaySeqNo((String)val);
+				saves.add("displaySeqNo");
+				return val;
+			case "fileid":
+				if(val instanceof Integer)
+					setFileId((Integer)val);
+				else if(val instanceof String)
+					setFileId((String)val);
+				saves.add("fileId");
+				return val;
+			case "filename":
+				if(val instanceof String)
+					setFileName((String)val);
+				saves.add("fileName");
+				return val;
+			case "uploaddate":
+				if(val instanceof String)
+					setUploadDate((String)val);
+				saves.add("uploadDate");
+				return val;
+			case "sequence":
+				if(val instanceof Integer)
+					setSequence((Integer)val);
+				else if(val instanceof String)
+					setSequence((String)val);
+				saves.add("sequence");
+				return val;
+			case "uniquename":
+				if(val instanceof String)
+					setUniqueName((String)val);
+				saves.add("uniqueName");
+				return val;
+			case "ext":
+				if(val instanceof String)
+					setExt((String)val);
+				saves.add("ext");
+				return val;
+			case "resourcefilesactive":
+				if(val instanceof String)
+					setResourceFilesActive((String)val);
+				saves.add("resourceFilesActive");
+				return val;
+			case "tempactive":
+				if(val instanceof String)
+					setTempactive((String)val);
+				saves.add("tempactive");
+				return val;
+			case "s3path":
+				if(val instanceof String)
+					setS3path((String)val);
+				saves.add("s3path");
+				return val;
+			case "sdfstatus":
+				if(val instanceof String)
+					setSdfStatus((String)val);
+				saves.add("sdfStatus");
+				return val;
+			case "transcoded":
+				if(val instanceof String)
+					setTranscoded((String)val);
+				saves.add("transcoded");
+				return val;
+			case "lodestar":
+				if(val instanceof String)
+					setLodestar((String)val);
+				saves.add("lodestar");
+				return val;
+			case "archive":
+				if(val instanceof String)
+					setArchive((String)val);
+				saves.add("archive");
+				return val;
+			case "identifier":
+				if(val instanceof String)
+					setIdentifier((String)val);
+				saves.add("identifier");
+				return val;
+			case "educationleveldisplayname":
+				if(val instanceof String)
+					setEducationLevelDisplayName((String)val);
+				saves.add("educationLevelDisplayName");
+				return val;
+			case "subjectarea":
+				if(val instanceof String)
+					setSubjectArea((String)val);
+				saves.add("subjectArea");
+				return val;
+			case "subjectareadisplayname":
+				if(val instanceof String)
+					setSubjectAreaDisplayName((String)val);
+				saves.add("subjectAreaDisplayName");
+				return val;
+			case "instructiontypedisplayname":
+				if(val instanceof String)
+					setInstructionTypeDisplayName((String)val);
+				saves.add("instructionTypeDisplayName");
+				return val;
+			case "name":
+				if(val instanceof String)
+					setName((String)val);
+				saves.add("name");
+				return val;
 			default:
-				return super.defineBaseModel(var, val);
+				return super.persistBaseModel(var, val);
 		}
 	}
 
@@ -6555,318 +7504,322 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	// populate //
 	/////////////
 
-	@Override public void populateForClass(SolrDocument solrDocument) {
-		populateCurrikiResource(solrDocument);
+	@Override public void populateForClass(SolrResponse.Doc doc) {
+		populateCurrikiResource(doc);
 	}
-	public void populateCurrikiResource(SolrDocument solrDocument) {
+	public void populateCurrikiResource(SolrResponse.Doc doc) {
 		CurrikiResource oCurrikiResource = (CurrikiResource)this;
-		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
+		saves = doc.get("saves_docvalues_strings");
 		if(saves != null) {
 
 			if(saves.contains("content")) {
-				String content = (String)solrDocument.get("content_stored_string");
+				String content = (String)doc.get("content_stored_string");
 				if(content != null)
 					oCurrikiResource.setContent(content);
 			}
 
 			if(saves.contains("ratingComment")) {
-				String ratingComment = (String)solrDocument.get("ratingComment_stored_string");
+				String ratingComment = (String)doc.get("ratingComment_stored_string");
 				if(ratingComment != null)
 					oCurrikiResource.setRatingComment(ratingComment);
 			}
 		}
 
-		super.populateBaseModel(solrDocument);
+		super.populateBaseModel(doc);
 	}
 
-	public void indexCurrikiResource(SolrInputDocument document) {
+	public void indexCurrikiResource(JsonObject doc) {
 		if(resourceId != null) {
-			document.addField("resourceId_docvalues_string", resourceId);
+			doc.put("resourceId_docvalues_string", resourceId);
 		}
 		if(licenseId != null) {
-			document.addField("licenseId_docvalues_string", licenseId);
+			doc.put("licenseId_docvalues_string", licenseId);
 		}
 		if(contributorId != null) {
-			document.addField("contributorId_docvalues_long", contributorId);
+			doc.put("contributorId_docvalues_long", contributorId);
 		}
 		if(contributionDate != null) {
-			document.addField("contributionDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(contributionDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("contributionDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(contributionDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(description != null) {
-			document.addField("description_docvalues_string", description);
+			doc.put("description_docvalues_string", description);
 		}
 		if(title != null) {
-			document.addField("title_docvalues_string", title);
+			doc.put("title_docvalues_string", title);
 		}
 		if(keywords != null) {
-			for(java.lang.String o : keywords) {
-				document.addField("keywords_docvalues_strings", o);
+			JsonArray l = new JsonArray();
+			doc.put("keywords_docvalues_strings", l);
+			for(String o : keywords) {
+				l.add(o);
 			}
 		}
 		if(generatedKeywords != null) {
-			for(java.lang.String o : generatedKeywords) {
-				document.addField("generatedKeywords_docvalues_strings", o);
+			JsonArray l = new JsonArray();
+			doc.put("generatedKeywords_docvalues_strings", l);
+			for(String o : generatedKeywords) {
+				l.add(o);
 			}
 		}
 		if(language != null) {
-			document.addField("language_docvalues_string", language);
+			doc.put("language_docvalues_string", language);
 		}
 		if(lastEditorId != null) {
-			document.addField("lastEditorId_docvalues_long", lastEditorId);
+			doc.put("lastEditorId_docvalues_long", lastEditorId);
 		}
 		if(lastEditDate != null) {
-			document.addField("lastEditDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastEditDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("lastEditDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastEditDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(currikiLicense != null) {
-			document.addField("currikiLicense_docvalues_string", currikiLicense);
+			doc.put("currikiLicense_docvalues_string", currikiLicense);
 		}
 		if(externalUrl != null) {
-			document.addField("externalUrl_docvalues_string", externalUrl);
+			doc.put("externalUrl_docvalues_string", externalUrl);
 		}
 		if(resourceChecked != null) {
-			document.addField("resourceChecked_docvalues_string", resourceChecked);
+			doc.put("resourceChecked_docvalues_string", resourceChecked);
 		}
 		if(content != null) {
-			document.addField("content_stored_string", content);
+			doc.put("content_stored_string", content);
 		}
 		if(resourceCheckDate != null) {
-			document.addField("resourceCheckDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(resourceCheckDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("resourceCheckDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(resourceCheckDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(resourceCheckId != null) {
-			document.addField("resourceCheckId_docvalues_long", resourceCheckId);
+			doc.put("resourceCheckId_docvalues_long", resourceCheckId);
 		}
 		if(studentFacing != null) {
-			document.addField("studentFacing_docvalues_string", studentFacing);
+			doc.put("studentFacing_docvalues_string", studentFacing);
 		}
 		if(source != null) {
-			document.addField("source_docvalues_string", source);
+			doc.put("source_docvalues_string", source);
 		}
 		if(reviewStatus != null) {
-			document.addField("reviewStatus_docvalues_string", reviewStatus);
+			doc.put("reviewStatus_docvalues_string", reviewStatus);
 		}
 		if(lastReviewDate != null) {
-			document.addField("lastReviewDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastReviewDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("lastReviewDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastReviewDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(reviewByID != null) {
-			document.addField("reviewByID_docvalues_long", reviewByID);
+			doc.put("reviewByID_docvalues_long", reviewByID);
 		}
 		if(reviewRating != null) {
-			document.addField("reviewRating_docvalues_double", reviewRating.doubleValue());
+			doc.put("reviewRating_docvalues_double", reviewRating.doubleValue());
 		}
 		if(technicalCompleteness != null) {
-			document.addField("technicalCompleteness_docvalues_int", technicalCompleteness);
+			doc.put("technicalCompleteness_docvalues_int", technicalCompleteness);
 		}
 		if(contentAccuracy != null) {
-			document.addField("contentAccuracy_docvalues_int", contentAccuracy);
+			doc.put("contentAccuracy_docvalues_int", contentAccuracy);
 		}
 		if(pedagogy != null) {
-			document.addField("pedagogy_docvalues_int", pedagogy);
+			doc.put("pedagogy_docvalues_int", pedagogy);
 		}
 		if(ratingComment != null) {
-			document.addField("ratingComment_stored_string", ratingComment);
+			doc.put("ratingComment_stored_string", ratingComment);
 		}
 		if(standardsAlignment != null) {
-			document.addField("standardsAlignment_docvalues_int", standardsAlignment);
+			doc.put("standardsAlignment_docvalues_int", standardsAlignment);
 		}
 		if(standardsAlignmentComment != null) {
-			document.addField("standardsAlignmentComment_docvalues_string", standardsAlignmentComment);
+			doc.put("standardsAlignmentComment_docvalues_string", standardsAlignmentComment);
 		}
 		if(subjectMatter != null) {
-			document.addField("subjectMatter_docvalues_int", subjectMatter);
+			doc.put("subjectMatter_docvalues_int", subjectMatter);
 		}
 		if(subjectMatterComment != null) {
-			document.addField("subjectMatterComment_docvalues_string", subjectMatterComment);
+			doc.put("subjectMatterComment_docvalues_string", subjectMatterComment);
 		}
 		if(supportsTeaching != null) {
-			document.addField("supportsTeaching_docvalues_int", supportsTeaching);
+			doc.put("supportsTeaching_docvalues_int", supportsTeaching);
 		}
 		if(supportsTeachingComment != null) {
-			document.addField("supportsTeachingComment_docvalues_string", supportsTeachingComment);
+			doc.put("supportsTeachingComment_docvalues_string", supportsTeachingComment);
 		}
 		if(assessmentsQuality != null) {
-			document.addField("assessmentsQuality_docvalues_int", assessmentsQuality);
+			doc.put("assessmentsQuality_docvalues_int", assessmentsQuality);
 		}
 		if(assessmentsQualityComment != null) {
-			document.addField("assessmentsQualityComment_docvalues_string", assessmentsQualityComment);
+			doc.put("assessmentsQualityComment_docvalues_string", assessmentsQualityComment);
 		}
 		if(interactivityQuality != null) {
-			document.addField("interactivityQuality_docvalues_int", interactivityQuality);
+			doc.put("interactivityQuality_docvalues_int", interactivityQuality);
 		}
 		if(interactivityQualityComment != null) {
-			document.addField("interactivityQualityComment_docvalues_string", interactivityQualityComment);
+			doc.put("interactivityQualityComment_docvalues_string", interactivityQualityComment);
 		}
 		if(instructionalQuality != null) {
-			document.addField("instructionalQuality_docvalues_int", instructionalQuality);
+			doc.put("instructionalQuality_docvalues_int", instructionalQuality);
 		}
 		if(instructionalQualityComment != null) {
-			document.addField("instructionalQualityComment_docvalues_string", instructionalQualityComment);
+			doc.put("instructionalQualityComment_docvalues_string", instructionalQualityComment);
 		}
 		if(deeperLearning != null) {
-			document.addField("deeperLearning_docvalues_int", deeperLearning);
+			doc.put("deeperLearning_docvalues_int", deeperLearning);
 		}
 		if(deeperLearningComment != null) {
-			document.addField("deeperLearningComment_docvalues_string", deeperLearningComment);
+			doc.put("deeperLearningComment_docvalues_string", deeperLearningComment);
 		}
 		if(partner != null) {
-			document.addField("partner_docvalues_string", partner);
+			doc.put("partner_docvalues_string", partner);
 		}
 		if(createDate != null) {
-			document.addField("createDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(createDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("createDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(createDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(type != null) {
-			document.addField("type_docvalues_string", type);
+			doc.put("type_docvalues_string", type);
 		}
 		if(featured != null) {
-			document.addField("featured_docvalues_string", featured);
+			doc.put("featured_docvalues_string", featured);
 		}
 		if(page != null) {
-			document.addField("page_docvalues_string", page);
+			doc.put("page_docvalues_string", page);
 		}
 		if(active != null) {
-			document.addField("active_docvalues_string", active);
+			doc.put("active_docvalues_string", active);
 		}
 		if(Public != null) {
-			document.addField("Public_docvalues_string", Public);
+			doc.put("Public_docvalues_string", Public);
 		}
 		if(xwd_id != null) {
-			document.addField("xwd_id_docvalues_int", xwd_id);
+			doc.put("xwd_id_docvalues_int", xwd_id);
 		}
 		if(mediaType != null) {
-			document.addField("mediaType_docvalues_string", mediaType);
+			doc.put("mediaType_docvalues_string", mediaType);
 		}
 		if(access != null) {
-			document.addField("access_docvalues_string", access);
+			doc.put("access_docvalues_string", access);
 		}
 		if(memberRating != null) {
-			document.addField("memberRating_docvalues_double", memberRating.doubleValue());
+			doc.put("memberRating_docvalues_double", memberRating.doubleValue());
 		}
 		if(aligned != null) {
-			document.addField("aligned_docvalues_string", aligned);
+			doc.put("aligned_docvalues_string", aligned);
 		}
 		if(pageUrl != null) {
-			document.addField("pageUrl_docvalues_string", pageUrl);
+			doc.put("pageUrl_docvalues_string", pageUrl);
 		}
 		if(indexed != null) {
-			document.addField("indexed_docvalues_string", indexed);
+			doc.put("indexed_docvalues_string", indexed);
 		}
 		if(lastIndexDate != null) {
-			document.addField("lastIndexDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastIndexDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("lastIndexDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastIndexDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(indexRequired != null) {
-			document.addField("indexRequired_docvalues_string", indexRequired);
+			doc.put("indexRequired_docvalues_string", indexRequired);
 		}
 		if(indexRequiredDate != null) {
-			document.addField("indexRequiredDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(indexRequiredDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("indexRequiredDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(indexRequiredDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(rescrape != null) {
-			document.addField("rescrape_docvalues_string", rescrape);
+			doc.put("rescrape_docvalues_string", rescrape);
 		}
 		if(goButton != null) {
-			document.addField("goButton_docvalues_string", goButton);
+			doc.put("goButton_docvalues_string", goButton);
 		}
 		if(downloadButton != null) {
-			document.addField("downloadButton_docvalues_string", downloadButton);
+			doc.put("downloadButton_docvalues_string", downloadButton);
 		}
 		if(topOfSearch != null) {
-			document.addField("topOfSearch_docvalues_string", topOfSearch);
+			doc.put("topOfSearch_docvalues_string", topOfSearch);
 		}
 		if(remove != null) {
-			document.addField("remove_docvalues_string", remove);
+			doc.put("remove_docvalues_string", remove);
 		}
 		if(spam != null) {
-			document.addField("spam_docvalues_string", spam);
+			doc.put("spam_docvalues_string", spam);
 		}
 		if(topOfSearchInt != null) {
-			document.addField("topOfSearchInt_docvalues_int", topOfSearchInt);
+			doc.put("topOfSearchInt_docvalues_int", topOfSearchInt);
 		}
 		if(partnerInt != null) {
-			document.addField("partnerInt_docvalues_int", partnerInt);
+			doc.put("partnerInt_docvalues_int", partnerInt);
 		}
 		if(reviewResource != null) {
-			document.addField("reviewResource_docvalues_string", reviewResource);
+			doc.put("reviewResource_docvalues_string", reviewResource);
 		}
 		if(oldUrl != null) {
-			document.addField("oldUrl_docvalues_string", oldUrl);
+			doc.put("oldUrl_docvalues_string", oldUrl);
 		}
 		if(contentDisplayOk != null) {
-			document.addField("contentDisplayOk_docvalues_string", contentDisplayOk);
+			doc.put("contentDisplayOk_docvalues_string", contentDisplayOk);
 		}
 		if(metadata != null) {
-			document.addField("metadata_docvalues_string", metadata);
+			doc.put("metadata_docvalues_string", metadata);
 		}
 		if(approvalStatus != null) {
-			document.addField("approvalStatus_docvalues_string", approvalStatus);
+			doc.put("approvalStatus_docvalues_string", approvalStatus);
 		}
 		if(approvalStatusDate != null) {
-			document.addField("approvalStatusDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(approvalStatusDate.toInstant(), ZoneId.of("UTC"))));
+			doc.put("approvalStatusDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(approvalStatusDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(spamUser != null) {
-			document.addField("spamUser_docvalues_string", spamUser);
+			doc.put("spamUser_docvalues_string", spamUser);
 		}
 		if(url != null) {
-			document.addField("url_docvalues_string", url);
+			doc.put("url_docvalues_string", url);
 		}
 		if(displaySeqNo != null) {
-			document.addField("displaySeqNo_docvalues_int", displaySeqNo);
+			doc.put("displaySeqNo_docvalues_int", displaySeqNo);
 		}
 		if(fileId != null) {
-			document.addField("fileId_docvalues_int", fileId);
+			doc.put("fileId_docvalues_int", fileId);
 		}
 		if(fileName != null) {
-			document.addField("fileName_docvalues_string", fileName);
+			doc.put("fileName_docvalues_string", fileName);
 		}
 		if(uploadDate != null) {
-			document.addField("uploadDate_docvalues_string", uploadDate);
+			doc.put("uploadDate_docvalues_string", uploadDate);
 		}
 		if(sequence != null) {
-			document.addField("sequence_docvalues_int", sequence);
+			doc.put("sequence_docvalues_int", sequence);
 		}
 		if(uniqueName != null) {
-			document.addField("uniqueName_docvalues_string", uniqueName);
+			doc.put("uniqueName_docvalues_string", uniqueName);
 		}
 		if(ext != null) {
-			document.addField("ext_docvalues_string", ext);
+			doc.put("ext_docvalues_string", ext);
 		}
 		if(resourceFilesActive != null) {
-			document.addField("resourceFilesActive_docvalues_string", resourceFilesActive);
+			doc.put("resourceFilesActive_docvalues_string", resourceFilesActive);
 		}
 		if(tempactive != null) {
-			document.addField("tempactive_docvalues_string", tempactive);
+			doc.put("tempactive_docvalues_string", tempactive);
 		}
 		if(s3path != null) {
-			document.addField("s3path_docvalues_string", s3path);
+			doc.put("s3path_docvalues_string", s3path);
 		}
 		if(sdfStatus != null) {
-			document.addField("sdfStatus_docvalues_string", sdfStatus);
+			doc.put("sdfStatus_docvalues_string", sdfStatus);
 		}
 		if(transcoded != null) {
-			document.addField("transcoded_docvalues_string", transcoded);
+			doc.put("transcoded_docvalues_string", transcoded);
 		}
 		if(lodestar != null) {
-			document.addField("lodestar_docvalues_string", lodestar);
+			doc.put("lodestar_docvalues_string", lodestar);
 		}
 		if(archive != null) {
-			document.addField("archive_docvalues_string", archive);
+			doc.put("archive_docvalues_string", archive);
 		}
 		if(identifier != null) {
-			document.addField("identifier_docvalues_string", identifier);
+			doc.put("identifier_docvalues_string", identifier);
 		}
 		if(educationLevelDisplayName != null) {
-			document.addField("educationLevelDisplayName_docvalues_string", educationLevelDisplayName);
+			doc.put("educationLevelDisplayName_docvalues_string", educationLevelDisplayName);
 		}
 		if(subjectArea != null) {
-			document.addField("subjectArea_docvalues_string", subjectArea);
+			doc.put("subjectArea_docvalues_string", subjectArea);
 		}
 		if(subjectAreaDisplayName != null) {
-			document.addField("subjectAreaDisplayName_docvalues_string", subjectAreaDisplayName);
+			doc.put("subjectAreaDisplayName_docvalues_string", subjectAreaDisplayName);
 		}
 		if(instructionTypeDisplayName != null) {
-			document.addField("instructionTypeDisplayName_docvalues_string", instructionTypeDisplayName);
+			doc.put("instructionTypeDisplayName_docvalues_string", instructionTypeDisplayName);
 		}
 		if(name != null) {
-			document.addField("name_docvalues_string", name);
+			doc.put("name_docvalues_string", name);
 		}
-		super.indexBaseModel(document);
+		super.indexBaseModel(doc);
 
 	}
 
@@ -7079,112 +8032,112 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	// store //
 	/////////////
 
-	@Override public void storeForClass(SolrDocument solrDocument) {
-		storeCurrikiResource(solrDocument);
+	@Override public void storeForClass(SolrResponse.Doc doc) {
+		storeCurrikiResource(doc);
 	}
-	public void storeCurrikiResource(SolrDocument solrDocument) {
+	public void storeCurrikiResource(SolrResponse.Doc doc) {
 		CurrikiResource oCurrikiResource = (CurrikiResource)this;
 
-		oCurrikiResource.setResourceId(Optional.ofNullable(solrDocument.get("resourceId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLicenseId(Optional.ofNullable(solrDocument.get("licenseId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContributorId(Optional.ofNullable(solrDocument.get("contributorId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContributionDate(Optional.ofNullable(solrDocument.get("contributionDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDescription(Optional.ofNullable(solrDocument.get("description_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTitle(Optional.ofNullable(solrDocument.get("title_docvalues_string")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)solrDocument.get("keywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oCurrikiResource.setResourceId(Optional.ofNullable(doc.get("resourceId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLicenseId(Optional.ofNullable(doc.get("licenseId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContributorId(Optional.ofNullable(doc.get("contributorId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContributionDate(Optional.ofNullable(doc.get("contributionDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDescription(Optional.ofNullable(doc.get("description_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTitle(Optional.ofNullable(doc.get("title_docvalues_string")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)doc.get("keywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oCurrikiResource.addKeywords(v.toString());
 		});
-		Optional.ofNullable((List<?>)solrDocument.get("generatedKeywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		Optional.ofNullable((List<?>)doc.get("generatedKeywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oCurrikiResource.addGeneratedKeywords(v.toString());
 		});
-		oCurrikiResource.setLanguage(Optional.ofNullable(solrDocument.get("language_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastEditorId(Optional.ofNullable(solrDocument.get("lastEditorId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastEditDate(Optional.ofNullable(solrDocument.get("lastEditDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setCurrikiLicense(Optional.ofNullable(solrDocument.get("currikiLicense_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setExternalUrl(Optional.ofNullable(solrDocument.get("externalUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceChecked(Optional.ofNullable(solrDocument.get("resourceChecked_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContent(Optional.ofNullable(solrDocument.get("content_stored_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceCheckDate(Optional.ofNullable(solrDocument.get("resourceCheckDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceCheckId(Optional.ofNullable(solrDocument.get("resourceCheckId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStudentFacing(Optional.ofNullable(solrDocument.get("studentFacing_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSource(Optional.ofNullable(solrDocument.get("source_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewStatus(Optional.ofNullable(solrDocument.get("reviewStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastReviewDate(Optional.ofNullable(solrDocument.get("lastReviewDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewByID(Optional.ofNullable(solrDocument.get("reviewByID_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewRating(Optional.ofNullable(solrDocument.get("reviewRating_docvalues_double")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTechnicalCompleteness(Optional.ofNullable(solrDocument.get("technicalCompleteness_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContentAccuracy(Optional.ofNullable(solrDocument.get("contentAccuracy_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPedagogy(Optional.ofNullable(solrDocument.get("pedagogy_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRatingComment(Optional.ofNullable(solrDocument.get("ratingComment_stored_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStandardsAlignment(Optional.ofNullable(solrDocument.get("standardsAlignment_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStandardsAlignmentComment(Optional.ofNullable(solrDocument.get("standardsAlignmentComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectMatter(Optional.ofNullable(solrDocument.get("subjectMatter_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectMatterComment(Optional.ofNullable(solrDocument.get("subjectMatterComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSupportsTeaching(Optional.ofNullable(solrDocument.get("supportsTeaching_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSupportsTeachingComment(Optional.ofNullable(solrDocument.get("supportsTeachingComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAssessmentsQuality(Optional.ofNullable(solrDocument.get("assessmentsQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAssessmentsQualityComment(Optional.ofNullable(solrDocument.get("assessmentsQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInteractivityQuality(Optional.ofNullable(solrDocument.get("interactivityQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInteractivityQualityComment(Optional.ofNullable(solrDocument.get("interactivityQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionalQuality(Optional.ofNullable(solrDocument.get("instructionalQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionalQualityComment(Optional.ofNullable(solrDocument.get("instructionalQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDeeperLearning(Optional.ofNullable(solrDocument.get("deeperLearning_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDeeperLearningComment(Optional.ofNullable(solrDocument.get("deeperLearningComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPartner(Optional.ofNullable(solrDocument.get("partner_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setCreateDate(Optional.ofNullable(solrDocument.get("createDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setType(Optional.ofNullable(solrDocument.get("type_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setFeatured(Optional.ofNullable(solrDocument.get("featured_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPage(Optional.ofNullable(solrDocument.get("page_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setActive(Optional.ofNullable(solrDocument.get("active_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPublic(Optional.ofNullable(solrDocument.get("Public_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setXwd_id(Optional.ofNullable(solrDocument.get("xwd_id_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMediaType(Optional.ofNullable(solrDocument.get("mediaType_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAccess(Optional.ofNullable(solrDocument.get("access_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMemberRating(Optional.ofNullable(solrDocument.get("memberRating_docvalues_double")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAligned(Optional.ofNullable(solrDocument.get("aligned_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPageUrl(Optional.ofNullable(solrDocument.get("pageUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexed(Optional.ofNullable(solrDocument.get("indexed_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastIndexDate(Optional.ofNullable(solrDocument.get("lastIndexDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexRequired(Optional.ofNullable(solrDocument.get("indexRequired_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexRequiredDate(Optional.ofNullable(solrDocument.get("indexRequiredDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRescrape(Optional.ofNullable(solrDocument.get("rescrape_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setGoButton(Optional.ofNullable(solrDocument.get("goButton_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDownloadButton(Optional.ofNullable(solrDocument.get("downloadButton_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTopOfSearch(Optional.ofNullable(solrDocument.get("topOfSearch_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRemove(Optional.ofNullable(solrDocument.get("remove_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSpam(Optional.ofNullable(solrDocument.get("spam_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTopOfSearchInt(Optional.ofNullable(solrDocument.get("topOfSearchInt_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPartnerInt(Optional.ofNullable(solrDocument.get("partnerInt_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewResource(Optional.ofNullable(solrDocument.get("reviewResource_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setOldUrl(Optional.ofNullable(solrDocument.get("oldUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContentDisplayOk(Optional.ofNullable(solrDocument.get("contentDisplayOk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMetadata(Optional.ofNullable(solrDocument.get("metadata_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setApprovalStatus(Optional.ofNullable(solrDocument.get("approvalStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setApprovalStatusDate(Optional.ofNullable(solrDocument.get("approvalStatusDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSpamUser(Optional.ofNullable(solrDocument.get("spamUser_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setUrl(Optional.ofNullable(solrDocument.get("url_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDisplaySeqNo(Optional.ofNullable(solrDocument.get("displaySeqNo_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setFileId(Optional.ofNullable(solrDocument.get("fileId_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setFileName(Optional.ofNullable(solrDocument.get("fileName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setUploadDate(Optional.ofNullable(solrDocument.get("uploadDate_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSequence(Optional.ofNullable(solrDocument.get("sequence_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setUniqueName(Optional.ofNullable(solrDocument.get("uniqueName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setExt(Optional.ofNullable(solrDocument.get("ext_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceFilesActive(Optional.ofNullable(solrDocument.get("resourceFilesActive_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTempactive(Optional.ofNullable(solrDocument.get("tempactive_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setS3path(Optional.ofNullable(solrDocument.get("s3path_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSdfStatus(Optional.ofNullable(solrDocument.get("sdfStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTranscoded(Optional.ofNullable(solrDocument.get("transcoded_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLodestar(Optional.ofNullable(solrDocument.get("lodestar_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setArchive(Optional.ofNullable(solrDocument.get("archive_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIdentifier(Optional.ofNullable(solrDocument.get("identifier_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setEducationLevelDisplayName(Optional.ofNullable(solrDocument.get("educationLevelDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectArea(Optional.ofNullable(solrDocument.get("subjectArea_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectAreaDisplayName(Optional.ofNullable(solrDocument.get("subjectAreaDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionTypeDisplayName(Optional.ofNullable(solrDocument.get("instructionTypeDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setName(Optional.ofNullable(solrDocument.get("name_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLanguage(Optional.ofNullable(doc.get("language_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastEditorId(Optional.ofNullable(doc.get("lastEditorId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastEditDate(Optional.ofNullable(doc.get("lastEditDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setCurrikiLicense(Optional.ofNullable(doc.get("currikiLicense_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setExternalUrl(Optional.ofNullable(doc.get("externalUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceChecked(Optional.ofNullable(doc.get("resourceChecked_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContent(Optional.ofNullable(doc.get("content_stored_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceCheckDate(Optional.ofNullable(doc.get("resourceCheckDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceCheckId(Optional.ofNullable(doc.get("resourceCheckId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStudentFacing(Optional.ofNullable(doc.get("studentFacing_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSource(Optional.ofNullable(doc.get("source_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewStatus(Optional.ofNullable(doc.get("reviewStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastReviewDate(Optional.ofNullable(doc.get("lastReviewDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewByID(Optional.ofNullable(doc.get("reviewByID_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewRating(Optional.ofNullable(doc.get("reviewRating_docvalues_double")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTechnicalCompleteness(Optional.ofNullable(doc.get("technicalCompleteness_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContentAccuracy(Optional.ofNullable(doc.get("contentAccuracy_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPedagogy(Optional.ofNullable(doc.get("pedagogy_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRatingComment(Optional.ofNullable(doc.get("ratingComment_stored_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStandardsAlignment(Optional.ofNullable(doc.get("standardsAlignment_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStandardsAlignmentComment(Optional.ofNullable(doc.get("standardsAlignmentComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectMatter(Optional.ofNullable(doc.get("subjectMatter_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectMatterComment(Optional.ofNullable(doc.get("subjectMatterComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSupportsTeaching(Optional.ofNullable(doc.get("supportsTeaching_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSupportsTeachingComment(Optional.ofNullable(doc.get("supportsTeachingComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAssessmentsQuality(Optional.ofNullable(doc.get("assessmentsQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAssessmentsQualityComment(Optional.ofNullable(doc.get("assessmentsQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInteractivityQuality(Optional.ofNullable(doc.get("interactivityQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInteractivityQualityComment(Optional.ofNullable(doc.get("interactivityQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionalQuality(Optional.ofNullable(doc.get("instructionalQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionalQualityComment(Optional.ofNullable(doc.get("instructionalQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDeeperLearning(Optional.ofNullable(doc.get("deeperLearning_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDeeperLearningComment(Optional.ofNullable(doc.get("deeperLearningComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPartner(Optional.ofNullable(doc.get("partner_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setCreateDate(Optional.ofNullable(doc.get("createDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setType(Optional.ofNullable(doc.get("type_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFeatured(Optional.ofNullable(doc.get("featured_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPage(Optional.ofNullable(doc.get("page_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setActive(Optional.ofNullable(doc.get("active_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPublic(Optional.ofNullable(doc.get("Public_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setXwd_id(Optional.ofNullable(doc.get("xwd_id_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMediaType(Optional.ofNullable(doc.get("mediaType_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAccess(Optional.ofNullable(doc.get("access_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMemberRating(Optional.ofNullable(doc.get("memberRating_docvalues_double")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAligned(Optional.ofNullable(doc.get("aligned_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPageUrl(Optional.ofNullable(doc.get("pageUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexed(Optional.ofNullable(doc.get("indexed_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastIndexDate(Optional.ofNullable(doc.get("lastIndexDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexRequired(Optional.ofNullable(doc.get("indexRequired_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexRequiredDate(Optional.ofNullable(doc.get("indexRequiredDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRescrape(Optional.ofNullable(doc.get("rescrape_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setGoButton(Optional.ofNullable(doc.get("goButton_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDownloadButton(Optional.ofNullable(doc.get("downloadButton_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTopOfSearch(Optional.ofNullable(doc.get("topOfSearch_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRemove(Optional.ofNullable(doc.get("remove_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSpam(Optional.ofNullable(doc.get("spam_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTopOfSearchInt(Optional.ofNullable(doc.get("topOfSearchInt_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPartnerInt(Optional.ofNullable(doc.get("partnerInt_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewResource(Optional.ofNullable(doc.get("reviewResource_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setOldUrl(Optional.ofNullable(doc.get("oldUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContentDisplayOk(Optional.ofNullable(doc.get("contentDisplayOk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMetadata(Optional.ofNullable(doc.get("metadata_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setApprovalStatus(Optional.ofNullable(doc.get("approvalStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setApprovalStatusDate(Optional.ofNullable(doc.get("approvalStatusDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSpamUser(Optional.ofNullable(doc.get("spamUser_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUrl(Optional.ofNullable(doc.get("url_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDisplaySeqNo(Optional.ofNullable(doc.get("displaySeqNo_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFileId(Optional.ofNullable(doc.get("fileId_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFileName(Optional.ofNullable(doc.get("fileName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUploadDate(Optional.ofNullable(doc.get("uploadDate_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSequence(Optional.ofNullable(doc.get("sequence_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUniqueName(Optional.ofNullable(doc.get("uniqueName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setExt(Optional.ofNullable(doc.get("ext_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceFilesActive(Optional.ofNullable(doc.get("resourceFilesActive_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTempactive(Optional.ofNullable(doc.get("tempactive_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setS3path(Optional.ofNullable(doc.get("s3path_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSdfStatus(Optional.ofNullable(doc.get("sdfStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTranscoded(Optional.ofNullable(doc.get("transcoded_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLodestar(Optional.ofNullable(doc.get("lodestar_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setArchive(Optional.ofNullable(doc.get("archive_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIdentifier(Optional.ofNullable(doc.get("identifier_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setEducationLevelDisplayName(Optional.ofNullable(doc.get("educationLevelDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectArea(Optional.ofNullable(doc.get("subjectArea_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectAreaDisplayName(Optional.ofNullable(doc.get("subjectAreaDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionTypeDisplayName(Optional.ofNullable(doc.get("instructionTypeDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setName(Optional.ofNullable(doc.get("name_docvalues_string")).map(v -> v.toString()).orElse(null));
 
-		super.storeBaseModel(solrDocument);
+		super.storeBaseModel(doc);
 	}
 
 	//////////////////
@@ -7192,7 +8145,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	//////////////////
 
 	public void apiRequestCurrikiResource() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof CurrikiResource) {
 			CurrikiResource original = (CurrikiResource)o;
@@ -7208,8 +8161,12 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("description");
 			if(!Objects.equals(title, original.getTitle()))
 				apiRequest.addVars("title");
+			if(!Objects.equals(keywordsStr, original.getKeywordsStr()))
+				apiRequest.addVars("keywordsStr");
 			if(!Objects.equals(keywords, original.getKeywords()))
 				apiRequest.addVars("keywords");
+			if(!Objects.equals(generatedKeywordsStr, original.getGeneratedKeywordsStr()))
+				apiRequest.addVars("generatedKeywordsStr");
 			if(!Objects.equals(generatedKeywords, original.getGeneratedKeywords()))
 				apiRequest.addVars("generatedKeywords");
 			if(!Objects.equals(language, original.getLanguage()))
@@ -7226,10 +8183,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("resourceChecked");
 			if(!Objects.equals(content, original.getContent()))
 				apiRequest.addVars("content");
+			if(!Objects.equals(resourceCheckRequestNote, original.getResourceCheckRequestNote()))
+				apiRequest.addVars("resourceCheckRequestNote");
 			if(!Objects.equals(resourceCheckDate, original.getResourceCheckDate()))
 				apiRequest.addVars("resourceCheckDate");
 			if(!Objects.equals(resourceCheckId, original.getResourceCheckId()))
 				apiRequest.addVars("resourceCheckId");
+			if(!Objects.equals(resourceCheckNote, original.getResourceCheckNote()))
+				apiRequest.addVars("resourceCheckNote");
 			if(!Objects.equals(studentFacing, original.getStudentFacing()))
 				apiRequest.addVars("studentFacing");
 			if(!Objects.equals(source, original.getSource()))
@@ -7401,7 +8362,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(contributionDate).map(v -> "contributionDate: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(description).map(v -> "description: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(title).map(v -> "title: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(keywordsStr).map(v -> "keywordsStr: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(keywords).map(v -> "keywords: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(generatedKeywordsStr).map(v -> "generatedKeywordsStr: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(generatedKeywords).map(v -> "generatedKeywords: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(language).map(v -> "language: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(lastEditorId).map(v -> "lastEditorId: " + v + "\n").orElse(""));
@@ -7410,8 +8373,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(externalUrl).map(v -> "externalUrl: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(resourceChecked).map(v -> "resourceChecked: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(content).map(v -> "content: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(resourceCheckRequestNote).map(v -> "resourceCheckRequestNote: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(resourceCheckDate).map(v -> "resourceCheckDate: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(resourceCheckId).map(v -> "resourceCheckId: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(resourceCheckNote).map(v -> "resourceCheckNote: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(studentFacing).map(v -> "studentFacing: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(source).map(v -> "source: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(reviewStatus).map(v -> "reviewStatus: \"" + v + "\"\n" ).orElse(""));
@@ -7590,4 +8555,1106 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	public static final String VAR_subjectAreaDisplayName = "subjectAreaDisplayName";
 	public static final String VAR_instructionTypeDisplayName = "instructionTypeDisplayName";
 	public static final String VAR_name = "name";
+
+	public static List<String> varsQForClass() {
+		return CurrikiResource.varsQCurrikiResource(new ArrayList<String>());
+	}
+	public static List<String> varsQCurrikiResource(List<String> vars) {
+		BaseModel.varsQBaseModel(vars);
+		return vars;
+	}
+
+	public static List<String> varsFqForClass() {
+		return CurrikiResource.varsFqCurrikiResource(new ArrayList<String>());
+	}
+	public static List<String> varsFqCurrikiResource(List<String> vars) {
+		vars.add(VAR_resourceId);
+		vars.add(VAR_licenseId);
+		vars.add(VAR_contributorId);
+		vars.add(VAR_contributionDate);
+		vars.add(VAR_description);
+		vars.add(VAR_title);
+		vars.add(VAR_keywords);
+		vars.add(VAR_generatedKeywords);
+		vars.add(VAR_language);
+		vars.add(VAR_lastEditorId);
+		vars.add(VAR_lastEditDate);
+		vars.add(VAR_currikiLicense);
+		vars.add(VAR_externalUrl);
+		vars.add(VAR_resourceChecked);
+		vars.add(VAR_resourceCheckDate);
+		vars.add(VAR_resourceCheckId);
+		vars.add(VAR_studentFacing);
+		vars.add(VAR_source);
+		vars.add(VAR_reviewStatus);
+		vars.add(VAR_lastReviewDate);
+		vars.add(VAR_reviewByID);
+		vars.add(VAR_reviewRating);
+		vars.add(VAR_technicalCompleteness);
+		vars.add(VAR_contentAccuracy);
+		vars.add(VAR_pedagogy);
+		vars.add(VAR_standardsAlignment);
+		vars.add(VAR_standardsAlignmentComment);
+		vars.add(VAR_subjectMatter);
+		vars.add(VAR_subjectMatterComment);
+		vars.add(VAR_supportsTeaching);
+		vars.add(VAR_supportsTeachingComment);
+		vars.add(VAR_assessmentsQuality);
+		vars.add(VAR_assessmentsQualityComment);
+		vars.add(VAR_interactivityQuality);
+		vars.add(VAR_interactivityQualityComment);
+		vars.add(VAR_instructionalQuality);
+		vars.add(VAR_instructionalQualityComment);
+		vars.add(VAR_deeperLearning);
+		vars.add(VAR_deeperLearningComment);
+		vars.add(VAR_partner);
+		vars.add(VAR_createDate);
+		vars.add(VAR_type);
+		vars.add(VAR_featured);
+		vars.add(VAR_page);
+		vars.add(VAR_active);
+		vars.add(VAR_Public);
+		vars.add(VAR_xwd_id);
+		vars.add(VAR_mediaType);
+		vars.add(VAR_access);
+		vars.add(VAR_memberRating);
+		vars.add(VAR_aligned);
+		vars.add(VAR_pageUrl);
+		vars.add(VAR_indexed);
+		vars.add(VAR_lastIndexDate);
+		vars.add(VAR_indexRequired);
+		vars.add(VAR_indexRequiredDate);
+		vars.add(VAR_rescrape);
+		vars.add(VAR_goButton);
+		vars.add(VAR_downloadButton);
+		vars.add(VAR_topOfSearch);
+		vars.add(VAR_remove);
+		vars.add(VAR_spam);
+		vars.add(VAR_topOfSearchInt);
+		vars.add(VAR_partnerInt);
+		vars.add(VAR_reviewResource);
+		vars.add(VAR_oldUrl);
+		vars.add(VAR_contentDisplayOk);
+		vars.add(VAR_metadata);
+		vars.add(VAR_approvalStatus);
+		vars.add(VAR_approvalStatusDate);
+		vars.add(VAR_spamUser);
+		vars.add(VAR_url);
+		vars.add(VAR_displaySeqNo);
+		vars.add(VAR_fileId);
+		vars.add(VAR_fileName);
+		vars.add(VAR_uploadDate);
+		vars.add(VAR_sequence);
+		vars.add(VAR_uniqueName);
+		vars.add(VAR_ext);
+		vars.add(VAR_resourceFilesActive);
+		vars.add(VAR_tempactive);
+		vars.add(VAR_s3path);
+		vars.add(VAR_sdfStatus);
+		vars.add(VAR_transcoded);
+		vars.add(VAR_lodestar);
+		vars.add(VAR_archive);
+		vars.add(VAR_identifier);
+		vars.add(VAR_educationLevelDisplayName);
+		vars.add(VAR_subjectArea);
+		vars.add(VAR_subjectAreaDisplayName);
+		vars.add(VAR_instructionTypeDisplayName);
+		vars.add(VAR_name);
+		BaseModel.varsFqBaseModel(vars);
+		return vars;
+	}
+
+	public static List<String> varsRangeForClass() {
+		return CurrikiResource.varsRangeCurrikiResource(new ArrayList<String>());
+	}
+	public static List<String> varsRangeCurrikiResource(List<String> vars) {
+		vars.add(VAR_contributorId);
+		vars.add(VAR_contributionDate);
+		vars.add(VAR_lastEditorId);
+		vars.add(VAR_lastEditDate);
+		vars.add(VAR_resourceCheckDate);
+		vars.add(VAR_resourceCheckId);
+		vars.add(VAR_lastReviewDate);
+		vars.add(VAR_reviewByID);
+		vars.add(VAR_reviewRating);
+		vars.add(VAR_technicalCompleteness);
+		vars.add(VAR_contentAccuracy);
+		vars.add(VAR_pedagogy);
+		vars.add(VAR_standardsAlignment);
+		vars.add(VAR_subjectMatter);
+		vars.add(VAR_supportsTeaching);
+		vars.add(VAR_assessmentsQuality);
+		vars.add(VAR_interactivityQuality);
+		vars.add(VAR_instructionalQuality);
+		vars.add(VAR_deeperLearning);
+		vars.add(VAR_createDate);
+		vars.add(VAR_xwd_id);
+		vars.add(VAR_memberRating);
+		vars.add(VAR_lastIndexDate);
+		vars.add(VAR_indexRequiredDate);
+		vars.add(VAR_topOfSearchInt);
+		vars.add(VAR_partnerInt);
+		vars.add(VAR_approvalStatusDate);
+		vars.add(VAR_displaySeqNo);
+		vars.add(VAR_fileId);
+		vars.add(VAR_sequence);
+		BaseModel.varsRangeBaseModel(vars);
+		return vars;
+	}
+
+	public static final String DISPLAY_NAME_resourceId = "resource ID";
+	public static final String DISPLAY_NAME_licenseId = "license ID";
+	public static final String DISPLAY_NAME_contributorId = "contributor ID";
+	public static final String DISPLAY_NAME_contributionDate = "contribution Date";
+	public static final String DISPLAY_NAME_description = "description";
+	public static final String DISPLAY_NAME_title = "title";
+	public static final String DISPLAY_NAME_keywordsStr = "Keywords String";
+	public static final String DISPLAY_NAME_keywords = "Keywords List";
+	public static final String DISPLAY_NAME_generatedKeywordsStr = "Generated Keywords String";
+	public static final String DISPLAY_NAME_generatedKeywords = "Generated Keywords List";
+	public static final String DISPLAY_NAME_language = "Language";
+	public static final String DISPLAY_NAME_lastEditorId = "Last Editor ID";
+	public static final String DISPLAY_NAME_lastEditDate = "Last Edit Date";
+	public static final String DISPLAY_NAME_currikiLicense = "Curriki License";
+	public static final String DISPLAY_NAME_externalUrl = "External URL";
+	public static final String DISPLAY_NAME_resourceChecked = "Resource Checked";
+	public static final String DISPLAY_NAME_content = "External URL";
+	public static final String DISPLAY_NAME_resourceCheckRequestNote = "Resource Check Request Note";
+	public static final String DISPLAY_NAME_resourceCheckDate = "Resource Check Date";
+	public static final String DISPLAY_NAME_resourceCheckId = "Resource Check ID";
+	public static final String DISPLAY_NAME_resourceCheckNote = "Resource Check Note";
+	public static final String DISPLAY_NAME_studentFacing = "Student Facing";
+	public static final String DISPLAY_NAME_source = "Source";
+	public static final String DISPLAY_NAME_reviewStatus = "Review Status";
+	public static final String DISPLAY_NAME_lastReviewDate = "Last Review Date";
+	public static final String DISPLAY_NAME_reviewByID = "Review By ID";
+	public static final String DISPLAY_NAME_reviewRating = "Review Rating";
+	public static final String DISPLAY_NAME_technicalCompleteness = "Technical Completeness";
+	public static final String DISPLAY_NAME_contentAccuracy = "Content Accuracy";
+	public static final String DISPLAY_NAME_pedagogy = "Pedagogy";
+	public static final String DISPLAY_NAME_ratingComment = "Rating Comment";
+	public static final String DISPLAY_NAME_standardsAlignment = "Standards Alignment";
+	public static final String DISPLAY_NAME_standardsAlignmentComment = "Standards Alignment Comment";
+	public static final String DISPLAY_NAME_subjectMatter = "Subject Matter";
+	public static final String DISPLAY_NAME_subjectMatterComment = "Subject Matter Comment";
+	public static final String DISPLAY_NAME_supportsTeaching = "Supports Teaching";
+	public static final String DISPLAY_NAME_supportsTeachingComment = "Supports Teaching Comment";
+	public static final String DISPLAY_NAME_assessmentsQuality = "Assessments Quality";
+	public static final String DISPLAY_NAME_assessmentsQualityComment = "Assessments Quality Comment";
+	public static final String DISPLAY_NAME_interactivityQuality = "Interactivity Quality";
+	public static final String DISPLAY_NAME_interactivityQualityComment = "Interactivity Quality Comment";
+	public static final String DISPLAY_NAME_instructionalQuality = "Instructional Quality";
+	public static final String DISPLAY_NAME_instructionalQualityComment = "Instructional Quality Comment";
+	public static final String DISPLAY_NAME_deeperLearning = "Deeper Learning";
+	public static final String DISPLAY_NAME_deeperLearningComment = "Deeper Learning Comment";
+	public static final String DISPLAY_NAME_partner = "Partner";
+	public static final String DISPLAY_NAME_createDate = "Create Date";
+	public static final String DISPLAY_NAME_type = "Type";
+	public static final String DISPLAY_NAME_featured = "Featured";
+	public static final String DISPLAY_NAME_page = "Page";
+	public static final String DISPLAY_NAME_active = "Active";
+	public static final String DISPLAY_NAME_Public = "Public";
+	public static final String DISPLAY_NAME_xwd_id = "xwd ID";
+	public static final String DISPLAY_NAME_mediaType = "Media Type";
+	public static final String DISPLAY_NAME_access = "Access";
+	public static final String DISPLAY_NAME_memberRating = "Member Rating";
+	public static final String DISPLAY_NAME_aligned = "Aligned";
+	public static final String DISPLAY_NAME_pageUrl = "Page URL";
+	public static final String DISPLAY_NAME_indexed = "Indexed";
+	public static final String DISPLAY_NAME_lastIndexDate = "Last Index Date";
+	public static final String DISPLAY_NAME_indexRequired = "Index Required";
+	public static final String DISPLAY_NAME_indexRequiredDate = "IndexRequiredDate";
+	public static final String DISPLAY_NAME_rescrape = "rescrape";
+	public static final String DISPLAY_NAME_goButton = "Go Button";
+	public static final String DISPLAY_NAME_downloadButton = "Download Button";
+	public static final String DISPLAY_NAME_topOfSearch = "Top of Search";
+	public static final String DISPLAY_NAME_remove = "Remove";
+	public static final String DISPLAY_NAME_spam = "Spam";
+	public static final String DISPLAY_NAME_topOfSearchInt = "Top of search int";
+	public static final String DISPLAY_NAME_partnerInt = "Partner Int";
+	public static final String DISPLAY_NAME_reviewResource = "Review Resource";
+	public static final String DISPLAY_NAME_oldUrl = "Old URL";
+	public static final String DISPLAY_NAME_contentDisplayOk = "Content Display OK";
+	public static final String DISPLAY_NAME_metadata = "Metadata";
+	public static final String DISPLAY_NAME_approvalStatus = "Approval Status";
+	public static final String DISPLAY_NAME_approvalStatusDate = "Approval Status Date";
+	public static final String DISPLAY_NAME_spamUser = "Spam User";
+	public static final String DISPLAY_NAME_url = "URL";
+	public static final String DISPLAY_NAME_displaySeqNo = "Display Sequence Number";
+	public static final String DISPLAY_NAME_fileId = "File ID";
+	public static final String DISPLAY_NAME_fileName = "Filename";
+	public static final String DISPLAY_NAME_uploadDate = "Upload Date";
+	public static final String DISPLAY_NAME_sequence = "Sequence";
+	public static final String DISPLAY_NAME_uniqueName = "Unique Name";
+	public static final String DISPLAY_NAME_ext = "Ext";
+	public static final String DISPLAY_NAME_resourceFilesActive = "Resource Files Active";
+	public static final String DISPLAY_NAME_tempactive = "Tempactive";
+	public static final String DISPLAY_NAME_s3path = "S3 Path";
+	public static final String DISPLAY_NAME_sdfStatus = "SDF Status";
+	public static final String DISPLAY_NAME_transcoded = "Transcoded";
+	public static final String DISPLAY_NAME_lodestar = "Lodestar";
+	public static final String DISPLAY_NAME_archive = "Archive";
+	public static final String DISPLAY_NAME_identifier = "Identifier";
+	public static final String DISPLAY_NAME_educationLevelDisplayName = "Education Level Display Name";
+	public static final String DISPLAY_NAME_subjectArea = "Subject Area";
+	public static final String DISPLAY_NAME_subjectAreaDisplayName = "Subject Area Display Name";
+	public static final String DISPLAY_NAME_instructionTypeDisplayName = "Instruction Type Display Name";
+	public static final String DISPLAY_NAME_name = "Name";
+
+	public static String displayNameForClass(String var) {
+		return CurrikiResource.displayNameCurrikiResource(var);
+	}
+	public static String displayNameCurrikiResource(String var) {
+		switch(var) {
+		case VAR_resourceId:
+			return DISPLAY_NAME_resourceId;
+		case VAR_licenseId:
+			return DISPLAY_NAME_licenseId;
+		case VAR_contributorId:
+			return DISPLAY_NAME_contributorId;
+		case VAR_contributionDate:
+			return DISPLAY_NAME_contributionDate;
+		case VAR_description:
+			return DISPLAY_NAME_description;
+		case VAR_title:
+			return DISPLAY_NAME_title;
+		case VAR_keywordsStr:
+			return DISPLAY_NAME_keywordsStr;
+		case VAR_keywords:
+			return DISPLAY_NAME_keywords;
+		case VAR_generatedKeywordsStr:
+			return DISPLAY_NAME_generatedKeywordsStr;
+		case VAR_generatedKeywords:
+			return DISPLAY_NAME_generatedKeywords;
+		case VAR_language:
+			return DISPLAY_NAME_language;
+		case VAR_lastEditorId:
+			return DISPLAY_NAME_lastEditorId;
+		case VAR_lastEditDate:
+			return DISPLAY_NAME_lastEditDate;
+		case VAR_currikiLicense:
+			return DISPLAY_NAME_currikiLicense;
+		case VAR_externalUrl:
+			return DISPLAY_NAME_externalUrl;
+		case VAR_resourceChecked:
+			return DISPLAY_NAME_resourceChecked;
+		case VAR_content:
+			return DISPLAY_NAME_content;
+		case VAR_resourceCheckRequestNote:
+			return DISPLAY_NAME_resourceCheckRequestNote;
+		case VAR_resourceCheckDate:
+			return DISPLAY_NAME_resourceCheckDate;
+		case VAR_resourceCheckId:
+			return DISPLAY_NAME_resourceCheckId;
+		case VAR_resourceCheckNote:
+			return DISPLAY_NAME_resourceCheckNote;
+		case VAR_studentFacing:
+			return DISPLAY_NAME_studentFacing;
+		case VAR_source:
+			return DISPLAY_NAME_source;
+		case VAR_reviewStatus:
+			return DISPLAY_NAME_reviewStatus;
+		case VAR_lastReviewDate:
+			return DISPLAY_NAME_lastReviewDate;
+		case VAR_reviewByID:
+			return DISPLAY_NAME_reviewByID;
+		case VAR_reviewRating:
+			return DISPLAY_NAME_reviewRating;
+		case VAR_technicalCompleteness:
+			return DISPLAY_NAME_technicalCompleteness;
+		case VAR_contentAccuracy:
+			return DISPLAY_NAME_contentAccuracy;
+		case VAR_pedagogy:
+			return DISPLAY_NAME_pedagogy;
+		case VAR_ratingComment:
+			return DISPLAY_NAME_ratingComment;
+		case VAR_standardsAlignment:
+			return DISPLAY_NAME_standardsAlignment;
+		case VAR_standardsAlignmentComment:
+			return DISPLAY_NAME_standardsAlignmentComment;
+		case VAR_subjectMatter:
+			return DISPLAY_NAME_subjectMatter;
+		case VAR_subjectMatterComment:
+			return DISPLAY_NAME_subjectMatterComment;
+		case VAR_supportsTeaching:
+			return DISPLAY_NAME_supportsTeaching;
+		case VAR_supportsTeachingComment:
+			return DISPLAY_NAME_supportsTeachingComment;
+		case VAR_assessmentsQuality:
+			return DISPLAY_NAME_assessmentsQuality;
+		case VAR_assessmentsQualityComment:
+			return DISPLAY_NAME_assessmentsQualityComment;
+		case VAR_interactivityQuality:
+			return DISPLAY_NAME_interactivityQuality;
+		case VAR_interactivityQualityComment:
+			return DISPLAY_NAME_interactivityQualityComment;
+		case VAR_instructionalQuality:
+			return DISPLAY_NAME_instructionalQuality;
+		case VAR_instructionalQualityComment:
+			return DISPLAY_NAME_instructionalQualityComment;
+		case VAR_deeperLearning:
+			return DISPLAY_NAME_deeperLearning;
+		case VAR_deeperLearningComment:
+			return DISPLAY_NAME_deeperLearningComment;
+		case VAR_partner:
+			return DISPLAY_NAME_partner;
+		case VAR_createDate:
+			return DISPLAY_NAME_createDate;
+		case VAR_type:
+			return DISPLAY_NAME_type;
+		case VAR_featured:
+			return DISPLAY_NAME_featured;
+		case VAR_page:
+			return DISPLAY_NAME_page;
+		case VAR_active:
+			return DISPLAY_NAME_active;
+		case VAR_Public:
+			return DISPLAY_NAME_Public;
+		case VAR_xwd_id:
+			return DISPLAY_NAME_xwd_id;
+		case VAR_mediaType:
+			return DISPLAY_NAME_mediaType;
+		case VAR_access:
+			return DISPLAY_NAME_access;
+		case VAR_memberRating:
+			return DISPLAY_NAME_memberRating;
+		case VAR_aligned:
+			return DISPLAY_NAME_aligned;
+		case VAR_pageUrl:
+			return DISPLAY_NAME_pageUrl;
+		case VAR_indexed:
+			return DISPLAY_NAME_indexed;
+		case VAR_lastIndexDate:
+			return DISPLAY_NAME_lastIndexDate;
+		case VAR_indexRequired:
+			return DISPLAY_NAME_indexRequired;
+		case VAR_indexRequiredDate:
+			return DISPLAY_NAME_indexRequiredDate;
+		case VAR_rescrape:
+			return DISPLAY_NAME_rescrape;
+		case VAR_goButton:
+			return DISPLAY_NAME_goButton;
+		case VAR_downloadButton:
+			return DISPLAY_NAME_downloadButton;
+		case VAR_topOfSearch:
+			return DISPLAY_NAME_topOfSearch;
+		case VAR_remove:
+			return DISPLAY_NAME_remove;
+		case VAR_spam:
+			return DISPLAY_NAME_spam;
+		case VAR_topOfSearchInt:
+			return DISPLAY_NAME_topOfSearchInt;
+		case VAR_partnerInt:
+			return DISPLAY_NAME_partnerInt;
+		case VAR_reviewResource:
+			return DISPLAY_NAME_reviewResource;
+		case VAR_oldUrl:
+			return DISPLAY_NAME_oldUrl;
+		case VAR_contentDisplayOk:
+			return DISPLAY_NAME_contentDisplayOk;
+		case VAR_metadata:
+			return DISPLAY_NAME_metadata;
+		case VAR_approvalStatus:
+			return DISPLAY_NAME_approvalStatus;
+		case VAR_approvalStatusDate:
+			return DISPLAY_NAME_approvalStatusDate;
+		case VAR_spamUser:
+			return DISPLAY_NAME_spamUser;
+		case VAR_url:
+			return DISPLAY_NAME_url;
+		case VAR_displaySeqNo:
+			return DISPLAY_NAME_displaySeqNo;
+		case VAR_fileId:
+			return DISPLAY_NAME_fileId;
+		case VAR_fileName:
+			return DISPLAY_NAME_fileName;
+		case VAR_uploadDate:
+			return DISPLAY_NAME_uploadDate;
+		case VAR_sequence:
+			return DISPLAY_NAME_sequence;
+		case VAR_uniqueName:
+			return DISPLAY_NAME_uniqueName;
+		case VAR_ext:
+			return DISPLAY_NAME_ext;
+		case VAR_resourceFilesActive:
+			return DISPLAY_NAME_resourceFilesActive;
+		case VAR_tempactive:
+			return DISPLAY_NAME_tempactive;
+		case VAR_s3path:
+			return DISPLAY_NAME_s3path;
+		case VAR_sdfStatus:
+			return DISPLAY_NAME_sdfStatus;
+		case VAR_transcoded:
+			return DISPLAY_NAME_transcoded;
+		case VAR_lodestar:
+			return DISPLAY_NAME_lodestar;
+		case VAR_archive:
+			return DISPLAY_NAME_archive;
+		case VAR_identifier:
+			return DISPLAY_NAME_identifier;
+		case VAR_educationLevelDisplayName:
+			return DISPLAY_NAME_educationLevelDisplayName;
+		case VAR_subjectArea:
+			return DISPLAY_NAME_subjectArea;
+		case VAR_subjectAreaDisplayName:
+			return DISPLAY_NAME_subjectAreaDisplayName;
+		case VAR_instructionTypeDisplayName:
+			return DISPLAY_NAME_instructionTypeDisplayName;
+		case VAR_name:
+			return DISPLAY_NAME_name;
+		default:
+			return BaseModel.displayNameBaseModel(var);
+		}
+	}
+
+	public static String descriptionCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.descriptionBaseModel(var);
+		}
+	}
+
+	public static String classSimpleNameCurrikiResource(String var) {
+		switch(var) {
+		case VAR_resourceId:
+			return "String";
+		case VAR_licenseId:
+			return "String";
+		case VAR_contributorId:
+			return "Long";
+		case VAR_contributionDate:
+			return "ZonedDateTime";
+		case VAR_description:
+			return "String";
+		case VAR_title:
+			return "String";
+		case VAR_keywordsStr:
+			return "String";
+		case VAR_keywords:
+			return "List";
+		case VAR_generatedKeywordsStr:
+			return "String";
+		case VAR_generatedKeywords:
+			return "List";
+		case VAR_language:
+			return "String";
+		case VAR_lastEditorId:
+			return "Long";
+		case VAR_lastEditDate:
+			return "ZonedDateTime";
+		case VAR_currikiLicense:
+			return "String";
+		case VAR_externalUrl:
+			return "String";
+		case VAR_resourceChecked:
+			return "String";
+		case VAR_content:
+			return "String";
+		case VAR_resourceCheckRequestNote:
+			return "String";
+		case VAR_resourceCheckDate:
+			return "ZonedDateTime";
+		case VAR_resourceCheckId:
+			return "Long";
+		case VAR_resourceCheckNote:
+			return "String";
+		case VAR_studentFacing:
+			return "String";
+		case VAR_source:
+			return "String";
+		case VAR_reviewStatus:
+			return "String";
+		case VAR_lastReviewDate:
+			return "ZonedDateTime";
+		case VAR_reviewByID:
+			return "Long";
+		case VAR_reviewRating:
+			return "BigDecimal";
+		case VAR_technicalCompleteness:
+			return "Integer";
+		case VAR_contentAccuracy:
+			return "Integer";
+		case VAR_pedagogy:
+			return "Integer";
+		case VAR_ratingComment:
+			return "String";
+		case VAR_standardsAlignment:
+			return "Integer";
+		case VAR_standardsAlignmentComment:
+			return "String";
+		case VAR_subjectMatter:
+			return "Integer";
+		case VAR_subjectMatterComment:
+			return "String";
+		case VAR_supportsTeaching:
+			return "Integer";
+		case VAR_supportsTeachingComment:
+			return "String";
+		case VAR_assessmentsQuality:
+			return "Integer";
+		case VAR_assessmentsQualityComment:
+			return "String";
+		case VAR_interactivityQuality:
+			return "Integer";
+		case VAR_interactivityQualityComment:
+			return "String";
+		case VAR_instructionalQuality:
+			return "Integer";
+		case VAR_instructionalQualityComment:
+			return "String";
+		case VAR_deeperLearning:
+			return "Integer";
+		case VAR_deeperLearningComment:
+			return "String";
+		case VAR_partner:
+			return "String";
+		case VAR_createDate:
+			return "ZonedDateTime";
+		case VAR_type:
+			return "String";
+		case VAR_featured:
+			return "String";
+		case VAR_page:
+			return "String";
+		case VAR_active:
+			return "String";
+		case VAR_Public:
+			return "String";
+		case VAR_xwd_id:
+			return "Integer";
+		case VAR_mediaType:
+			return "String";
+		case VAR_access:
+			return "String";
+		case VAR_memberRating:
+			return "BigDecimal";
+		case VAR_aligned:
+			return "String";
+		case VAR_pageUrl:
+			return "String";
+		case VAR_indexed:
+			return "String";
+		case VAR_lastIndexDate:
+			return "ZonedDateTime";
+		case VAR_indexRequired:
+			return "String";
+		case VAR_indexRequiredDate:
+			return "ZonedDateTime";
+		case VAR_rescrape:
+			return "String";
+		case VAR_goButton:
+			return "String";
+		case VAR_downloadButton:
+			return "String";
+		case VAR_topOfSearch:
+			return "String";
+		case VAR_remove:
+			return "String";
+		case VAR_spam:
+			return "String";
+		case VAR_topOfSearchInt:
+			return "Integer";
+		case VAR_partnerInt:
+			return "Integer";
+		case VAR_reviewResource:
+			return "String";
+		case VAR_oldUrl:
+			return "String";
+		case VAR_contentDisplayOk:
+			return "String";
+		case VAR_metadata:
+			return "String";
+		case VAR_approvalStatus:
+			return "String";
+		case VAR_approvalStatusDate:
+			return "ZonedDateTime";
+		case VAR_spamUser:
+			return "String";
+		case VAR_url:
+			return "String";
+		case VAR_displaySeqNo:
+			return "Integer";
+		case VAR_fileId:
+			return "Integer";
+		case VAR_fileName:
+			return "String";
+		case VAR_uploadDate:
+			return "String";
+		case VAR_sequence:
+			return "Integer";
+		case VAR_uniqueName:
+			return "String";
+		case VAR_ext:
+			return "String";
+		case VAR_resourceFilesActive:
+			return "String";
+		case VAR_tempactive:
+			return "String";
+		case VAR_s3path:
+			return "String";
+		case VAR_sdfStatus:
+			return "String";
+		case VAR_transcoded:
+			return "String";
+		case VAR_lodestar:
+			return "String";
+		case VAR_archive:
+			return "String";
+		case VAR_identifier:
+			return "String";
+		case VAR_educationLevelDisplayName:
+			return "String";
+		case VAR_subjectArea:
+			return "String";
+		case VAR_subjectAreaDisplayName:
+			return "String";
+		case VAR_instructionTypeDisplayName:
+			return "String";
+		case VAR_name:
+			return "String";
+			default:
+				return BaseModel.classSimpleNameBaseModel(var);
+		}
+	}
+
+	public static Integer htmlColumnCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.htmlColumnBaseModel(var);
+		}
+	}
+
+	public static Integer htmlRowCurrikiResource(String var) {
+		switch(var) {
+		case VAR_resourceId:
+			return 3;
+		case VAR_licenseId:
+			return 3;
+		case VAR_contributorId:
+			return 3;
+		case VAR_contributionDate:
+			return 4;
+		case VAR_description:
+			return 4;
+		case VAR_title:
+			return 4;
+		case VAR_keywordsStr:
+			return 5;
+		case VAR_keywords:
+			return 5;
+		case VAR_generatedKeywordsStr:
+			return 5;
+		case VAR_generatedKeywords:
+			return 6;
+		case VAR_language:
+			return 6;
+		case VAR_lastEditorId:
+			return 6;
+		case VAR_lastEditDate:
+			return 7;
+		case VAR_currikiLicense:
+			return 7;
+		case VAR_externalUrl:
+			return 7;
+		case VAR_resourceChecked:
+			return 8;
+		case VAR_content:
+			return 8;
+		case VAR_resourceCheckRequestNote:
+			return 8;
+		case VAR_resourceCheckDate:
+			return 9;
+		case VAR_resourceCheckId:
+			return 9;
+		case VAR_resourceCheckNote:
+			return 9;
+		case VAR_studentFacing:
+			return 10;
+		case VAR_source:
+			return 10;
+		case VAR_reviewStatus:
+			return 10;
+		case VAR_lastReviewDate:
+			return 11;
+		case VAR_reviewByID:
+			return 11;
+		case VAR_reviewRating:
+			return 11;
+		case VAR_technicalCompleteness:
+			return 12;
+		case VAR_contentAccuracy:
+			return 12;
+		case VAR_pedagogy:
+			return 12;
+		case VAR_ratingComment:
+			return 13;
+		case VAR_standardsAlignment:
+			return 13;
+		case VAR_standardsAlignmentComment:
+			return 13;
+		case VAR_subjectMatter:
+			return 14;
+		case VAR_subjectMatterComment:
+			return 14;
+		case VAR_supportsTeaching:
+			return 14;
+		case VAR_supportsTeachingComment:
+			return 15;
+		case VAR_assessmentsQuality:
+			return 15;
+		case VAR_assessmentsQualityComment:
+			return 15;
+		case VAR_interactivityQuality:
+			return 16;
+		case VAR_interactivityQualityComment:
+			return 16;
+		case VAR_instructionalQuality:
+			return 16;
+		case VAR_instructionalQualityComment:
+			return 17;
+		case VAR_deeperLearning:
+			return 17;
+		case VAR_deeperLearningComment:
+			return 17;
+		case VAR_partner:
+			return 18;
+		case VAR_createDate:
+			return 18;
+		case VAR_type:
+			return 18;
+		case VAR_featured:
+			return 19;
+		case VAR_page:
+			return 19;
+		case VAR_active:
+			return 19;
+		case VAR_Public:
+			return 20;
+		case VAR_xwd_id:
+			return 20;
+		case VAR_mediaType:
+			return 20;
+		case VAR_access:
+			return 21;
+		case VAR_memberRating:
+			return 21;
+		case VAR_aligned:
+			return 21;
+		case VAR_pageUrl:
+			return 22;
+		case VAR_indexed:
+			return 22;
+		case VAR_lastIndexDate:
+			return 22;
+		case VAR_indexRequired:
+			return 23;
+		case VAR_indexRequiredDate:
+			return 23;
+		case VAR_rescrape:
+			return 24;
+		case VAR_goButton:
+			return 25;
+		case VAR_downloadButton:
+			return 25;
+		case VAR_topOfSearch:
+			return 25;
+		case VAR_remove:
+			return 26;
+		case VAR_spam:
+			return 26;
+		case VAR_topOfSearchInt:
+			return 26;
+		case VAR_partnerInt:
+			return 27;
+		case VAR_reviewResource:
+			return 27;
+		case VAR_oldUrl:
+			return 27;
+		case VAR_contentDisplayOk:
+			return 28;
+		case VAR_metadata:
+			return 28;
+		case VAR_approvalStatus:
+			return 28;
+		case VAR_approvalStatusDate:
+			return 29;
+		case VAR_spamUser:
+			return 29;
+		case VAR_url:
+			return 30;
+		case VAR_displaySeqNo:
+			return 30;
+		case VAR_fileId:
+			return 30;
+		case VAR_fileName:
+			return 31;
+		case VAR_uploadDate:
+			return 31;
+		case VAR_sequence:
+			return 31;
+		case VAR_uniqueName:
+			return 32;
+		case VAR_ext:
+			return 32;
+		case VAR_resourceFilesActive:
+			return 32;
+		case VAR_tempactive:
+			return 33;
+		case VAR_s3path:
+			return 33;
+		case VAR_sdfStatus:
+			return 33;
+		case VAR_transcoded:
+			return 34;
+		case VAR_lodestar:
+			return 34;
+		case VAR_archive:
+			return 34;
+		case VAR_identifier:
+			return 35;
+		case VAR_educationLevelDisplayName:
+			return 35;
+		case VAR_subjectArea:
+			return 35;
+		case VAR_subjectAreaDisplayName:
+			return 36;
+		case VAR_instructionTypeDisplayName:
+			return 36;
+		case VAR_name:
+			return 36;
+			default:
+				return BaseModel.htmlRowBaseModel(var);
+		}
+	}
+
+	public static Integer htmlCellCurrikiResource(String var) {
+		switch(var) {
+		case VAR_resourceId:
+			return 1;
+		case VAR_licenseId:
+			return 2;
+		case VAR_contributorId:
+			return 3;
+		case VAR_contributionDate:
+			return 1;
+		case VAR_description:
+			return 2;
+		case VAR_title:
+			return 3;
+		case VAR_keywordsStr:
+			return 1;
+		case VAR_keywords:
+			return 2;
+		case VAR_generatedKeywordsStr:
+			return 3;
+		case VAR_generatedKeywords:
+			return 1;
+		case VAR_language:
+			return 2;
+		case VAR_lastEditorId:
+			return 3;
+		case VAR_lastEditDate:
+			return 1;
+		case VAR_currikiLicense:
+			return 2;
+		case VAR_externalUrl:
+			return 3;
+		case VAR_resourceChecked:
+			return 1;
+		case VAR_content:
+			return 2;
+		case VAR_resourceCheckRequestNote:
+			return 3;
+		case VAR_resourceCheckDate:
+			return 1;
+		case VAR_resourceCheckId:
+			return 2;
+		case VAR_resourceCheckNote:
+			return 3;
+		case VAR_studentFacing:
+			return 1;
+		case VAR_source:
+			return 2;
+		case VAR_reviewStatus:
+			return 3;
+		case VAR_lastReviewDate:
+			return 1;
+		case VAR_reviewByID:
+			return 2;
+		case VAR_reviewRating:
+			return 3;
+		case VAR_technicalCompleteness:
+			return 1;
+		case VAR_contentAccuracy:
+			return 2;
+		case VAR_pedagogy:
+			return 3;
+		case VAR_ratingComment:
+			return 1;
+		case VAR_standardsAlignment:
+			return 2;
+		case VAR_standardsAlignmentComment:
+			return 3;
+		case VAR_subjectMatter:
+			return 1;
+		case VAR_subjectMatterComment:
+			return 2;
+		case VAR_supportsTeaching:
+			return 3;
+		case VAR_supportsTeachingComment:
+			return 1;
+		case VAR_assessmentsQuality:
+			return 2;
+		case VAR_assessmentsQualityComment:
+			return 3;
+		case VAR_interactivityQuality:
+			return 1;
+		case VAR_interactivityQualityComment:
+			return 2;
+		case VAR_instructionalQuality:
+			return 3;
+		case VAR_instructionalQualityComment:
+			return 1;
+		case VAR_deeperLearning:
+			return 2;
+		case VAR_deeperLearningComment:
+			return 3;
+		case VAR_partner:
+			return 1;
+		case VAR_createDate:
+			return 2;
+		case VAR_type:
+			return 3;
+		case VAR_featured:
+			return 1;
+		case VAR_page:
+			return 2;
+		case VAR_active:
+			return 3;
+		case VAR_Public:
+			return 1;
+		case VAR_xwd_id:
+			return 2;
+		case VAR_mediaType:
+			return 3;
+		case VAR_access:
+			return 1;
+		case VAR_memberRating:
+			return 2;
+		case VAR_aligned:
+			return 3;
+		case VAR_pageUrl:
+			return 1;
+		case VAR_indexed:
+			return 2;
+		case VAR_lastIndexDate:
+			return 3;
+		case VAR_indexRequired:
+			return 1;
+		case VAR_indexRequiredDate:
+			return 2;
+		case VAR_rescrape:
+			return 3;
+		case VAR_goButton:
+			return 1;
+		case VAR_downloadButton:
+			return 2;
+		case VAR_topOfSearch:
+			return 3;
+		case VAR_remove:
+			return 1;
+		case VAR_spam:
+			return 2;
+		case VAR_topOfSearchInt:
+			return 3;
+		case VAR_partnerInt:
+			return 1;
+		case VAR_reviewResource:
+			return 2;
+		case VAR_oldUrl:
+			return 3;
+		case VAR_contentDisplayOk:
+			return 1;
+		case VAR_metadata:
+			return 2;
+		case VAR_approvalStatus:
+			return 3;
+		case VAR_approvalStatusDate:
+			return 1;
+		case VAR_spamUser:
+			return 2;
+		case VAR_url:
+			return 1;
+		case VAR_displaySeqNo:
+			return 2;
+		case VAR_fileId:
+			return 3;
+		case VAR_fileName:
+			return 1;
+		case VAR_uploadDate:
+			return 2;
+		case VAR_sequence:
+			return 3;
+		case VAR_uniqueName:
+			return 1;
+		case VAR_ext:
+			return 2;
+		case VAR_resourceFilesActive:
+			return 3;
+		case VAR_tempactive:
+			return 1;
+		case VAR_s3path:
+			return 2;
+		case VAR_sdfStatus:
+			return 3;
+		case VAR_transcoded:
+			return 1;
+		case VAR_lodestar:
+			return 2;
+		case VAR_archive:
+			return 3;
+		case VAR_identifier:
+			return 1;
+		case VAR_educationLevelDisplayName:
+			return 2;
+		case VAR_subjectArea:
+			return 3;
+		case VAR_subjectAreaDisplayName:
+			return 1;
+		case VAR_instructionTypeDisplayName:
+			return 2;
+		case VAR_name:
+			return 3;
+			default:
+				return BaseModel.htmlCellBaseModel(var);
+		}
+	}
+
+	public static Integer lengthMinCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.lengthMinBaseModel(var);
+		}
+	}
+
+	public static Integer lengthMaxCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.lengthMaxBaseModel(var);
+		}
+	}
+
+	public static Integer maxCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.maxBaseModel(var);
+		}
+	}
+
+	public static Integer minCurrikiResource(String var) {
+		switch(var) {
+			default:
+				return BaseModel.minBaseModel(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
@@ -4642,6 +4642,55 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return CurrikiResource.staticSolrStrExt(siteRequest_, CurrikiResource.staticSolrExt(siteRequest_, CurrikiResource.staticSetExt(siteRequest_, o)));
 	}
 
+	/////////////////////////
+	// resourceFilesActive //
+	/////////////////////////
+
+	/**	 The entity resourceFilesActive
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String resourceFilesActive;
+
+	/**	<br/> The entity resourceFilesActive
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceFilesActive">Find the entity resourceFilesActive in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _resourceFilesActive(Wrap<String> w);
+
+	public String getResourceFilesActive() {
+		return resourceFilesActive;
+	}
+	public void setResourceFilesActive(String o) {
+		this.resourceFilesActive = CurrikiResource.staticSetResourceFilesActive(siteRequest_, o);
+	}
+	public static String staticSetResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource resourceFilesActiveInit() {
+		Wrap<String> resourceFilesActiveWrap = new Wrap<String>().var("resourceFilesActive");
+		if(resourceFilesActive == null) {
+			_resourceFilesActive(resourceFilesActiveWrap);
+			setResourceFilesActive(resourceFilesActiveWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqResourceFilesActive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceFilesActive(siteRequest_, CurrikiResource.staticSolrResourceFilesActive(siteRequest_, CurrikiResource.staticSetResourceFilesActive(siteRequest_, o)));
+	}
+
 	////////////////
 	// tempactive //
 	////////////////
@@ -4985,53 +5034,53 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return CurrikiResource.staticSolrStrIdentifier(siteRequest_, CurrikiResource.staticSolrIdentifier(siteRequest_, CurrikiResource.staticSetIdentifier(siteRequest_, o)));
 	}
 
-	/////////////////
-	// displayName //
-	/////////////////
+	///////////////////////////////
+	// educationLevelDisplayName //
+	///////////////////////////////
 
-	/**	 The entity displayName
+	/**	 The entity educationLevelDisplayName
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
 	@JsonInclude(Include.NON_NULL)
-	protected String displayName;
+	protected String educationLevelDisplayName;
 
-	/**	<br/> The entity displayName
+	/**	<br/> The entity educationLevelDisplayName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:displayName">Find the entity displayName in Solr</a>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:educationLevelDisplayName">Find the entity educationLevelDisplayName in Solr</a>
 	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
-	protected abstract void _displayName(Wrap<String> w);
+	protected abstract void _educationLevelDisplayName(Wrap<String> w);
 
-	public String getDisplayName() {
-		return displayName;
+	public String getEducationLevelDisplayName() {
+		return educationLevelDisplayName;
 	}
-	public void setDisplayName(String o) {
-		this.displayName = CurrikiResource.staticSetDisplayName(siteRequest_, o);
+	public void setEducationLevelDisplayName(String o) {
+		this.educationLevelDisplayName = CurrikiResource.staticSetEducationLevelDisplayName(siteRequest_, o);
 	}
-	public static String staticSetDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSetEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
-	protected CurrikiResource displayNameInit() {
-		Wrap<String> displayNameWrap = new Wrap<String>().var("displayName");
-		if(displayName == null) {
-			_displayName(displayNameWrap);
-			setDisplayName(displayNameWrap.o);
+	protected CurrikiResource educationLevelDisplayNameInit() {
+		Wrap<String> educationLevelDisplayNameWrap = new Wrap<String>().var("educationLevelDisplayName");
+		if(educationLevelDisplayName == null) {
+			_educationLevelDisplayName(educationLevelDisplayNameWrap);
+			setEducationLevelDisplayName(educationLevelDisplayNameWrap.o);
 		}
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSolrDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrDisplayName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqDisplayName(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSolrStrDisplayName(siteRequest_, CurrikiResource.staticSolrDisplayName(siteRequest_, CurrikiResource.staticSetDisplayName(siteRequest_, o)));
+	public static String staticSolrFqEducationLevelDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSolrEducationLevelDisplayName(siteRequest_, CurrikiResource.staticSetEducationLevelDisplayName(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -5081,6 +5130,120 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 
 	public static String staticSolrFqSubjectArea(SiteRequestEnUS siteRequest_, String o) {
 		return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, CurrikiResource.staticSolrSubjectArea(siteRequest_, CurrikiResource.staticSetSubjectArea(siteRequest_, o)));
+	}
+
+	////////////////////////////
+	// subjectAreaDisplayName //
+	////////////////////////////
+
+	/**	 The entity subjectAreaDisplayName
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer subjectAreaDisplayName;
+
+	/**	<br/> The entity subjectAreaDisplayName
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectAreaDisplayName">Find the entity subjectAreaDisplayName in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _subjectAreaDisplayName(Wrap<Integer> w);
+
+	public Integer getSubjectAreaDisplayName() {
+		return subjectAreaDisplayName;
+	}
+
+	public void setSubjectAreaDisplayName(Integer subjectAreaDisplayName) {
+		this.subjectAreaDisplayName = subjectAreaDisplayName;
+	}
+	@JsonIgnore
+	public void setSubjectAreaDisplayName(String o) {
+		this.subjectAreaDisplayName = CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o);
+	}
+	public static Integer staticSetSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResource subjectAreaDisplayNameInit() {
+		Wrap<Integer> subjectAreaDisplayNameWrap = new Wrap<Integer>().var("subjectAreaDisplayName");
+		if(subjectAreaDisplayName == null) {
+			_subjectAreaDisplayName(subjectAreaDisplayNameWrap);
+			setSubjectAreaDisplayName(subjectAreaDisplayNameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static Integer staticSolrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSolrStrSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqSubjectAreaDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o)));
+	}
+
+	////////////////////////////////
+	// instructionTypeDisplayName //
+	////////////////////////////////
+
+	/**	 The entity instructionTypeDisplayName
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer instructionTypeDisplayName;
+
+	/**	<br/> The entity instructionTypeDisplayName
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionTypeDisplayName">Find the entity instructionTypeDisplayName in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _instructionTypeDisplayName(Wrap<Integer> w);
+
+	public Integer getInstructionTypeDisplayName() {
+		return instructionTypeDisplayName;
+	}
+
+	public void setInstructionTypeDisplayName(Integer instructionTypeDisplayName) {
+		this.instructionTypeDisplayName = instructionTypeDisplayName;
+	}
+	@JsonIgnore
+	public void setInstructionTypeDisplayName(String o) {
+		this.instructionTypeDisplayName = CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o);
+	}
+	public static Integer staticSetInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResource instructionTypeDisplayNameInit() {
+		Wrap<Integer> instructionTypeDisplayNameWrap = new Wrap<Integer>().var("instructionTypeDisplayName");
+		if(instructionTypeDisplayName == null) {
+			_instructionTypeDisplayName(instructionTypeDisplayNameWrap);
+			setInstructionTypeDisplayName(instructionTypeDisplayNameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static Integer staticSolrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSolrStrInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqInstructionTypeDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o)));
 	}
 
 	//////////
@@ -5246,6 +5409,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				sequenceInit();
 				uniqueNameInit();
 				extInit();
+				resourceFilesActiveInit();
 				tempactiveInit();
 				s3pathInit();
 				sdfStatusInit();
@@ -5253,8 +5417,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				lodestarInit();
 				archiveInit();
 				identifierInit();
-				displayNameInit();
+				educationLevelDisplayNameInit();
 				subjectAreaInit();
+				subjectAreaDisplayNameInit();
+				instructionTypeDisplayNameInit();
 				nameInit();
 				promise2.complete();
 			} catch(Exception ex) {
@@ -5479,6 +5645,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return oCurrikiResource.uniqueName;
 			case "ext":
 				return oCurrikiResource.ext;
+			case "resourceFilesActive":
+				return oCurrikiResource.resourceFilesActive;
 			case "tempactive":
 				return oCurrikiResource.tempactive;
 			case "s3path":
@@ -5493,10 +5661,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return oCurrikiResource.archive;
 			case "identifier":
 				return oCurrikiResource.identifier;
-			case "displayName":
-				return oCurrikiResource.displayName;
+			case "educationLevelDisplayName":
+				return oCurrikiResource.educationLevelDisplayName;
 			case "subjectArea":
 				return oCurrikiResource.subjectArea;
+			case "subjectAreaDisplayName":
+				return oCurrikiResource.subjectAreaDisplayName;
+			case "instructionTypeDisplayName":
+				return oCurrikiResource.instructionTypeDisplayName;
 			case "name":
 				return oCurrikiResource.name;
 			default:
@@ -5708,6 +5880,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSetUniqueName(siteRequest_, o);
 		case "ext":
 			return CurrikiResource.staticSetExt(siteRequest_, o);
+		case "resourceFilesActive":
+			return CurrikiResource.staticSetResourceFilesActive(siteRequest_, o);
 		case "tempactive":
 			return CurrikiResource.staticSetTempactive(siteRequest_, o);
 		case "s3path":
@@ -5722,10 +5896,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSetArchive(siteRequest_, o);
 		case "identifier":
 			return CurrikiResource.staticSetIdentifier(siteRequest_, o);
-		case "displayName":
-			return CurrikiResource.staticSetDisplayName(siteRequest_, o);
+		case "educationLevelDisplayName":
+			return CurrikiResource.staticSetEducationLevelDisplayName(siteRequest_, o);
 		case "subjectArea":
 			return CurrikiResource.staticSetSubjectArea(siteRequest_, o);
+		case "subjectAreaDisplayName":
+			return CurrikiResource.staticSetSubjectAreaDisplayName(siteRequest_, o);
+		case "instructionTypeDisplayName":
+			return CurrikiResource.staticSetInstructionTypeDisplayName(siteRequest_, o);
 		case "name":
 			return CurrikiResource.staticSetName(siteRequest_, o);
 			default:
@@ -5912,6 +6090,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrUniqueName(siteRequest_, (String)o);
 		case "ext":
 			return CurrikiResource.staticSolrExt(siteRequest_, (String)o);
+		case "resourceFilesActive":
+			return CurrikiResource.staticSolrResourceFilesActive(siteRequest_, (String)o);
 		case "tempactive":
 			return CurrikiResource.staticSolrTempactive(siteRequest_, (String)o);
 		case "s3path":
@@ -5926,10 +6106,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrArchive(siteRequest_, (String)o);
 		case "identifier":
 			return CurrikiResource.staticSolrIdentifier(siteRequest_, (String)o);
-		case "displayName":
-			return CurrikiResource.staticSolrDisplayName(siteRequest_, (String)o);
+		case "educationLevelDisplayName":
+			return CurrikiResource.staticSolrEducationLevelDisplayName(siteRequest_, (String)o);
 		case "subjectArea":
 			return CurrikiResource.staticSolrSubjectArea(siteRequest_, (String)o);
+		case "subjectAreaDisplayName":
+			return CurrikiResource.staticSolrSubjectAreaDisplayName(siteRequest_, (Integer)o);
+		case "instructionTypeDisplayName":
+			return CurrikiResource.staticSolrInstructionTypeDisplayName(siteRequest_, (Integer)o);
 		case "name":
 			return CurrikiResource.staticSolrName(siteRequest_, (String)o);
 			default:
@@ -6116,6 +6300,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrStrUniqueName(siteRequest_, (String)o);
 		case "ext":
 			return CurrikiResource.staticSolrStrExt(siteRequest_, (String)o);
+		case "resourceFilesActive":
+			return CurrikiResource.staticSolrStrResourceFilesActive(siteRequest_, (String)o);
 		case "tempactive":
 			return CurrikiResource.staticSolrStrTempactive(siteRequest_, (String)o);
 		case "s3path":
@@ -6130,10 +6316,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrStrArchive(siteRequest_, (String)o);
 		case "identifier":
 			return CurrikiResource.staticSolrStrIdentifier(siteRequest_, (String)o);
-		case "displayName":
-			return CurrikiResource.staticSolrStrDisplayName(siteRequest_, (String)o);
+		case "educationLevelDisplayName":
+			return CurrikiResource.staticSolrStrEducationLevelDisplayName(siteRequest_, (String)o);
 		case "subjectArea":
 			return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, (String)o);
+		case "subjectAreaDisplayName":
+			return CurrikiResource.staticSolrStrSubjectAreaDisplayName(siteRequest_, (Integer)o);
+		case "instructionTypeDisplayName":
+			return CurrikiResource.staticSolrStrInstructionTypeDisplayName(siteRequest_, (Integer)o);
 		case "name":
 			return CurrikiResource.staticSolrStrName(siteRequest_, (String)o);
 			default:
@@ -6320,6 +6510,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrFqUniqueName(siteRequest_, o);
 		case "ext":
 			return CurrikiResource.staticSolrFqExt(siteRequest_, o);
+		case "resourceFilesActive":
+			return CurrikiResource.staticSolrFqResourceFilesActive(siteRequest_, o);
 		case "tempactive":
 			return CurrikiResource.staticSolrFqTempactive(siteRequest_, o);
 		case "s3path":
@@ -6334,10 +6526,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSolrFqArchive(siteRequest_, o);
 		case "identifier":
 			return CurrikiResource.staticSolrFqIdentifier(siteRequest_, o);
-		case "displayName":
-			return CurrikiResource.staticSolrFqDisplayName(siteRequest_, o);
+		case "educationLevelDisplayName":
+			return CurrikiResource.staticSolrFqEducationLevelDisplayName(siteRequest_, o);
 		case "subjectArea":
 			return CurrikiResource.staticSolrFqSubjectArea(siteRequest_, o);
+		case "subjectAreaDisplayName":
+			return CurrikiResource.staticSolrFqSubjectAreaDisplayName(siteRequest_, o);
+		case "instructionTypeDisplayName":
+			return CurrikiResource.staticSolrFqInstructionTypeDisplayName(siteRequest_, o);
 		case "name":
 			return CurrikiResource.staticSolrFqName(siteRequest_, o);
 			default:
@@ -6647,6 +6843,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		if(ext != null) {
 			document.addField("ext_docvalues_string", ext);
 		}
+		if(resourceFilesActive != null) {
+			document.addField("resourceFilesActive_docvalues_string", resourceFilesActive);
+		}
 		if(tempactive != null) {
 			document.addField("tempactive_docvalues_string", tempactive);
 		}
@@ -6668,11 +6867,17 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		if(identifier != null) {
 			document.addField("identifier_docvalues_string", identifier);
 		}
-		if(displayName != null) {
-			document.addField("displayName_docvalues_string", displayName);
+		if(educationLevelDisplayName != null) {
+			document.addField("educationLevelDisplayName_docvalues_string", educationLevelDisplayName);
 		}
 		if(subjectArea != null) {
 			document.addField("subjectArea_docvalues_string", subjectArea);
+		}
+		if(subjectAreaDisplayName != null) {
+			document.addField("subjectAreaDisplayName_docvalues_int", subjectAreaDisplayName);
+		}
+		if(instructionTypeDisplayName != null) {
+			document.addField("instructionTypeDisplayName_docvalues_int", instructionTypeDisplayName);
 		}
 		if(name != null) {
 			document.addField("name_docvalues_string", name);
@@ -6841,6 +7046,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return "uniqueName_docvalues_string";
 			case "ext":
 				return "ext_docvalues_string";
+			case "resourceFilesActive":
+				return "resourceFilesActive_docvalues_string";
 			case "tempactive":
 				return "tempactive_docvalues_string";
 			case "s3path":
@@ -6855,10 +7062,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return "archive_docvalues_string";
 			case "identifier":
 				return "identifier_docvalues_string";
-			case "displayName":
-				return "displayName_docvalues_string";
+			case "educationLevelDisplayName":
+				return "educationLevelDisplayName_docvalues_string";
 			case "subjectArea":
 				return "subjectArea_docvalues_string";
+			case "subjectAreaDisplayName":
+				return "subjectAreaDisplayName_docvalues_int";
+			case "instructionTypeDisplayName":
+				return "instructionTypeDisplayName_docvalues_int";
 			case "name":
 				return "name_docvalues_string";
 			default:
@@ -6975,6 +7186,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		oCurrikiResource.setSequence(Optional.ofNullable(solrDocument.get("sequence_docvalues_int")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setUniqueName(Optional.ofNullable(solrDocument.get("uniqueName_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setExt(Optional.ofNullable(solrDocument.get("ext_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceFilesActive(Optional.ofNullable(solrDocument.get("resourceFilesActive_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setTempactive(Optional.ofNullable(solrDocument.get("tempactive_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setS3path(Optional.ofNullable(solrDocument.get("s3path_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setSdfStatus(Optional.ofNullable(solrDocument.get("sdfStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
@@ -6982,8 +7194,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		oCurrikiResource.setLodestar(Optional.ofNullable(solrDocument.get("lodestar_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setArchive(Optional.ofNullable(solrDocument.get("archive_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setIdentifier(Optional.ofNullable(solrDocument.get("identifier_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDisplayName(Optional.ofNullable(solrDocument.get("displayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setEducationLevelDisplayName(Optional.ofNullable(solrDocument.get("educationLevelDisplayName_docvalues_string")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setSubjectArea(Optional.ofNullable(solrDocument.get("subjectArea_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectAreaDisplayName(Optional.ofNullable(solrDocument.get("subjectAreaDisplayName_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionTypeDisplayName(Optional.ofNullable(solrDocument.get("instructionTypeDisplayName_docvalues_int")).map(v -> v.toString()).orElse(null));
 		oCurrikiResource.setName(Optional.ofNullable(solrDocument.get("name_docvalues_string")).map(v -> v.toString()).orElse(null));
 
 		super.storeBaseModel(solrDocument);
@@ -7160,6 +7374,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("uniqueName");
 			if(!Objects.equals(ext, original.getExt()))
 				apiRequest.addVars("ext");
+			if(!Objects.equals(resourceFilesActive, original.getResourceFilesActive()))
+				apiRequest.addVars("resourceFilesActive");
 			if(!Objects.equals(tempactive, original.getTempactive()))
 				apiRequest.addVars("tempactive");
 			if(!Objects.equals(s3path, original.getS3path()))
@@ -7174,10 +7390,14 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("archive");
 			if(!Objects.equals(identifier, original.getIdentifier()))
 				apiRequest.addVars("identifier");
-			if(!Objects.equals(displayName, original.getDisplayName()))
-				apiRequest.addVars("displayName");
+			if(!Objects.equals(educationLevelDisplayName, original.getEducationLevelDisplayName()))
+				apiRequest.addVars("educationLevelDisplayName");
 			if(!Objects.equals(subjectArea, original.getSubjectArea()))
 				apiRequest.addVars("subjectArea");
+			if(!Objects.equals(subjectAreaDisplayName, original.getSubjectAreaDisplayName()))
+				apiRequest.addVars("subjectAreaDisplayName");
+			if(!Objects.equals(instructionTypeDisplayName, original.getInstructionTypeDisplayName()))
+				apiRequest.addVars("instructionTypeDisplayName");
 			if(!Objects.equals(name, original.getName()))
 				apiRequest.addVars("name");
 			super.apiRequestBaseModel();
@@ -7272,6 +7492,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(sequence).map(v -> "sequence: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(uniqueName).map(v -> "uniqueName: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(ext).map(v -> "ext: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(resourceFilesActive).map(v -> "resourceFilesActive: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(tempactive).map(v -> "tempactive: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(s3path).map(v -> "s3path: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(sdfStatus).map(v -> "sdfStatus: \"" + v + "\"\n" ).orElse(""));
@@ -7279,8 +7500,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(lodestar).map(v -> "lodestar: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(archive).map(v -> "archive: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(identifier).map(v -> "identifier: \"" + v + "\"\n" ).orElse(""));
-		sb.append(Optional.ofNullable(displayName).map(v -> "displayName: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(educationLevelDisplayName).map(v -> "educationLevelDisplayName: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(subjectArea).map(v -> "subjectArea: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(subjectAreaDisplayName).map(v -> "subjectAreaDisplayName: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(instructionTypeDisplayName).map(v -> "instructionTypeDisplayName: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(name).map(v -> "name: \"" + v + "\"\n" ).orElse(""));
 		return sb.toString();
 	}
@@ -7370,6 +7593,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	public static final String VAR_sequence = "sequence";
 	public static final String VAR_uniqueName = "uniqueName";
 	public static final String VAR_ext = "ext";
+	public static final String VAR_resourceFilesActive = "resourceFilesActive";
 	public static final String VAR_tempactive = "tempactive";
 	public static final String VAR_s3path = "s3path";
 	public static final String VAR_sdfStatus = "sdfStatus";
@@ -7377,7 +7601,9 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	public static final String VAR_lodestar = "lodestar";
 	public static final String VAR_archive = "archive";
 	public static final String VAR_identifier = "identifier";
-	public static final String VAR_displayName = "displayName";
+	public static final String VAR_educationLevelDisplayName = "educationLevelDisplayName";
 	public static final String VAR_subjectArea = "subjectArea";
+	public static final String VAR_subjectAreaDisplayName = "subjectAreaDisplayName";
+	public static final String VAR_instructionTypeDisplayName = "instructionTypeDisplayName";
 	public static final String VAR_name = "name";
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGen.java
@@ -1,67 +1,68 @@
 package org.curriki.api.enus.model.resource;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import io.vertx.core.json.JsonObject;
-import java.util.Date;
-import java.util.Set;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import java.lang.String;
-import java.lang.Long;
+import org.curriki.api.enus.base.BaseModel;
+import java.util.Date;
 import java.time.ZonedDateTime;
-import java.time.ZoneId;
+import org.slf4j.LoggerFactory;
+import org.apache.commons.lang3.StringUtils;
+import java.lang.Integer;
+import java.math.BigDecimal;
+import java.lang.Long;
+import java.util.Locale;
+import java.util.Map;
+import io.vertx.core.json.JsonObject;
 import java.time.ZoneOffset;
+import java.math.RoundingMode;
+import org.curriki.api.enus.model.base.BaseModel;
+import java.math.MathContext;
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
+import io.vertx.core.Future;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.List;
+import java.time.OffsetDateTime;
+import org.apache.solr.client.solrj.SolrQuery;
+import java.util.Optional;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.request.api.ApiRequest;
 import java.time.LocalDateTime;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import org.slf4j.Logger;
+import io.vertx.core.Promise;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.curriki.api.enus.config.ConfigKeys;
+import org.apache.solr.client.solrj.SolrClient;
+import io.vertx.core.json.JsonArray;
+import org.apache.solr.common.SolrDocument;
 import java.time.temporal.ChronoUnit;
 import java.time.format.DateTimeFormatter;
-import java.time.Instant;
-import java.util.Locale;
-import java.time.OffsetDateTime;
-import io.vertx.core.json.JsonArray;
-import java.math.BigDecimal;
-import java.lang.Integer;
-import org.computate.search.wrap.Wrap;
-import io.vertx.core.Promise;
-import io.vertx.core.Future;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.computate.search.response.solr.SolrResponse;
+import org.apache.commons.lang3.math.NumberUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource">Find the class CurrikiResource in Solr. </a>
- * <br><br>Delete the class CurrikiResource in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.resource in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.resource&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResource.class);
@@ -99,10 +100,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceId;
 
-	/**	<br> The entity resourceId
+	/**	<br/> The entity resourceId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceId">Find the entity resourceId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceId">Find the entity resourceId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceId(Wrap<String> w);
@@ -125,20 +126,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchResourceId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrResourceId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrResourceId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrResourceId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqResourceId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceId(siteRequest_, CurrikiResource.staticSearchResourceId(siteRequest_, CurrikiResource.staticSetResourceId(siteRequest_, o)));
-	}
-
-	public String sqlResourceId() {
-		return resourceId;
+	public static String staticSolrFqResourceId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceId(siteRequest_, CurrikiResource.staticSolrResourceId(siteRequest_, CurrikiResource.staticSetResourceId(siteRequest_, o)));
 	}
 
 	///////////////
@@ -152,10 +149,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String licenseId;
 
-	/**	<br> The entity licenseId
+	/**	<br/> The entity licenseId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:licenseId">Find the entity licenseId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:licenseId">Find the entity licenseId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _licenseId(Wrap<String> w);
@@ -178,20 +175,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchLicenseId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrLicenseId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrLicenseId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrLicenseId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLicenseId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLicenseId(siteRequest_, CurrikiResource.staticSearchLicenseId(siteRequest_, CurrikiResource.staticSetLicenseId(siteRequest_, o)));
-	}
-
-	public String sqlLicenseId() {
-		return licenseId;
+	public static String staticSolrFqLicenseId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLicenseId(siteRequest_, CurrikiResource.staticSolrLicenseId(siteRequest_, CurrikiResource.staticSetLicenseId(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -206,10 +199,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long contributorId;
 
-	/**	<br> The entity contributorId
+	/**	<br/> The entity contributorId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:contributorId">Find the entity contributorId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributorId">Find the entity contributorId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contributorId(Wrap<Long> w);
@@ -239,20 +232,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSearchContributorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrContributorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrContributorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrContributorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContributorId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrContributorId(siteRequest_, CurrikiResource.staticSearchContributorId(siteRequest_, CurrikiResource.staticSetContributorId(siteRequest_, o)));
-	}
-
-	public Long sqlContributorId() {
-		return contributorId;
+	public static String staticSolrFqContributorId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrContributorId(siteRequest_, CurrikiResource.staticSolrContributorId(siteRequest_, CurrikiResource.staticSetContributorId(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -263,16 +252,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime contributionDate;
 
-	/**	<br> The entity contributionDate
+	/**	<br/> The entity contributionDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:contributionDate">Find the entity contributionDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contributionDate">Find the entity contributionDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contributionDate(Wrap<ZonedDateTime> w);
@@ -294,8 +283,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.contributionDate = CurrikiResource.staticSetContributionDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetContributionDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -314,20 +301,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchContributionDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrContributionDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrContributionDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrContributionDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqContributionDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrContributionDate(siteRequest_, CurrikiResource.staticSearchContributionDate(siteRequest_, CurrikiResource.staticSetContributionDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlContributionDate() {
-		return contributionDate == null ? null : contributionDate.toOffsetDateTime();
+	public static String staticSolrFqContributionDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrContributionDate(siteRequest_, CurrikiResource.staticSolrContributionDate(siteRequest_, CurrikiResource.staticSetContributionDate(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -341,10 +324,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String description;
 
-	/**	<br> The entity description
+	/**	<br/> The entity description
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:description">Find the entity description in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:description">Find the entity description in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _description(Wrap<String> w);
@@ -367,20 +350,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDescription(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrDescription(siteRequest_, CurrikiResource.staticSearchDescription(siteRequest_, CurrikiResource.staticSetDescription(siteRequest_, o)));
-	}
-
-	public String sqlDescription() {
-		return description;
+	public static String staticSolrFqDescription(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDescription(siteRequest_, CurrikiResource.staticSolrDescription(siteRequest_, CurrikiResource.staticSetDescription(siteRequest_, o)));
 	}
 
 	///////////
@@ -394,10 +373,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String title;
 
-	/**	<br> The entity title
+	/**	<br/> The entity title
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:title">Find the entity title in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:title">Find the entity title in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _title(Wrap<String> w);
@@ -420,20 +399,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqTitle(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrTitle(siteRequest_, CurrikiResource.staticSearchTitle(siteRequest_, CurrikiResource.staticSetTitle(siteRequest_, o)));
-	}
-
-	public String sqlTitle() {
-		return title;
+	public static String staticSolrFqTitle(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTitle(siteRequest_, CurrikiResource.staticSolrTitle(siteRequest_, CurrikiResource.staticSetTitle(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -447,10 +422,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String keywordsStr;
 
-	/**	<br> The entity keywordsStr
+	/**	<br/> The entity keywordsStr
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:keywordsStr">Find the entity keywordsStr in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywordsStr">Find the entity keywordsStr in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _keywordsStr(Wrap<String> w);
@@ -473,20 +448,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrKeywordsStr(siteRequest_, CurrikiResource.staticSearchKeywordsStr(siteRequest_, CurrikiResource.staticSetKeywordsStr(siteRequest_, o)));
-	}
-
-	public String sqlKeywordsStr() {
-		return keywordsStr;
+	public static String staticSolrFqKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrKeywordsStr(siteRequest_, CurrikiResource.staticSolrKeywordsStr(siteRequest_, CurrikiResource.staticSetKeywordsStr(siteRequest_, o)));
 	}
 
 	//////////////
@@ -494,18 +465,18 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	//////////////
 
 	/**	 The entity keywords
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> keywords = new ArrayList<String>();
 
-	/**	<br> The entity keywords
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:keywords">Find the entity keywords in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity keywords
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:keywords">Find the entity keywords in Solr</a>
+	 * <br/>
+	 * @param keywords is the entity already constructed. 
 	 **/
 	protected abstract void _keywords(List<String> l);
 
@@ -543,16 +514,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqKeywords(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrKeywords(siteRequest_, CurrikiResource.staticSearchKeywords(siteRequest_, CurrikiResource.staticSetKeywords(siteRequest_, o)));
+	public static String staticSolrFqKeywords(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrKeywords(siteRequest_, CurrikiResource.staticSolrKeywords(siteRequest_, CurrikiResource.staticSetKeywords(siteRequest_, o)));
 	}
 
 	//////////////////////////
@@ -566,10 +537,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String generatedKeywordsStr;
 
-	/**	<br> The entity generatedKeywordsStr
+	/**	<br/> The entity generatedKeywordsStr
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:generatedKeywordsStr">Find the entity generatedKeywordsStr in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywordsStr">Find the entity generatedKeywordsStr in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _generatedKeywordsStr(Wrap<String> w);
@@ -592,20 +563,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSearchGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSetGeneratedKeywordsStr(siteRequest_, o)));
-	}
-
-	public String sqlGeneratedKeywordsStr() {
-		return generatedKeywordsStr;
+	public static String staticSolrFqGeneratedKeywordsStr(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSolrGeneratedKeywordsStr(siteRequest_, CurrikiResource.staticSetGeneratedKeywordsStr(siteRequest_, o)));
 	}
 
 	///////////////////////
@@ -613,18 +580,18 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	///////////////////////
 
 	/**	 The entity generatedKeywords
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> generatedKeywords = new ArrayList<String>();
 
-	/**	<br> The entity generatedKeywords
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:generatedKeywords">Find the entity generatedKeywords in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity generatedKeywords
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:generatedKeywords">Find the entity generatedKeywords in Solr</a>
+	 * <br/>
+	 * @param generatedKeywords is the entity already constructed. 
 	 **/
 	protected abstract void _generatedKeywords(List<String> l);
 
@@ -662,16 +629,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrGeneratedKeywords(siteRequest_, CurrikiResource.staticSearchGeneratedKeywords(siteRequest_, CurrikiResource.staticSetGeneratedKeywords(siteRequest_, o)));
+	public static String staticSolrFqGeneratedKeywords(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrGeneratedKeywords(siteRequest_, CurrikiResource.staticSolrGeneratedKeywords(siteRequest_, CurrikiResource.staticSetGeneratedKeywords(siteRequest_, o)));
 	}
 
 	//////////////
@@ -685,10 +652,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String language;
 
-	/**	<br> The entity language
+	/**	<br/> The entity language
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:language">Find the entity language in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:language">Find the entity language in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _language(Wrap<String> w);
@@ -711,20 +678,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchLanguage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrLanguage(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrLanguage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrLanguage(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLanguage(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLanguage(siteRequest_, CurrikiResource.staticSearchLanguage(siteRequest_, CurrikiResource.staticSetLanguage(siteRequest_, o)));
-	}
-
-	public String sqlLanguage() {
-		return language;
+	public static String staticSolrFqLanguage(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLanguage(siteRequest_, CurrikiResource.staticSolrLanguage(siteRequest_, CurrikiResource.staticSetLanguage(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -739,10 +702,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long lastEditorId;
 
-	/**	<br> The entity lastEditorId
+	/**	<br/> The entity lastEditorId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:lastEditorId">Find the entity lastEditorId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditorId">Find the entity lastEditorId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastEditorId(Wrap<Long> w);
@@ -772,20 +735,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSearchLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrLastEditorId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLastEditorId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLastEditorId(siteRequest_, CurrikiResource.staticSearchLastEditorId(siteRequest_, CurrikiResource.staticSetLastEditorId(siteRequest_, o)));
-	}
-
-	public Long sqlLastEditorId() {
-		return lastEditorId;
+	public static String staticSolrFqLastEditorId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLastEditorId(siteRequest_, CurrikiResource.staticSolrLastEditorId(siteRequest_, CurrikiResource.staticSetLastEditorId(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -796,16 +755,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastEditDate;
 
-	/**	<br> The entity lastEditDate
+	/**	<br/> The entity lastEditDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:lastEditDate">Find the entity lastEditDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastEditDate">Find the entity lastEditDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastEditDate(Wrap<ZonedDateTime> w);
@@ -827,8 +786,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastEditDate = CurrikiResource.staticSetLastEditDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastEditDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -847,20 +804,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchLastEditDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrLastEditDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrLastEditDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrLastEditDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqLastEditDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLastEditDate(siteRequest_, CurrikiResource.staticSearchLastEditDate(siteRequest_, CurrikiResource.staticSetLastEditDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlLastEditDate() {
-		return lastEditDate == null ? null : lastEditDate.toOffsetDateTime();
+	public static String staticSolrFqLastEditDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLastEditDate(siteRequest_, CurrikiResource.staticSolrLastEditDate(siteRequest_, CurrikiResource.staticSetLastEditDate(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -874,10 +827,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String currikiLicense;
 
-	/**	<br> The entity currikiLicense
+	/**	<br/> The entity currikiLicense
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:currikiLicense">Find the entity currikiLicense in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiLicense">Find the entity currikiLicense in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiLicense(Wrap<String> w);
@@ -900,20 +853,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrCurrikiLicense(siteRequest_, CurrikiResource.staticSearchCurrikiLicense(siteRequest_, CurrikiResource.staticSetCurrikiLicense(siteRequest_, o)));
-	}
-
-	public String sqlCurrikiLicense() {
-		return currikiLicense;
+	public static String staticSolrFqCurrikiLicense(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrCurrikiLicense(siteRequest_, CurrikiResource.staticSolrCurrikiLicense(siteRequest_, CurrikiResource.staticSetCurrikiLicense(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -927,10 +876,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String externalUrl;
 
-	/**	<br> The entity externalUrl
+	/**	<br/> The entity externalUrl
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:externalUrl">Find the entity externalUrl in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:externalUrl">Find the entity externalUrl in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _externalUrl(Wrap<String> w);
@@ -953,20 +902,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrExternalUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqExternalUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrExternalUrl(siteRequest_, CurrikiResource.staticSearchExternalUrl(siteRequest_, CurrikiResource.staticSetExternalUrl(siteRequest_, o)));
-	}
-
-	public String sqlExternalUrl() {
-		return externalUrl;
+	public static String staticSolrFqExternalUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrExternalUrl(siteRequest_, CurrikiResource.staticSolrExternalUrl(siteRequest_, CurrikiResource.staticSetExternalUrl(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -980,10 +925,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceChecked;
 
-	/**	<br> The entity resourceChecked
+	/**	<br/> The entity resourceChecked
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceChecked">Find the entity resourceChecked in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceChecked">Find the entity resourceChecked in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceChecked(Wrap<String> w);
@@ -1006,20 +951,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrResourceChecked(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqResourceChecked(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceChecked(siteRequest_, CurrikiResource.staticSearchResourceChecked(siteRequest_, CurrikiResource.staticSetResourceChecked(siteRequest_, o)));
-	}
-
-	public String sqlResourceChecked() {
-		return resourceChecked;
+	public static String staticSolrFqResourceChecked(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceChecked(siteRequest_, CurrikiResource.staticSolrResourceChecked(siteRequest_, CurrikiResource.staticSetResourceChecked(siteRequest_, o)));
 	}
 
 	/////////////
@@ -1033,10 +974,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String content;
 
-	/**	<br> The entity content
+	/**	<br/> The entity content
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:content">Find the entity content in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:content">Find the entity content in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _content(Wrap<String> w);
@@ -1059,20 +1000,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchContent(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrContent(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrContent(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrContent(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContent(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrContent(siteRequest_, CurrikiResource.staticSearchContent(siteRequest_, CurrikiResource.staticSetContent(siteRequest_, o)));
-	}
-
-	public String sqlContent() {
-		return content;
+	public static String staticSolrFqContent(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrContent(siteRequest_, CurrikiResource.staticSolrContent(siteRequest_, CurrikiResource.staticSetContent(siteRequest_, o)));
 	}
 
 	//////////////////////////////
@@ -1086,10 +1023,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceCheckRequestNote;
 
-	/**	<br> The entity resourceCheckRequestNote
+	/**	<br/> The entity resourceCheckRequestNote
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceCheckRequestNote">Find the entity resourceCheckRequestNote in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckRequestNote">Find the entity resourceCheckRequestNote in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckRequestNote(Wrap<String> w);
@@ -1112,20 +1049,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSearchResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSetResourceCheckRequestNote(siteRequest_, o)));
-	}
-
-	public String sqlResourceCheckRequestNote() {
-		return resourceCheckRequestNote;
+	public static String staticSolrFqResourceCheckRequestNote(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSolrResourceCheckRequestNote(siteRequest_, CurrikiResource.staticSetResourceCheckRequestNote(siteRequest_, o)));
 	}
 
 	///////////////////////
@@ -1136,16 +1069,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime resourceCheckDate;
 
-	/**	<br> The entity resourceCheckDate
+	/**	<br/> The entity resourceCheckDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceCheckDate">Find the entity resourceCheckDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckDate">Find the entity resourceCheckDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckDate(Wrap<ZonedDateTime> w);
@@ -1167,8 +1100,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.resourceCheckDate = CurrikiResource.staticSetResourceCheckDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -1187,20 +1118,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchResourceCheckDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrResourceCheckDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrResourceCheckDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrResourceCheckDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceCheckDate(siteRequest_, CurrikiResource.staticSearchResourceCheckDate(siteRequest_, CurrikiResource.staticSetResourceCheckDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlResourceCheckDate() {
-		return resourceCheckDate == null ? null : resourceCheckDate.toOffsetDateTime();
+	public static String staticSolrFqResourceCheckDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceCheckDate(siteRequest_, CurrikiResource.staticSolrResourceCheckDate(siteRequest_, CurrikiResource.staticSetResourceCheckDate(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1215,10 +1142,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long resourceCheckId;
 
-	/**	<br> The entity resourceCheckId
+	/**	<br/> The entity resourceCheckId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceCheckId">Find the entity resourceCheckId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckId">Find the entity resourceCheckId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckId(Wrap<Long> w);
@@ -1248,20 +1175,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSearchResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrResourceCheckId(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqResourceCheckId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceCheckId(siteRequest_, CurrikiResource.staticSearchResourceCheckId(siteRequest_, CurrikiResource.staticSetResourceCheckId(siteRequest_, o)));
-	}
-
-	public Long sqlResourceCheckId() {
-		return resourceCheckId;
+	public static String staticSolrFqResourceCheckId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceCheckId(siteRequest_, CurrikiResource.staticSolrResourceCheckId(siteRequest_, CurrikiResource.staticSetResourceCheckId(siteRequest_, o)));
 	}
 
 	///////////////////////
@@ -1275,10 +1198,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String resourceCheckNote;
 
-	/**	<br> The entity resourceCheckNote
+	/**	<br/> The entity resourceCheckNote
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:resourceCheckNote">Find the entity resourceCheckNote in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:resourceCheckNote">Find the entity resourceCheckNote in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _resourceCheckNote(Wrap<String> w);
@@ -1301,20 +1224,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrResourceCheckNote(siteRequest_, CurrikiResource.staticSearchResourceCheckNote(siteRequest_, CurrikiResource.staticSetResourceCheckNote(siteRequest_, o)));
-	}
-
-	public String sqlResourceCheckNote() {
-		return resourceCheckNote;
+	public static String staticSolrFqResourceCheckNote(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrResourceCheckNote(siteRequest_, CurrikiResource.staticSolrResourceCheckNote(siteRequest_, CurrikiResource.staticSetResourceCheckNote(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1328,10 +1247,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String studentFacing;
 
-	/**	<br> The entity studentFacing
+	/**	<br/> The entity studentFacing
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:studentFacing">Find the entity studentFacing in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:studentFacing">Find the entity studentFacing in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _studentFacing(Wrap<String> w);
@@ -1354,20 +1273,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrStudentFacing(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqStudentFacing(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrStudentFacing(siteRequest_, CurrikiResource.staticSearchStudentFacing(siteRequest_, CurrikiResource.staticSetStudentFacing(siteRequest_, o)));
-	}
-
-	public String sqlStudentFacing() {
-		return studentFacing;
+	public static String staticSolrFqStudentFacing(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrStudentFacing(siteRequest_, CurrikiResource.staticSolrStudentFacing(siteRequest_, CurrikiResource.staticSetStudentFacing(siteRequest_, o)));
 	}
 
 	////////////
@@ -1381,10 +1296,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String source;
 
-	/**	<br> The entity source
+	/**	<br/> The entity source
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:source">Find the entity source in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:source">Find the entity source in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _source(Wrap<String> w);
@@ -1407,20 +1322,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchSource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSource(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSource(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSource(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSource(siteRequest_, CurrikiResource.staticSearchSource(siteRequest_, CurrikiResource.staticSetSource(siteRequest_, o)));
-	}
-
-	public String sqlSource() {
-		return source;
+	public static String staticSolrFqSource(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSource(siteRequest_, CurrikiResource.staticSolrSource(siteRequest_, CurrikiResource.staticSetSource(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -1434,10 +1345,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String reviewStatus;
 
-	/**	<br> The entity reviewStatus
+	/**	<br/> The entity reviewStatus
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:reviewStatus">Find the entity reviewStatus in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewStatus">Find the entity reviewStatus in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewStatus(Wrap<String> w);
@@ -1460,20 +1371,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrReviewStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqReviewStatus(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrReviewStatus(siteRequest_, CurrikiResource.staticSearchReviewStatus(siteRequest_, CurrikiResource.staticSetReviewStatus(siteRequest_, o)));
-	}
-
-	public String sqlReviewStatus() {
-		return reviewStatus;
+	public static String staticSolrFqReviewStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrReviewStatus(siteRequest_, CurrikiResource.staticSolrReviewStatus(siteRequest_, CurrikiResource.staticSetReviewStatus(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -1484,16 +1391,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastReviewDate;
 
-	/**	<br> The entity lastReviewDate
+	/**	<br/> The entity lastReviewDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:lastReviewDate">Find the entity lastReviewDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastReviewDate">Find the entity lastReviewDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastReviewDate(Wrap<ZonedDateTime> w);
@@ -1515,8 +1422,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastReviewDate = CurrikiResource.staticSetLastReviewDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -1535,20 +1440,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchLastReviewDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrLastReviewDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrLastReviewDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrLastReviewDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLastReviewDate(siteRequest_, CurrikiResource.staticSearchLastReviewDate(siteRequest_, CurrikiResource.staticSetLastReviewDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlLastReviewDate() {
-		return lastReviewDate == null ? null : lastReviewDate.toOffsetDateTime();
+	public static String staticSolrFqLastReviewDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLastReviewDate(siteRequest_, CurrikiResource.staticSolrLastReviewDate(siteRequest_, CurrikiResource.staticSetLastReviewDate(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1563,10 +1464,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Long reviewByID;
 
-	/**	<br> The entity reviewByID
+	/**	<br/> The entity reviewByID
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:reviewByID">Find the entity reviewByID in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewByID">Find the entity reviewByID in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewByID(Wrap<Long> w);
@@ -1596,20 +1497,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Long staticSearchReviewByID(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrReviewByID(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqReviewByID(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrReviewByID(siteRequest_, CurrikiResource.staticSearchReviewByID(siteRequest_, CurrikiResource.staticSetReviewByID(siteRequest_, o)));
-	}
-
-	public Long sqlReviewByID() {
-		return reviewByID;
+	public static String staticSolrFqReviewByID(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrReviewByID(siteRequest_, CurrikiResource.staticSolrReviewByID(siteRequest_, CurrikiResource.staticSetReviewByID(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -1624,10 +1521,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected BigDecimal reviewRating;
 
-	/**	<br> The entity reviewRating
+	/**	<br/> The entity reviewRating
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:reviewRating">Find the entity reviewRating in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewRating">Find the entity reviewRating in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewRating(Wrap<BigDecimal> w);
@@ -1666,20 +1563,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Double staticSearchReviewRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
+	public static Double staticSolrReviewRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
 		return o == null ? null : o.doubleValue();
 	}
 
-	public static String staticSearchStrReviewRating(SiteRequestEnUS siteRequest_, Double o) {
+	public static String staticSolrStrReviewRating(SiteRequestEnUS siteRequest_, Double o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqReviewRating(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrReviewRating(siteRequest_, CurrikiResource.staticSearchReviewRating(siteRequest_, CurrikiResource.staticSetReviewRating(siteRequest_, o)));
-	}
-
-	public BigDecimal sqlReviewRating() {
-		return reviewRating;
+	public static String staticSolrFqReviewRating(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrReviewRating(siteRequest_, CurrikiResource.staticSolrReviewRating(siteRequest_, CurrikiResource.staticSetReviewRating(siteRequest_, o)));
 	}
 
 	///////////////////////////
@@ -1694,10 +1587,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer technicalCompleteness;
 
-	/**	<br> The entity technicalCompleteness
+	/**	<br/> The entity technicalCompleteness
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:technicalCompleteness">Find the entity technicalCompleteness in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:technicalCompleteness">Find the entity technicalCompleteness in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _technicalCompleteness(Wrap<Integer> w);
@@ -1727,20 +1620,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrTechnicalCompleteness(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqTechnicalCompleteness(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSearchTechnicalCompleteness(siteRequest_, CurrikiResource.staticSetTechnicalCompleteness(siteRequest_, o)));
-	}
-
-	public Integer sqlTechnicalCompleteness() {
-		return technicalCompleteness;
+	public static String staticSolrFqTechnicalCompleteness(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSolrTechnicalCompleteness(siteRequest_, CurrikiResource.staticSetTechnicalCompleteness(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1755,10 +1644,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer contentAccuracy;
 
-	/**	<br> The entity contentAccuracy
+	/**	<br/> The entity contentAccuracy
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:contentAccuracy">Find the entity contentAccuracy in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentAccuracy">Find the entity contentAccuracy in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contentAccuracy(Wrap<Integer> w);
@@ -1788,20 +1677,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrContentAccuracy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContentAccuracy(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrContentAccuracy(siteRequest_, CurrikiResource.staticSearchContentAccuracy(siteRequest_, CurrikiResource.staticSetContentAccuracy(siteRequest_, o)));
-	}
-
-	public Integer sqlContentAccuracy() {
-		return contentAccuracy;
+	public static String staticSolrFqContentAccuracy(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrContentAccuracy(siteRequest_, CurrikiResource.staticSolrContentAccuracy(siteRequest_, CurrikiResource.staticSetContentAccuracy(siteRequest_, o)));
 	}
 
 	//////////////
@@ -1816,10 +1701,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer pedagogy;
 
-	/**	<br> The entity pedagogy
+	/**	<br/> The entity pedagogy
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:pedagogy">Find the entity pedagogy in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pedagogy">Find the entity pedagogy in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pedagogy(Wrap<Integer> w);
@@ -1849,20 +1734,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrPedagogy(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPedagogy(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPedagogy(siteRequest_, CurrikiResource.staticSearchPedagogy(siteRequest_, CurrikiResource.staticSetPedagogy(siteRequest_, o)));
-	}
-
-	public Integer sqlPedagogy() {
-		return pedagogy;
+	public static String staticSolrFqPedagogy(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPedagogy(siteRequest_, CurrikiResource.staticSolrPedagogy(siteRequest_, CurrikiResource.staticSetPedagogy(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1876,10 +1757,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String ratingComment;
 
-	/**	<br> The entity ratingComment
+	/**	<br/> The entity ratingComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:ratingComment">Find the entity ratingComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ratingComment">Find the entity ratingComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _ratingComment(Wrap<String> w);
@@ -1902,20 +1783,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchRatingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRatingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRatingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRatingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRatingComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrRatingComment(siteRequest_, CurrikiResource.staticSearchRatingComment(siteRequest_, CurrikiResource.staticSetRatingComment(siteRequest_, o)));
-	}
-
-	public String sqlRatingComment() {
-		return ratingComment;
+	public static String staticSolrFqRatingComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrRatingComment(siteRequest_, CurrikiResource.staticSolrRatingComment(siteRequest_, CurrikiResource.staticSetRatingComment(siteRequest_, o)));
 	}
 
 	////////////////////////
@@ -1930,10 +1807,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer standardsAlignment;
 
-	/**	<br> The entity standardsAlignment
+	/**	<br/> The entity standardsAlignment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:standardsAlignment">Find the entity standardsAlignment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignment">Find the entity standardsAlignment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _standardsAlignment(Wrap<Integer> w);
@@ -1963,20 +1840,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrStandardsAlignment(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqStandardsAlignment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrStandardsAlignment(siteRequest_, CurrikiResource.staticSearchStandardsAlignment(siteRequest_, CurrikiResource.staticSetStandardsAlignment(siteRequest_, o)));
-	}
-
-	public Integer sqlStandardsAlignment() {
-		return standardsAlignment;
+	public static String staticSolrFqStandardsAlignment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrStandardsAlignment(siteRequest_, CurrikiResource.staticSolrStandardsAlignment(siteRequest_, CurrikiResource.staticSetStandardsAlignment(siteRequest_, o)));
 	}
 
 	///////////////////////////////
@@ -1990,10 +1863,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String standardsAlignmentComment;
 
-	/**	<br> The entity standardsAlignmentComment
+	/**	<br/> The entity standardsAlignmentComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:standardsAlignmentComment">Find the entity standardsAlignmentComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:standardsAlignmentComment">Find the entity standardsAlignmentComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _standardsAlignmentComment(Wrap<String> w);
@@ -2016,20 +1889,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSearchStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSetStandardsAlignmentComment(siteRequest_, o)));
-	}
-
-	public String sqlStandardsAlignmentComment() {
-		return standardsAlignmentComment;
+	public static String staticSolrFqStandardsAlignmentComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSolrStandardsAlignmentComment(siteRequest_, CurrikiResource.staticSetStandardsAlignmentComment(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -2044,10 +1913,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer subjectMatter;
 
-	/**	<br> The entity subjectMatter
+	/**	<br/> The entity subjectMatter
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:subjectMatter">Find the entity subjectMatter in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatter">Find the entity subjectMatter in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectMatter(Wrap<Integer> w);
@@ -2077,20 +1946,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrSubjectMatter(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSubjectMatter(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSubjectMatter(siteRequest_, CurrikiResource.staticSearchSubjectMatter(siteRequest_, CurrikiResource.staticSetSubjectMatter(siteRequest_, o)));
-	}
-
-	public Integer sqlSubjectMatter() {
-		return subjectMatter;
+	public static String staticSolrFqSubjectMatter(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSubjectMatter(siteRequest_, CurrikiResource.staticSolrSubjectMatter(siteRequest_, CurrikiResource.staticSetSubjectMatter(siteRequest_, o)));
 	}
 
 	//////////////////////////
@@ -2104,10 +1969,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String subjectMatterComment;
 
-	/**	<br> The entity subjectMatterComment
+	/**	<br/> The entity subjectMatterComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:subjectMatterComment">Find the entity subjectMatterComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectMatterComment">Find the entity subjectMatterComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _subjectMatterComment(Wrap<String> w);
@@ -2130,20 +1995,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSubjectMatterComment(siteRequest_, CurrikiResource.staticSearchSubjectMatterComment(siteRequest_, CurrikiResource.staticSetSubjectMatterComment(siteRequest_, o)));
-	}
-
-	public String sqlSubjectMatterComment() {
-		return subjectMatterComment;
+	public static String staticSolrFqSubjectMatterComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSubjectMatterComment(siteRequest_, CurrikiResource.staticSolrSubjectMatterComment(siteRequest_, CurrikiResource.staticSetSubjectMatterComment(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -2158,10 +2019,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer supportsTeaching;
 
-	/**	<br> The entity supportsTeaching
+	/**	<br/> The entity supportsTeaching
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:supportsTeaching">Find the entity supportsTeaching in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeaching">Find the entity supportsTeaching in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _supportsTeaching(Wrap<Integer> w);
@@ -2191,20 +2052,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrSupportsTeaching(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSupportsTeaching(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSupportsTeaching(siteRequest_, CurrikiResource.staticSearchSupportsTeaching(siteRequest_, CurrikiResource.staticSetSupportsTeaching(siteRequest_, o)));
-	}
-
-	public Integer sqlSupportsTeaching() {
-		return supportsTeaching;
+	public static String staticSolrFqSupportsTeaching(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSupportsTeaching(siteRequest_, CurrikiResource.staticSolrSupportsTeaching(siteRequest_, CurrikiResource.staticSetSupportsTeaching(siteRequest_, o)));
 	}
 
 	/////////////////////////////
@@ -2218,10 +2075,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String supportsTeachingComment;
 
-	/**	<br> The entity supportsTeachingComment
+	/**	<br/> The entity supportsTeachingComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:supportsTeachingComment">Find the entity supportsTeachingComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:supportsTeachingComment">Find the entity supportsTeachingComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _supportsTeachingComment(Wrap<String> w);
@@ -2244,20 +2101,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSearchSupportsTeachingComment(siteRequest_, CurrikiResource.staticSetSupportsTeachingComment(siteRequest_, o)));
-	}
-
-	public String sqlSupportsTeachingComment() {
-		return supportsTeachingComment;
+	public static String staticSolrFqSupportsTeachingComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSolrSupportsTeachingComment(siteRequest_, CurrikiResource.staticSetSupportsTeachingComment(siteRequest_, o)));
 	}
 
 	////////////////////////
@@ -2272,10 +2125,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer assessmentsQuality;
 
-	/**	<br> The entity assessmentsQuality
+	/**	<br/> The entity assessmentsQuality
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:assessmentsQuality">Find the entity assessmentsQuality in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQuality">Find the entity assessmentsQuality in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _assessmentsQuality(Wrap<Integer> w);
@@ -2305,20 +2158,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrAssessmentsQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqAssessmentsQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrAssessmentsQuality(siteRequest_, CurrikiResource.staticSearchAssessmentsQuality(siteRequest_, CurrikiResource.staticSetAssessmentsQuality(siteRequest_, o)));
-	}
-
-	public Integer sqlAssessmentsQuality() {
-		return assessmentsQuality;
+	public static String staticSolrFqAssessmentsQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrAssessmentsQuality(siteRequest_, CurrikiResource.staticSolrAssessmentsQuality(siteRequest_, CurrikiResource.staticSetAssessmentsQuality(siteRequest_, o)));
 	}
 
 	///////////////////////////////
@@ -2332,10 +2181,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String assessmentsQualityComment;
 
-	/**	<br> The entity assessmentsQualityComment
+	/**	<br/> The entity assessmentsQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:assessmentsQualityComment">Find the entity assessmentsQualityComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:assessmentsQualityComment">Find the entity assessmentsQualityComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _assessmentsQualityComment(Wrap<String> w);
@@ -2358,20 +2207,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSearchAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSetAssessmentsQualityComment(siteRequest_, o)));
-	}
-
-	public String sqlAssessmentsQualityComment() {
-		return assessmentsQualityComment;
+	public static String staticSolrFqAssessmentsQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSolrAssessmentsQualityComment(siteRequest_, CurrikiResource.staticSetAssessmentsQualityComment(siteRequest_, o)));
 	}
 
 	//////////////////////////
@@ -2386,10 +2231,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer interactivityQuality;
 
-	/**	<br> The entity interactivityQuality
+	/**	<br/> The entity interactivityQuality
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:interactivityQuality">Find the entity interactivityQuality in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQuality">Find the entity interactivityQuality in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _interactivityQuality(Wrap<Integer> w);
@@ -2419,20 +2264,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrInteractivityQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInteractivityQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrInteractivityQuality(siteRequest_, CurrikiResource.staticSearchInteractivityQuality(siteRequest_, CurrikiResource.staticSetInteractivityQuality(siteRequest_, o)));
-	}
-
-	public Integer sqlInteractivityQuality() {
-		return interactivityQuality;
+	public static String staticSolrFqInteractivityQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrInteractivityQuality(siteRequest_, CurrikiResource.staticSolrInteractivityQuality(siteRequest_, CurrikiResource.staticSetInteractivityQuality(siteRequest_, o)));
 	}
 
 	/////////////////////////////////
@@ -2446,10 +2287,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String interactivityQualityComment;
 
-	/**	<br> The entity interactivityQualityComment
+	/**	<br/> The entity interactivityQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:interactivityQualityComment">Find the entity interactivityQualityComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:interactivityQualityComment">Find the entity interactivityQualityComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _interactivityQualityComment(Wrap<String> w);
@@ -2472,20 +2313,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSearchInteractivityQualityComment(siteRequest_, CurrikiResource.staticSetInteractivityQualityComment(siteRequest_, o)));
-	}
-
-	public String sqlInteractivityQualityComment() {
-		return interactivityQualityComment;
+	public static String staticSolrFqInteractivityQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSolrInteractivityQualityComment(siteRequest_, CurrikiResource.staticSetInteractivityQualityComment(siteRequest_, o)));
 	}
 
 	//////////////////////////
@@ -2500,10 +2337,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer instructionalQuality;
 
-	/**	<br> The entity instructionalQuality
+	/**	<br/> The entity instructionalQuality
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:instructionalQuality">Find the entity instructionalQuality in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQuality">Find the entity instructionalQuality in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _instructionalQuality(Wrap<Integer> w);
@@ -2533,20 +2370,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrInstructionalQuality(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInstructionalQuality(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrInstructionalQuality(siteRequest_, CurrikiResource.staticSearchInstructionalQuality(siteRequest_, CurrikiResource.staticSetInstructionalQuality(siteRequest_, o)));
-	}
-
-	public Integer sqlInstructionalQuality() {
-		return instructionalQuality;
+	public static String staticSolrFqInstructionalQuality(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrInstructionalQuality(siteRequest_, CurrikiResource.staticSolrInstructionalQuality(siteRequest_, CurrikiResource.staticSetInstructionalQuality(siteRequest_, o)));
 	}
 
 	/////////////////////////////////
@@ -2560,10 +2393,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String instructionalQualityComment;
 
-	/**	<br> The entity instructionalQualityComment
+	/**	<br/> The entity instructionalQualityComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:instructionalQualityComment">Find the entity instructionalQualityComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:instructionalQualityComment">Find the entity instructionalQualityComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _instructionalQualityComment(Wrap<String> w);
@@ -2586,20 +2419,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSearchInstructionalQualityComment(siteRequest_, CurrikiResource.staticSetInstructionalQualityComment(siteRequest_, o)));
-	}
-
-	public String sqlInstructionalQualityComment() {
-		return instructionalQualityComment;
+	public static String staticSolrFqInstructionalQualityComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSolrInstructionalQualityComment(siteRequest_, CurrikiResource.staticSetInstructionalQualityComment(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -2614,10 +2443,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer deeperLearning;
 
-	/**	<br> The entity deeperLearning
+	/**	<br/> The entity deeperLearning
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:deeperLearning">Find the entity deeperLearning in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearning">Find the entity deeperLearning in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deeperLearning(Wrap<Integer> w);
@@ -2647,20 +2476,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrDeeperLearning(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDeeperLearning(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrDeeperLearning(siteRequest_, CurrikiResource.staticSearchDeeperLearning(siteRequest_, CurrikiResource.staticSetDeeperLearning(siteRequest_, o)));
-	}
-
-	public Integer sqlDeeperLearning() {
-		return deeperLearning;
+	public static String staticSolrFqDeeperLearning(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDeeperLearning(siteRequest_, CurrikiResource.staticSolrDeeperLearning(siteRequest_, CurrikiResource.staticSetDeeperLearning(siteRequest_, o)));
 	}
 
 	///////////////////////////
@@ -2674,10 +2499,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String deeperLearningComment;
 
-	/**	<br> The entity deeperLearningComment
+	/**	<br/> The entity deeperLearningComment
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:deeperLearningComment">Find the entity deeperLearningComment in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:deeperLearningComment">Find the entity deeperLearningComment in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _deeperLearningComment(Wrap<String> w);
@@ -2700,20 +2525,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrDeeperLearningComment(siteRequest_, CurrikiResource.staticSearchDeeperLearningComment(siteRequest_, CurrikiResource.staticSetDeeperLearningComment(siteRequest_, o)));
-	}
-
-	public String sqlDeeperLearningComment() {
-		return deeperLearningComment;
+	public static String staticSolrFqDeeperLearningComment(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDeeperLearningComment(siteRequest_, CurrikiResource.staticSolrDeeperLearningComment(siteRequest_, CurrikiResource.staticSetDeeperLearningComment(siteRequest_, o)));
 	}
 
 	/////////////
@@ -2727,10 +2548,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String partner;
 
-	/**	<br> The entity partner
+	/**	<br/> The entity partner
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:partner">Find the entity partner in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partner">Find the entity partner in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _partner(Wrap<String> w);
@@ -2753,20 +2574,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchPartner(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPartner(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPartner(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPartner(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPartner(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPartner(siteRequest_, CurrikiResource.staticSearchPartner(siteRequest_, CurrikiResource.staticSetPartner(siteRequest_, o)));
-	}
-
-	public String sqlPartner() {
-		return partner;
+	public static String staticSolrFqPartner(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPartner(siteRequest_, CurrikiResource.staticSolrPartner(siteRequest_, CurrikiResource.staticSetPartner(siteRequest_, o)));
 	}
 
 	////////////////
@@ -2777,16 +2594,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime createDate;
 
-	/**	<br> The entity createDate
+	/**	<br/> The entity createDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:createDate">Find the entity createDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:createDate">Find the entity createDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _createDate(Wrap<ZonedDateTime> w);
@@ -2808,8 +2625,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.createDate = CurrikiResource.staticSetCreateDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetCreateDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -2828,20 +2643,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchCreateDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrCreateDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrCreateDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrCreateDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqCreateDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrCreateDate(siteRequest_, CurrikiResource.staticSearchCreateDate(siteRequest_, CurrikiResource.staticSetCreateDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlCreateDate() {
-		return createDate == null ? null : createDate.toOffsetDateTime();
+	public static String staticSolrFqCreateDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrCreateDate(siteRequest_, CurrikiResource.staticSolrCreateDate(siteRequest_, CurrikiResource.staticSetCreateDate(siteRequest_, o)));
 	}
 
 	//////////
@@ -2855,10 +2666,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String type;
 
-	/**	<br> The entity type
+	/**	<br/> The entity type
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:type">Find the entity type in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:type">Find the entity type in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _type(Wrap<String> w);
@@ -2881,20 +2692,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrType(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrType(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqType(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrType(siteRequest_, CurrikiResource.staticSearchType(siteRequest_, CurrikiResource.staticSetType(siteRequest_, o)));
-	}
-
-	public String sqlType() {
-		return type;
+	public static String staticSolrFqType(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrType(siteRequest_, CurrikiResource.staticSolrType(siteRequest_, CurrikiResource.staticSetType(siteRequest_, o)));
 	}
 
 	//////////////
@@ -2908,10 +2715,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String featured;
 
-	/**	<br> The entity featured
+	/**	<br/> The entity featured
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:featured">Find the entity featured in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:featured">Find the entity featured in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _featured(Wrap<String> w);
@@ -2934,20 +2741,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchFeatured(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFeatured(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrFeatured(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrFeatured(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqFeatured(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrFeatured(siteRequest_, CurrikiResource.staticSearchFeatured(siteRequest_, CurrikiResource.staticSetFeatured(siteRequest_, o)));
-	}
-
-	public String sqlFeatured() {
-		return featured;
+	public static String staticSolrFqFeatured(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrFeatured(siteRequest_, CurrikiResource.staticSolrFeatured(siteRequest_, CurrikiResource.staticSetFeatured(siteRequest_, o)));
 	}
 
 	//////////
@@ -2961,10 +2764,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String page;
 
-	/**	<br> The entity page
+	/**	<br/> The entity page
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:page">Find the entity page in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:page">Find the entity page in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _page(Wrap<String> w);
@@ -2987,20 +2790,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchPage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPage(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPage(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPage(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPage(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPage(siteRequest_, CurrikiResource.staticSearchPage(siteRequest_, CurrikiResource.staticSetPage(siteRequest_, o)));
-	}
-
-	public String sqlPage() {
-		return page;
+	public static String staticSolrFqPage(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPage(siteRequest_, CurrikiResource.staticSolrPage(siteRequest_, CurrikiResource.staticSetPage(siteRequest_, o)));
 	}
 
 	////////////
@@ -3014,10 +2813,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String active;
 
-	/**	<br> The entity active
+	/**	<br/> The entity active
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:active">Find the entity active in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:active">Find the entity active in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _active(Wrap<String> w);
@@ -3040,20 +2839,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrActive(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrActive(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrActive(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqActive(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrActive(siteRequest_, CurrikiResource.staticSearchActive(siteRequest_, CurrikiResource.staticSetActive(siteRequest_, o)));
-	}
-
-	public String sqlActive() {
-		return active;
+	public static String staticSolrFqActive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrActive(siteRequest_, CurrikiResource.staticSolrActive(siteRequest_, CurrikiResource.staticSetActive(siteRequest_, o)));
 	}
 
 	////////////
@@ -3067,10 +2862,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String Public;
 
-	/**	<br> The entity Public
+	/**	<br/> The entity Public
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:Public">Find the entity Public in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:Public">Find the entity Public in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _Public(Wrap<String> w);
@@ -3093,20 +2888,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchPublic(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPublic(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPublic(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPublic(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPublic(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPublic(siteRequest_, CurrikiResource.staticSearchPublic(siteRequest_, CurrikiResource.staticSetPublic(siteRequest_, o)));
-	}
-
-	public String sqlPublic() {
-		return Public;
+	public static String staticSolrFqPublic(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPublic(siteRequest_, CurrikiResource.staticSolrPublic(siteRequest_, CurrikiResource.staticSetPublic(siteRequest_, o)));
 	}
 
 	////////////
@@ -3121,10 +2912,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer xwd_id;
 
-	/**	<br> The entity xwd_id
+	/**	<br/> The entity xwd_id
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:xwd_id">Find the entity xwd_id in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:xwd_id">Find the entity xwd_id in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _xwd_id(Wrap<Integer> w);
@@ -3154,20 +2945,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrXwd_id(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqXwd_id(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrXwd_id(siteRequest_, CurrikiResource.staticSearchXwd_id(siteRequest_, CurrikiResource.staticSetXwd_id(siteRequest_, o)));
-	}
-
-	public Integer sqlXwd_id() {
-		return xwd_id;
+	public static String staticSolrFqXwd_id(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrXwd_id(siteRequest_, CurrikiResource.staticSolrXwd_id(siteRequest_, CurrikiResource.staticSetXwd_id(siteRequest_, o)));
 	}
 
 	///////////////
@@ -3181,10 +2968,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String mediaType;
 
-	/**	<br> The entity mediaType
+	/**	<br/> The entity mediaType
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:mediaType">Find the entity mediaType in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:mediaType">Find the entity mediaType in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _mediaType(Wrap<String> w);
@@ -3207,20 +2994,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchMediaType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrMediaType(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrMediaType(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrMediaType(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqMediaType(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrMediaType(siteRequest_, CurrikiResource.staticSearchMediaType(siteRequest_, CurrikiResource.staticSetMediaType(siteRequest_, o)));
-	}
-
-	public String sqlMediaType() {
-		return mediaType;
+	public static String staticSolrFqMediaType(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrMediaType(siteRequest_, CurrikiResource.staticSolrMediaType(siteRequest_, CurrikiResource.staticSetMediaType(siteRequest_, o)));
 	}
 
 	////////////
@@ -3234,10 +3017,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String access;
 
-	/**	<br> The entity access
+	/**	<br/> The entity access
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:access">Find the entity access in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:access">Find the entity access in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _access(Wrap<String> w);
@@ -3260,20 +3043,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchAccess(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrAccess(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrAccess(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrAccess(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqAccess(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrAccess(siteRequest_, CurrikiResource.staticSearchAccess(siteRequest_, CurrikiResource.staticSetAccess(siteRequest_, o)));
-	}
-
-	public String sqlAccess() {
-		return access;
+	public static String staticSolrFqAccess(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrAccess(siteRequest_, CurrikiResource.staticSolrAccess(siteRequest_, CurrikiResource.staticSetAccess(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -3288,10 +3067,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected BigDecimal memberRating;
 
-	/**	<br> The entity memberRating
+	/**	<br/> The entity memberRating
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:memberRating">Find the entity memberRating in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:memberRating">Find the entity memberRating in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _memberRating(Wrap<BigDecimal> w);
@@ -3330,20 +3109,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Double staticSearchMemberRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
+	public static Double staticSolrMemberRating(SiteRequestEnUS siteRequest_, BigDecimal o) {
 		return o == null ? null : o.doubleValue();
 	}
 
-	public static String staticSearchStrMemberRating(SiteRequestEnUS siteRequest_, Double o) {
+	public static String staticSolrStrMemberRating(SiteRequestEnUS siteRequest_, Double o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqMemberRating(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrMemberRating(siteRequest_, CurrikiResource.staticSearchMemberRating(siteRequest_, CurrikiResource.staticSetMemberRating(siteRequest_, o)));
-	}
-
-	public BigDecimal sqlMemberRating() {
-		return memberRating;
+	public static String staticSolrFqMemberRating(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrMemberRating(siteRequest_, CurrikiResource.staticSolrMemberRating(siteRequest_, CurrikiResource.staticSetMemberRating(siteRequest_, o)));
 	}
 
 	/////////////
@@ -3357,10 +3132,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String aligned;
 
-	/**	<br> The entity aligned
+	/**	<br/> The entity aligned
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:aligned">Find the entity aligned in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:aligned">Find the entity aligned in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _aligned(Wrap<String> w);
@@ -3383,20 +3158,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchAligned(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrAligned(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrAligned(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrAligned(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqAligned(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrAligned(siteRequest_, CurrikiResource.staticSearchAligned(siteRequest_, CurrikiResource.staticSetAligned(siteRequest_, o)));
-	}
-
-	public String sqlAligned() {
-		return aligned;
+	public static String staticSolrFqAligned(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrAligned(siteRequest_, CurrikiResource.staticSolrAligned(siteRequest_, CurrikiResource.staticSetAligned(siteRequest_, o)));
 	}
 
 	/////////////
@@ -3410,10 +3181,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUrl;
 
-	/**	<br> The entity pageUrl
+	/**	<br/> The entity pageUrl
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:pageUrl">Find the entity pageUrl in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUrl">Find the entity pageUrl in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUrl(Wrap<String> w);
@@ -3436,20 +3207,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchPageUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPageUrl(siteRequest_, CurrikiResource.staticSearchPageUrl(siteRequest_, CurrikiResource.staticSetPageUrl(siteRequest_, o)));
-	}
-
-	public String sqlPageUrl() {
-		return pageUrl;
+	public static String staticSolrFqPageUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPageUrl(siteRequest_, CurrikiResource.staticSolrPageUrl(siteRequest_, CurrikiResource.staticSetPageUrl(siteRequest_, o)));
 	}
 
 	/////////////
@@ -3463,10 +3230,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String indexed;
 
-	/**	<br> The entity indexed
+	/**	<br/> The entity indexed
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:indexed">Find the entity indexed in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexed">Find the entity indexed in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexed(Wrap<String> w);
@@ -3489,20 +3256,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchIndexed(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrIndexed(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrIndexed(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrIndexed(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqIndexed(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrIndexed(siteRequest_, CurrikiResource.staticSearchIndexed(siteRequest_, CurrikiResource.staticSetIndexed(siteRequest_, o)));
-	}
-
-	public String sqlIndexed() {
-		return indexed;
+	public static String staticSolrFqIndexed(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrIndexed(siteRequest_, CurrikiResource.staticSolrIndexed(siteRequest_, CurrikiResource.staticSetIndexed(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -3513,16 +3276,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime lastIndexDate;
 
-	/**	<br> The entity lastIndexDate
+	/**	<br/> The entity lastIndexDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:lastIndexDate">Find the entity lastIndexDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lastIndexDate">Find the entity lastIndexDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _lastIndexDate(Wrap<ZonedDateTime> w);
@@ -3544,8 +3307,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.lastIndexDate = CurrikiResource.staticSetLastIndexDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -3564,20 +3325,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchLastIndexDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrLastIndexDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrLastIndexDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrLastIndexDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrLastIndexDate(siteRequest_, CurrikiResource.staticSearchLastIndexDate(siteRequest_, CurrikiResource.staticSetLastIndexDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlLastIndexDate() {
-		return lastIndexDate == null ? null : lastIndexDate.toOffsetDateTime();
+	public static String staticSolrFqLastIndexDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLastIndexDate(siteRequest_, CurrikiResource.staticSolrLastIndexDate(siteRequest_, CurrikiResource.staticSetLastIndexDate(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -3591,10 +3348,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String indexRequired;
 
-	/**	<br> The entity indexRequired
+	/**	<br/> The entity indexRequired
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:indexRequired">Find the entity indexRequired in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequired">Find the entity indexRequired in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexRequired(Wrap<String> w);
@@ -3617,20 +3374,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrIndexRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqIndexRequired(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrIndexRequired(siteRequest_, CurrikiResource.staticSearchIndexRequired(siteRequest_, CurrikiResource.staticSetIndexRequired(siteRequest_, o)));
-	}
-
-	public String sqlIndexRequired() {
-		return indexRequired;
+	public static String staticSolrFqIndexRequired(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrIndexRequired(siteRequest_, CurrikiResource.staticSolrIndexRequired(siteRequest_, CurrikiResource.staticSetIndexRequired(siteRequest_, o)));
 	}
 
 	///////////////////////
@@ -3641,16 +3394,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime indexRequiredDate;
 
-	/**	<br> The entity indexRequiredDate
+	/**	<br/> The entity indexRequiredDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:indexRequiredDate">Find the entity indexRequiredDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:indexRequiredDate">Find the entity indexRequiredDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _indexRequiredDate(Wrap<ZonedDateTime> w);
@@ -3672,8 +3425,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.indexRequiredDate = CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -3692,20 +3443,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchIndexRequiredDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrIndexRequiredDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrIndexRequiredDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrIndexRequiredDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrIndexRequiredDate(siteRequest_, CurrikiResource.staticSearchIndexRequiredDate(siteRequest_, CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlIndexRequiredDate() {
-		return indexRequiredDate == null ? null : indexRequiredDate.toOffsetDateTime();
+	public static String staticSolrFqIndexRequiredDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrIndexRequiredDate(siteRequest_, CurrikiResource.staticSolrIndexRequiredDate(siteRequest_, CurrikiResource.staticSetIndexRequiredDate(siteRequest_, o)));
 	}
 
 	//////////////
@@ -3719,10 +3466,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String rescrape;
 
-	/**	<br> The entity rescrape
+	/**	<br/> The entity rescrape
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:rescrape">Find the entity rescrape in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rescrape">Find the entity rescrape in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _rescrape(Wrap<String> w);
@@ -3745,20 +3492,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchRescrape(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRescrape(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRescrape(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRescrape(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRescrape(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrRescrape(siteRequest_, CurrikiResource.staticSearchRescrape(siteRequest_, CurrikiResource.staticSetRescrape(siteRequest_, o)));
-	}
-
-	public String sqlRescrape() {
-		return rescrape;
+	public static String staticSolrFqRescrape(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrRescrape(siteRequest_, CurrikiResource.staticSolrRescrape(siteRequest_, CurrikiResource.staticSetRescrape(siteRequest_, o)));
 	}
 
 	//////////////
@@ -3772,10 +3515,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String goButton;
 
-	/**	<br> The entity goButton
+	/**	<br/> The entity goButton
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:goButton">Find the entity goButton in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:goButton">Find the entity goButton in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _goButton(Wrap<String> w);
@@ -3798,20 +3541,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchGoButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrGoButton(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrGoButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrGoButton(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqGoButton(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrGoButton(siteRequest_, CurrikiResource.staticSearchGoButton(siteRequest_, CurrikiResource.staticSetGoButton(siteRequest_, o)));
-	}
-
-	public String sqlGoButton() {
-		return goButton;
+	public static String staticSolrFqGoButton(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrGoButton(siteRequest_, CurrikiResource.staticSolrGoButton(siteRequest_, CurrikiResource.staticSetGoButton(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -3825,10 +3564,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String downloadButton;
 
-	/**	<br> The entity downloadButton
+	/**	<br/> The entity downloadButton
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:downloadButton">Find the entity downloadButton in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:downloadButton">Find the entity downloadButton in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _downloadButton(Wrap<String> w);
@@ -3851,20 +3590,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrDownloadButton(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDownloadButton(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrDownloadButton(siteRequest_, CurrikiResource.staticSearchDownloadButton(siteRequest_, CurrikiResource.staticSetDownloadButton(siteRequest_, o)));
-	}
-
-	public String sqlDownloadButton() {
-		return downloadButton;
+	public static String staticSolrFqDownloadButton(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDownloadButton(siteRequest_, CurrikiResource.staticSolrDownloadButton(siteRequest_, CurrikiResource.staticSetDownloadButton(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -3878,10 +3613,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String topOfSearch;
 
-	/**	<br> The entity topOfSearch
+	/**	<br/> The entity topOfSearch
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:topOfSearch">Find the entity topOfSearch in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearch">Find the entity topOfSearch in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _topOfSearch(Wrap<String> w);
@@ -3904,20 +3639,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrTopOfSearch(siteRequest_, CurrikiResource.staticSearchTopOfSearch(siteRequest_, CurrikiResource.staticSetTopOfSearch(siteRequest_, o)));
-	}
-
-	public String sqlTopOfSearch() {
-		return topOfSearch;
+	public static String staticSolrFqTopOfSearch(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTopOfSearch(siteRequest_, CurrikiResource.staticSolrTopOfSearch(siteRequest_, CurrikiResource.staticSetTopOfSearch(siteRequest_, o)));
 	}
 
 	////////////
@@ -3931,10 +3662,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String remove;
 
-	/**	<br> The entity remove
+	/**	<br/> The entity remove
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:remove">Find the entity remove in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:remove">Find the entity remove in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _remove(Wrap<String> w);
@@ -3957,20 +3688,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchRemove(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRemove(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRemove(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRemove(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRemove(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrRemove(siteRequest_, CurrikiResource.staticSearchRemove(siteRequest_, CurrikiResource.staticSetRemove(siteRequest_, o)));
-	}
-
-	public String sqlRemove() {
-		return remove;
+	public static String staticSolrFqRemove(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrRemove(siteRequest_, CurrikiResource.staticSolrRemove(siteRequest_, CurrikiResource.staticSetRemove(siteRequest_, o)));
 	}
 
 	//////////
@@ -3984,10 +3711,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String spam;
 
-	/**	<br> The entity spam
+	/**	<br/> The entity spam
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:spam">Find the entity spam in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spam">Find the entity spam in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _spam(Wrap<String> w);
@@ -4010,20 +3737,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchSpam(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSpam(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSpam(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSpam(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSpam(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSpam(siteRequest_, CurrikiResource.staticSearchSpam(siteRequest_, CurrikiResource.staticSetSpam(siteRequest_, o)));
-	}
-
-	public String sqlSpam() {
-		return spam;
+	public static String staticSolrFqSpam(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSpam(siteRequest_, CurrikiResource.staticSolrSpam(siteRequest_, CurrikiResource.staticSetSpam(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -4038,10 +3761,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer topOfSearchInt;
 
-	/**	<br> The entity topOfSearchInt
+	/**	<br/> The entity topOfSearchInt
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:topOfSearchInt">Find the entity topOfSearchInt in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:topOfSearchInt">Find the entity topOfSearchInt in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _topOfSearchInt(Wrap<Integer> w);
@@ -4071,20 +3794,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrTopOfSearchInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqTopOfSearchInt(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrTopOfSearchInt(siteRequest_, CurrikiResource.staticSearchTopOfSearchInt(siteRequest_, CurrikiResource.staticSetTopOfSearchInt(siteRequest_, o)));
-	}
-
-	public Integer sqlTopOfSearchInt() {
-		return topOfSearchInt;
+	public static String staticSolrFqTopOfSearchInt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTopOfSearchInt(siteRequest_, CurrikiResource.staticSolrTopOfSearchInt(siteRequest_, CurrikiResource.staticSetTopOfSearchInt(siteRequest_, o)));
 	}
 
 	////////////////
@@ -4099,10 +3818,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer partnerInt;
 
-	/**	<br> The entity partnerInt
+	/**	<br/> The entity partnerInt
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:partnerInt">Find the entity partnerInt in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:partnerInt">Find the entity partnerInt in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _partnerInt(Wrap<Integer> w);
@@ -4132,20 +3851,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrPartnerInt(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPartnerInt(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrPartnerInt(siteRequest_, CurrikiResource.staticSearchPartnerInt(siteRequest_, CurrikiResource.staticSetPartnerInt(siteRequest_, o)));
-	}
-
-	public Integer sqlPartnerInt() {
-		return partnerInt;
+	public static String staticSolrFqPartnerInt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrPartnerInt(siteRequest_, CurrikiResource.staticSolrPartnerInt(siteRequest_, CurrikiResource.staticSetPartnerInt(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -4159,10 +3874,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String reviewResource;
 
-	/**	<br> The entity reviewResource
+	/**	<br/> The entity reviewResource
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:reviewResource">Find the entity reviewResource in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:reviewResource">Find the entity reviewResource in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _reviewResource(Wrap<String> w);
@@ -4185,20 +3900,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchReviewResource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrReviewResource(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrReviewResource(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrReviewResource(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqReviewResource(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrReviewResource(siteRequest_, CurrikiResource.staticSearchReviewResource(siteRequest_, CurrikiResource.staticSetReviewResource(siteRequest_, o)));
-	}
-
-	public String sqlReviewResource() {
-		return reviewResource;
+	public static String staticSolrFqReviewResource(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrReviewResource(siteRequest_, CurrikiResource.staticSolrReviewResource(siteRequest_, CurrikiResource.staticSetReviewResource(siteRequest_, o)));
 	}
 
 	////////////
@@ -4212,10 +3923,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String oldUrl;
 
-	/**	<br> The entity oldUrl
+	/**	<br/> The entity oldUrl
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:oldUrl">Find the entity oldUrl in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:oldUrl">Find the entity oldUrl in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _oldUrl(Wrap<String> w);
@@ -4238,20 +3949,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchOldUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrOldUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrOldUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrOldUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqOldUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrOldUrl(siteRequest_, CurrikiResource.staticSearchOldUrl(siteRequest_, CurrikiResource.staticSetOldUrl(siteRequest_, o)));
-	}
-
-	public String sqlOldUrl() {
-		return oldUrl;
+	public static String staticSolrFqOldUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrOldUrl(siteRequest_, CurrikiResource.staticSolrOldUrl(siteRequest_, CurrikiResource.staticSetOldUrl(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -4265,10 +3972,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String contentDisplayOk;
 
-	/**	<br> The entity contentDisplayOk
+	/**	<br/> The entity contentDisplayOk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:contentDisplayOk">Find the entity contentDisplayOk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contentDisplayOk">Find the entity contentDisplayOk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contentDisplayOk(Wrap<String> w);
@@ -4291,20 +3998,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrContentDisplayOk(siteRequest_, CurrikiResource.staticSearchContentDisplayOk(siteRequest_, CurrikiResource.staticSetContentDisplayOk(siteRequest_, o)));
-	}
-
-	public String sqlContentDisplayOk() {
-		return contentDisplayOk;
+	public static String staticSolrFqContentDisplayOk(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrContentDisplayOk(siteRequest_, CurrikiResource.staticSolrContentDisplayOk(siteRequest_, CurrikiResource.staticSetContentDisplayOk(siteRequest_, o)));
 	}
 
 	//////////////
@@ -4318,10 +4021,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String metadata;
 
-	/**	<br> The entity metadata
+	/**	<br/> The entity metadata
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:metadata">Find the entity metadata in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:metadata">Find the entity metadata in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _metadata(Wrap<String> w);
@@ -4344,20 +4047,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchMetadata(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrMetadata(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrMetadata(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrMetadata(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqMetadata(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrMetadata(siteRequest_, CurrikiResource.staticSearchMetadata(siteRequest_, CurrikiResource.staticSetMetadata(siteRequest_, o)));
-	}
-
-	public String sqlMetadata() {
-		return metadata;
+	public static String staticSolrFqMetadata(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrMetadata(siteRequest_, CurrikiResource.staticSolrMetadata(siteRequest_, CurrikiResource.staticSetMetadata(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -4371,10 +4070,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String approvalStatus;
 
-	/**	<br> The entity approvalStatus
+	/**	<br/> The entity approvalStatus
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:approvalStatus">Find the entity approvalStatus in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatus">Find the entity approvalStatus in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _approvalStatus(Wrap<String> w);
@@ -4397,20 +4096,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrApprovalStatus(siteRequest_, CurrikiResource.staticSearchApprovalStatus(siteRequest_, CurrikiResource.staticSetApprovalStatus(siteRequest_, o)));
-	}
-
-	public String sqlApprovalStatus() {
-		return approvalStatus;
+	public static String staticSolrFqApprovalStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrApprovalStatus(siteRequest_, CurrikiResource.staticSolrApprovalStatus(siteRequest_, CurrikiResource.staticSetApprovalStatus(siteRequest_, o)));
 	}
 
 	////////////////////////
@@ -4421,16 +4116,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	 *	 is defined as null before being initialized. 
 	 */
 	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonDeserialize(using = ZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ZonedDateTimeSerializer.class)
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
 	@JsonInclude(Include.NON_NULL)
 	protected ZonedDateTime approvalStatusDate;
 
-	/**	<br> The entity approvalStatusDate
+	/**	<br/> The entity approvalStatusDate
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:approvalStatusDate">Find the entity approvalStatusDate in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:approvalStatusDate">Find the entity approvalStatusDate in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _approvalStatusDate(Wrap<ZonedDateTime> w);
@@ -4452,8 +4147,6 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		this.approvalStatusDate = CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o);
 	}
 	public static ZonedDateTime staticSetApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
 		if(StringUtils.endsWith(o, "Z"))
 			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
 		else
@@ -4472,20 +4165,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Date staticSearchApprovalStatusDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+	public static Date staticSolrApprovalStatusDate(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
 		return o == null ? null : Date.from(o.toInstant());
 	}
 
-	public static String staticSearchStrApprovalStatusDate(SiteRequestEnUS siteRequest_, Date o) {
+	public static String staticSolrStrApprovalStatusDate(SiteRequestEnUS siteRequest_, Date o) {
 		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
 	}
 
-	public static String staticSearchFqApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrApprovalStatusDate(siteRequest_, CurrikiResource.staticSearchApprovalStatusDate(siteRequest_, CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o)));
-	}
-
-	public OffsetDateTime sqlApprovalStatusDate() {
-		return approvalStatusDate == null ? null : approvalStatusDate.toOffsetDateTime();
+	public static String staticSolrFqApprovalStatusDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrApprovalStatusDate(siteRequest_, CurrikiResource.staticSolrApprovalStatusDate(siteRequest_, CurrikiResource.staticSetApprovalStatusDate(siteRequest_, o)));
 	}
 
 	//////////////
@@ -4499,10 +4188,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String spamUser;
 
-	/**	<br> The entity spamUser
+	/**	<br/> The entity spamUser
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:spamUser">Find the entity spamUser in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:spamUser">Find the entity spamUser in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _spamUser(Wrap<String> w);
@@ -4525,20 +4214,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchSpamUser(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSpamUser(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSpamUser(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSpamUser(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSpamUser(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrSpamUser(siteRequest_, CurrikiResource.staticSearchSpamUser(siteRequest_, CurrikiResource.staticSetSpamUser(siteRequest_, o)));
-	}
-
-	public String sqlSpamUser() {
-		return spamUser;
+	public static String staticSolrFqSpamUser(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSpamUser(siteRequest_, CurrikiResource.staticSolrSpamUser(siteRequest_, CurrikiResource.staticSetSpamUser(siteRequest_, o)));
 	}
 
 	/////////
@@ -4552,10 +4237,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String url;
 
-	/**	<br> The entity url
+	/**	<br/> The entity url
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:url">Find the entity url in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:url">Find the entity url in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _url(Wrap<String> w);
@@ -4578,20 +4263,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static String staticSearchUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUrl(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrUrl(siteRequest_, CurrikiResource.staticSearchUrl(siteRequest_, CurrikiResource.staticSetUrl(siteRequest_, o)));
-	}
-
-	public String sqlUrl() {
-		return url;
+	public static String staticSolrFqUrl(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrUrl(siteRequest_, CurrikiResource.staticSolrUrl(siteRequest_, CurrikiResource.staticSetUrl(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -4606,10 +4287,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer displaySeqNo;
 
-	/**	<br> The entity displaySeqNo
+	/**	<br/> The entity displaySeqNo
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:displaySeqNo">Find the entity displaySeqNo in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:displaySeqNo">Find the entity displaySeqNo in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _displaySeqNo(Wrap<Integer> w);
@@ -4639,20 +4320,16 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrDisplaySeqNo(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqDisplaySeqNo(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrDisplaySeqNo(siteRequest_, CurrikiResource.staticSearchDisplaySeqNo(siteRequest_, CurrikiResource.staticSetDisplaySeqNo(siteRequest_, o)));
-	}
-
-	public Integer sqlDisplaySeqNo() {
-		return displaySeqNo;
+	public static String staticSolrFqDisplaySeqNo(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDisplaySeqNo(siteRequest_, CurrikiResource.staticSolrDisplaySeqNo(siteRequest_, CurrikiResource.staticSetDisplaySeqNo(siteRequest_, o)));
 	}
 
 	////////////
@@ -4667,10 +4344,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer fileId;
 
-	/**	<br> The entity fileId
+	/**	<br/> The entity fileId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=entiteVar_enUS_indexed_string:fileId">Find the entity fileId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileId">Find the entity fileId in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _fileId(Wrap<Integer> w);
@@ -4700,20 +4377,759 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		return (CurrikiResource)this;
 	}
 
-	public static Integer staticSearchFileId(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrFileId(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrFileId(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrFileId(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqFileId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResource.staticSearchStrFileId(siteRequest_, CurrikiResource.staticSearchFileId(siteRequest_, CurrikiResource.staticSetFileId(siteRequest_, o)));
+	public static String staticSolrFqFileId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrFileId(siteRequest_, CurrikiResource.staticSolrFileId(siteRequest_, CurrikiResource.staticSetFileId(siteRequest_, o)));
 	}
 
-	public Integer sqlFileId() {
-		return fileId;
+	//////////////
+	// fileName //
+	//////////////
+
+	/**	 The entity fileName
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String fileName;
+
+	/**	<br/> The entity fileName
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:fileName">Find the entity fileName in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _fileName(Wrap<String> w);
+
+	public String getFileName() {
+		return fileName;
+	}
+	public void setFileName(String o) {
+		this.fileName = CurrikiResource.staticSetFileName(siteRequest_, o);
+	}
+	public static String staticSetFileName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource fileNameInit() {
+		Wrap<String> fileNameWrap = new Wrap<String>().var("fileName");
+		if(fileName == null) {
+			_fileName(fileNameWrap);
+			setFileName(fileNameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrFileName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrFileName(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqFileName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrFileName(siteRequest_, CurrikiResource.staticSolrFileName(siteRequest_, CurrikiResource.staticSetFileName(siteRequest_, o)));
+	}
+
+	////////////////
+	// uploadDate //
+	////////////////
+
+	/**	 The entity uploadDate
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String uploadDate;
+
+	/**	<br/> The entity uploadDate
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uploadDate">Find the entity uploadDate in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _uploadDate(Wrap<String> w);
+
+	public String getUploadDate() {
+		return uploadDate;
+	}
+	public void setUploadDate(String o) {
+		this.uploadDate = CurrikiResource.staticSetUploadDate(siteRequest_, o);
+	}
+	public static String staticSetUploadDate(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource uploadDateInit() {
+		Wrap<String> uploadDateWrap = new Wrap<String>().var("uploadDate");
+		if(uploadDate == null) {
+			_uploadDate(uploadDateWrap);
+			setUploadDate(uploadDateWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrUploadDate(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrUploadDate(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqUploadDate(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrUploadDate(siteRequest_, CurrikiResource.staticSolrUploadDate(siteRequest_, CurrikiResource.staticSetUploadDate(siteRequest_, o)));
+	}
+
+	//////////////
+	// sequence //
+	//////////////
+
+	/**	 The entity sequence
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer sequence;
+
+	/**	<br/> The entity sequence
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sequence">Find the entity sequence in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _sequence(Wrap<Integer> w);
+
+	public Integer getSequence() {
+		return sequence;
+	}
+
+	public void setSequence(Integer sequence) {
+		this.sequence = sequence;
+	}
+	@JsonIgnore
+	public void setSequence(String o) {
+		this.sequence = CurrikiResource.staticSetSequence(siteRequest_, o);
+	}
+	public static Integer staticSetSequence(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResource sequenceInit() {
+		Wrap<Integer> sequenceWrap = new Wrap<Integer>().var("sequence");
+		if(sequence == null) {
+			_sequence(sequenceWrap);
+			setSequence(sequenceWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static Integer staticSolrSequence(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSolrStrSequence(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqSequence(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSequence(siteRequest_, CurrikiResource.staticSolrSequence(siteRequest_, CurrikiResource.staticSetSequence(siteRequest_, o)));
+	}
+
+	////////////////
+	// uniqueName //
+	////////////////
+
+	/**	 The entity uniqueName
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String uniqueName;
+
+	/**	<br/> The entity uniqueName
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:uniqueName">Find the entity uniqueName in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _uniqueName(Wrap<String> w);
+
+	public String getUniqueName() {
+		return uniqueName;
+	}
+	public void setUniqueName(String o) {
+		this.uniqueName = CurrikiResource.staticSetUniqueName(siteRequest_, o);
+	}
+	public static String staticSetUniqueName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource uniqueNameInit() {
+		Wrap<String> uniqueNameWrap = new Wrap<String>().var("uniqueName");
+		if(uniqueName == null) {
+			_uniqueName(uniqueNameWrap);
+			setUniqueName(uniqueNameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrUniqueName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrUniqueName(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqUniqueName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrUniqueName(siteRequest_, CurrikiResource.staticSolrUniqueName(siteRequest_, CurrikiResource.staticSetUniqueName(siteRequest_, o)));
+	}
+
+	/////////
+	// ext //
+	/////////
+
+	/**	 The entity ext
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String ext;
+
+	/**	<br/> The entity ext
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:ext">Find the entity ext in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _ext(Wrap<String> w);
+
+	public String getExt() {
+		return ext;
+	}
+	public void setExt(String o) {
+		this.ext = CurrikiResource.staticSetExt(siteRequest_, o);
+	}
+	public static String staticSetExt(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource extInit() {
+		Wrap<String> extWrap = new Wrap<String>().var("ext");
+		if(ext == null) {
+			_ext(extWrap);
+			setExt(extWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrExt(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrExt(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqExt(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrExt(siteRequest_, CurrikiResource.staticSolrExt(siteRequest_, CurrikiResource.staticSetExt(siteRequest_, o)));
+	}
+
+	////////////////
+	// tempactive //
+	////////////////
+
+	/**	 The entity tempactive
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String tempactive;
+
+	/**	<br/> The entity tempactive
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:tempactive">Find the entity tempactive in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _tempactive(Wrap<String> w);
+
+	public String getTempactive() {
+		return tempactive;
+	}
+	public void setTempactive(String o) {
+		this.tempactive = CurrikiResource.staticSetTempactive(siteRequest_, o);
+	}
+	public static String staticSetTempactive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource tempactiveInit() {
+		Wrap<String> tempactiveWrap = new Wrap<String>().var("tempactive");
+		if(tempactive == null) {
+			_tempactive(tempactiveWrap);
+			setTempactive(tempactiveWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrTempactive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrTempactive(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqTempactive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTempactive(siteRequest_, CurrikiResource.staticSolrTempactive(siteRequest_, CurrikiResource.staticSetTempactive(siteRequest_, o)));
+	}
+
+	////////////
+	// s3path //
+	////////////
+
+	/**	 The entity s3path
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String s3path;
+
+	/**	<br/> The entity s3path
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:s3path">Find the entity s3path in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _s3path(Wrap<String> w);
+
+	public String getS3path() {
+		return s3path;
+	}
+	public void setS3path(String o) {
+		this.s3path = CurrikiResource.staticSetS3path(siteRequest_, o);
+	}
+	public static String staticSetS3path(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource s3pathInit() {
+		Wrap<String> s3pathWrap = new Wrap<String>().var("s3path");
+		if(s3path == null) {
+			_s3path(s3pathWrap);
+			setS3path(s3pathWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrS3path(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrS3path(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqS3path(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrS3path(siteRequest_, CurrikiResource.staticSolrS3path(siteRequest_, CurrikiResource.staticSetS3path(siteRequest_, o)));
+	}
+
+	///////////////
+	// sdfStatus //
+	///////////////
+
+	/**	 The entity sdfStatus
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String sdfStatus;
+
+	/**	<br/> The entity sdfStatus
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sdfStatus">Find the entity sdfStatus in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _sdfStatus(Wrap<String> w);
+
+	public String getSdfStatus() {
+		return sdfStatus;
+	}
+	public void setSdfStatus(String o) {
+		this.sdfStatus = CurrikiResource.staticSetSdfStatus(siteRequest_, o);
+	}
+	public static String staticSetSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource sdfStatusInit() {
+		Wrap<String> sdfStatusWrap = new Wrap<String>().var("sdfStatus");
+		if(sdfStatus == null) {
+			_sdfStatus(sdfStatusWrap);
+			setSdfStatus(sdfStatusWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqSdfStatus(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSdfStatus(siteRequest_, CurrikiResource.staticSolrSdfStatus(siteRequest_, CurrikiResource.staticSetSdfStatus(siteRequest_, o)));
+	}
+
+	////////////////
+	// transcoded //
+	////////////////
+
+	/**	 The entity transcoded
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String transcoded;
+
+	/**	<br/> The entity transcoded
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:transcoded">Find the entity transcoded in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _transcoded(Wrap<String> w);
+
+	public String getTranscoded() {
+		return transcoded;
+	}
+	public void setTranscoded(String o) {
+		this.transcoded = CurrikiResource.staticSetTranscoded(siteRequest_, o);
+	}
+	public static String staticSetTranscoded(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource transcodedInit() {
+		Wrap<String> transcodedWrap = new Wrap<String>().var("transcoded");
+		if(transcoded == null) {
+			_transcoded(transcodedWrap);
+			setTranscoded(transcodedWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrTranscoded(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrTranscoded(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqTranscoded(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrTranscoded(siteRequest_, CurrikiResource.staticSolrTranscoded(siteRequest_, CurrikiResource.staticSetTranscoded(siteRequest_, o)));
+	}
+
+	//////////////
+	// lodestar //
+	//////////////
+
+	/**	 The entity lodestar
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String lodestar;
+
+	/**	<br/> The entity lodestar
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lodestar">Find the entity lodestar in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _lodestar(Wrap<String> w);
+
+	public String getLodestar() {
+		return lodestar;
+	}
+	public void setLodestar(String o) {
+		this.lodestar = CurrikiResource.staticSetLodestar(siteRequest_, o);
+	}
+	public static String staticSetLodestar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource lodestarInit() {
+		Wrap<String> lodestarWrap = new Wrap<String>().var("lodestar");
+		if(lodestar == null) {
+			_lodestar(lodestarWrap);
+			setLodestar(lodestarWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrLodestar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrLodestar(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqLodestar(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrLodestar(siteRequest_, CurrikiResource.staticSolrLodestar(siteRequest_, CurrikiResource.staticSetLodestar(siteRequest_, o)));
+	}
+
+	/////////////
+	// archive //
+	/////////////
+
+	/**	 The entity archive
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String archive;
+
+	/**	<br/> The entity archive
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:archive">Find the entity archive in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _archive(Wrap<String> w);
+
+	public String getArchive() {
+		return archive;
+	}
+	public void setArchive(String o) {
+		this.archive = CurrikiResource.staticSetArchive(siteRequest_, o);
+	}
+	public static String staticSetArchive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource archiveInit() {
+		Wrap<String> archiveWrap = new Wrap<String>().var("archive");
+		if(archive == null) {
+			_archive(archiveWrap);
+			setArchive(archiveWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrArchive(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrArchive(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqArchive(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrArchive(siteRequest_, CurrikiResource.staticSolrArchive(siteRequest_, CurrikiResource.staticSetArchive(siteRequest_, o)));
+	}
+
+	////////////////
+	// identifier //
+	////////////////
+
+	/**	 The entity identifier
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String identifier;
+
+	/**	<br/> The entity identifier
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:identifier">Find the entity identifier in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _identifier(Wrap<String> w);
+
+	public String getIdentifier() {
+		return identifier;
+	}
+	public void setIdentifier(String o) {
+		this.identifier = CurrikiResource.staticSetIdentifier(siteRequest_, o);
+	}
+	public static String staticSetIdentifier(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource identifierInit() {
+		Wrap<String> identifierWrap = new Wrap<String>().var("identifier");
+		if(identifier == null) {
+			_identifier(identifierWrap);
+			setIdentifier(identifierWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrIdentifier(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrIdentifier(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqIdentifier(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrIdentifier(siteRequest_, CurrikiResource.staticSolrIdentifier(siteRequest_, CurrikiResource.staticSetIdentifier(siteRequest_, o)));
+	}
+
+	/////////////////
+	// displayName //
+	/////////////////
+
+	/**	 The entity displayName
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String displayName;
+
+	/**	<br/> The entity displayName
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:displayName">Find the entity displayName in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _displayName(Wrap<String> w);
+
+	public String getDisplayName() {
+		return displayName;
+	}
+	public void setDisplayName(String o) {
+		this.displayName = CurrikiResource.staticSetDisplayName(siteRequest_, o);
+	}
+	public static String staticSetDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource displayNameInit() {
+		Wrap<String> displayNameWrap = new Wrap<String>().var("displayName");
+		if(displayName == null) {
+			_displayName(displayNameWrap);
+			setDisplayName(displayNameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqDisplayName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrDisplayName(siteRequest_, CurrikiResource.staticSolrDisplayName(siteRequest_, CurrikiResource.staticSetDisplayName(siteRequest_, o)));
+	}
+
+	/////////////////
+	// subjectArea //
+	/////////////////
+
+	/**	 The entity subjectArea
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String subjectArea;
+
+	/**	<br/> The entity subjectArea
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:subjectArea">Find the entity subjectArea in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _subjectArea(Wrap<String> w);
+
+	public String getSubjectArea() {
+		return subjectArea;
+	}
+	public void setSubjectArea(String o) {
+		this.subjectArea = CurrikiResource.staticSetSubjectArea(siteRequest_, o);
+	}
+	public static String staticSetSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource subjectAreaInit() {
+		Wrap<String> subjectAreaWrap = new Wrap<String>().var("subjectArea");
+		if(subjectArea == null) {
+			_subjectArea(subjectAreaWrap);
+			setSubjectArea(subjectAreaWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqSubjectArea(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, CurrikiResource.staticSolrSubjectArea(siteRequest_, CurrikiResource.staticSetSubjectArea(siteRequest_, o)));
+	}
+
+	//////////
+	// name //
+	//////////
+
+	/**	 The entity name
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String name;
+
+	/**	<br/> The entity name
+	 *  is defined as null before being initialized. 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResource&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:name">Find the entity name in Solr</a>
+	 * <br/>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _name(Wrap<String> w);
+
+	public String getName() {
+		return name;
+	}
+	public void setName(String o) {
+		this.name = CurrikiResource.staticSetName(siteRequest_, o);
+	}
+	public static String staticSetName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResource nameInit() {
+		Wrap<String> nameWrap = new Wrap<String>().var("name");
+		if(name == null) {
+			_name(nameWrap);
+			setName(nameWrap.o);
+		}
+		return (CurrikiResource)this;
+	}
+
+	public static String staticSolrName(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSolrStrName(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSolrFqName(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResource.staticSolrStrName(siteRequest_, CurrikiResource.staticSolrName(siteRequest_, CurrikiResource.staticSetName(siteRequest_, o)));
 	}
 
 	//////////////
@@ -4825,6 +5241,21 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				urlInit();
 				displaySeqNoInit();
 				fileIdInit();
+				fileNameInit();
+				uploadDateInit();
+				sequenceInit();
+				uniqueNameInit();
+				extInit();
+				tempactiveInit();
+				s3pathInit();
+				sdfStatusInit();
+				transcodedInit();
+				lodestarInit();
+				archiveInit();
+				identifierInit();
+				displayNameInit();
+				subjectAreaInit();
+				nameInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -5038,6 +5469,36 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return oCurrikiResource.displaySeqNo;
 			case "fileId":
 				return oCurrikiResource.fileId;
+			case "fileName":
+				return oCurrikiResource.fileName;
+			case "uploadDate":
+				return oCurrikiResource.uploadDate;
+			case "sequence":
+				return oCurrikiResource.sequence;
+			case "uniqueName":
+				return oCurrikiResource.uniqueName;
+			case "ext":
+				return oCurrikiResource.ext;
+			case "tempactive":
+				return oCurrikiResource.tempactive;
+			case "s3path":
+				return oCurrikiResource.s3path;
+			case "sdfStatus":
+				return oCurrikiResource.sdfStatus;
+			case "transcoded":
+				return oCurrikiResource.transcoded;
+			case "lodestar":
+				return oCurrikiResource.lodestar;
+			case "archive":
+				return oCurrikiResource.archive;
+			case "identifier":
+				return oCurrikiResource.identifier;
+			case "displayName":
+				return oCurrikiResource.displayName;
+			case "subjectArea":
+				return oCurrikiResource.subjectArea;
+			case "name":
+				return oCurrikiResource.name;
 			default:
 				return super.obtainBaseModel(var);
 		}
@@ -5237,1020 +5698,676 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 			return CurrikiResource.staticSetDisplaySeqNo(siteRequest_, o);
 		case "fileId":
 			return CurrikiResource.staticSetFileId(siteRequest_, o);
+		case "fileName":
+			return CurrikiResource.staticSetFileName(siteRequest_, o);
+		case "uploadDate":
+			return CurrikiResource.staticSetUploadDate(siteRequest_, o);
+		case "sequence":
+			return CurrikiResource.staticSetSequence(siteRequest_, o);
+		case "uniqueName":
+			return CurrikiResource.staticSetUniqueName(siteRequest_, o);
+		case "ext":
+			return CurrikiResource.staticSetExt(siteRequest_, o);
+		case "tempactive":
+			return CurrikiResource.staticSetTempactive(siteRequest_, o);
+		case "s3path":
+			return CurrikiResource.staticSetS3path(siteRequest_, o);
+		case "sdfStatus":
+			return CurrikiResource.staticSetSdfStatus(siteRequest_, o);
+		case "transcoded":
+			return CurrikiResource.staticSetTranscoded(siteRequest_, o);
+		case "lodestar":
+			return CurrikiResource.staticSetLodestar(siteRequest_, o);
+		case "archive":
+			return CurrikiResource.staticSetArchive(siteRequest_, o);
+		case "identifier":
+			return CurrikiResource.staticSetIdentifier(siteRequest_, o);
+		case "displayName":
+			return CurrikiResource.staticSetDisplayName(siteRequest_, o);
+		case "subjectArea":
+			return CurrikiResource.staticSetSubjectArea(siteRequest_, o);
+		case "name":
+			return CurrikiResource.staticSetName(siteRequest_, o);
 			default:
 				return BaseModel.staticSetBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchCurrikiResource(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSearchResourceId(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrResourceId(siteRequest_, (String)o);
 		case "licenseId":
-			return CurrikiResource.staticSearchLicenseId(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrLicenseId(siteRequest_, (String)o);
 		case "contributorId":
-			return CurrikiResource.staticSearchContributorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrContributorId(siteRequest_, (Long)o);
 		case "contributionDate":
-			return CurrikiResource.staticSearchContributionDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrContributionDate(siteRequest_, (ZonedDateTime)o);
 		case "description":
-			return CurrikiResource.staticSearchDescription(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrDescription(siteRequest_, (String)o);
 		case "title":
-			return CurrikiResource.staticSearchTitle(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrTitle(siteRequest_, (String)o);
 		case "keywordsStr":
-			return CurrikiResource.staticSearchKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrKeywordsStr(siteRequest_, (String)o);
 		case "keywords":
-			return CurrikiResource.staticSearchKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrKeywords(siteRequest_, (String)o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSearchGeneratedKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrGeneratedKeywordsStr(siteRequest_, (String)o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSearchGeneratedKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrGeneratedKeywords(siteRequest_, (String)o);
 		case "language":
-			return CurrikiResource.staticSearchLanguage(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrLanguage(siteRequest_, (String)o);
 		case "lastEditorId":
-			return CurrikiResource.staticSearchLastEditorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrLastEditorId(siteRequest_, (Long)o);
 		case "lastEditDate":
-			return CurrikiResource.staticSearchLastEditDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrLastEditDate(siteRequest_, (ZonedDateTime)o);
 		case "currikiLicense":
-			return CurrikiResource.staticSearchCurrikiLicense(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrCurrikiLicense(siteRequest_, (String)o);
 		case "externalUrl":
-			return CurrikiResource.staticSearchExternalUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrExternalUrl(siteRequest_, (String)o);
 		case "resourceChecked":
-			return CurrikiResource.staticSearchResourceChecked(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrResourceChecked(siteRequest_, (String)o);
 		case "content":
-			return CurrikiResource.staticSearchContent(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrContent(siteRequest_, (String)o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSearchResourceCheckRequestNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrResourceCheckRequestNote(siteRequest_, (String)o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSearchResourceCheckDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrResourceCheckDate(siteRequest_, (ZonedDateTime)o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSearchResourceCheckId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrResourceCheckId(siteRequest_, (Long)o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSearchResourceCheckNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrResourceCheckNote(siteRequest_, (String)o);
 		case "studentFacing":
-			return CurrikiResource.staticSearchStudentFacing(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStudentFacing(siteRequest_, (String)o);
 		case "source":
-			return CurrikiResource.staticSearchSource(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrSource(siteRequest_, (String)o);
 		case "reviewStatus":
-			return CurrikiResource.staticSearchReviewStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrReviewStatus(siteRequest_, (String)o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSearchLastReviewDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrLastReviewDate(siteRequest_, (ZonedDateTime)o);
 		case "reviewByID":
-			return CurrikiResource.staticSearchReviewByID(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrReviewByID(siteRequest_, (Long)o);
 		case "reviewRating":
-			return CurrikiResource.staticSearchReviewRating(siteRequest_, (BigDecimal)o);
+			return CurrikiResource.staticSolrReviewRating(siteRequest_, (BigDecimal)o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSearchTechnicalCompleteness(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrTechnicalCompleteness(siteRequest_, (Integer)o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSearchContentAccuracy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrContentAccuracy(siteRequest_, (Integer)o);
 		case "pedagogy":
-			return CurrikiResource.staticSearchPedagogy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrPedagogy(siteRequest_, (Integer)o);
 		case "ratingComment":
-			return CurrikiResource.staticSearchRatingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrRatingComment(siteRequest_, (String)o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSearchStandardsAlignment(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStandardsAlignment(siteRequest_, (Integer)o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSearchStandardsAlignmentComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStandardsAlignmentComment(siteRequest_, (String)o);
 		case "subjectMatter":
-			return CurrikiResource.staticSearchSubjectMatter(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrSubjectMatter(siteRequest_, (Integer)o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSearchSubjectMatterComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrSubjectMatterComment(siteRequest_, (String)o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSearchSupportsTeaching(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrSupportsTeaching(siteRequest_, (Integer)o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSearchSupportsTeachingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrSupportsTeachingComment(siteRequest_, (String)o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSearchAssessmentsQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrAssessmentsQuality(siteRequest_, (Integer)o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSearchAssessmentsQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrAssessmentsQualityComment(siteRequest_, (String)o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSearchInteractivityQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrInteractivityQuality(siteRequest_, (Integer)o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSearchInteractivityQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrInteractivityQualityComment(siteRequest_, (String)o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSearchInstructionalQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrInstructionalQuality(siteRequest_, (Integer)o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSearchInstructionalQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrInstructionalQualityComment(siteRequest_, (String)o);
 		case "deeperLearning":
-			return CurrikiResource.staticSearchDeeperLearning(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrDeeperLearning(siteRequest_, (Integer)o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSearchDeeperLearningComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrDeeperLearningComment(siteRequest_, (String)o);
 		case "partner":
-			return CurrikiResource.staticSearchPartner(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrPartner(siteRequest_, (String)o);
 		case "createDate":
-			return CurrikiResource.staticSearchCreateDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrCreateDate(siteRequest_, (ZonedDateTime)o);
 		case "type":
-			return CurrikiResource.staticSearchType(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrType(siteRequest_, (String)o);
 		case "featured":
-			return CurrikiResource.staticSearchFeatured(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrFeatured(siteRequest_, (String)o);
 		case "page":
-			return CurrikiResource.staticSearchPage(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrPage(siteRequest_, (String)o);
 		case "active":
-			return CurrikiResource.staticSearchActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrActive(siteRequest_, (String)o);
 		case "Public":
-			return CurrikiResource.staticSearchPublic(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrPublic(siteRequest_, (String)o);
 		case "xwd_id":
-			return CurrikiResource.staticSearchXwd_id(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrXwd_id(siteRequest_, (Integer)o);
 		case "mediaType":
-			return CurrikiResource.staticSearchMediaType(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrMediaType(siteRequest_, (String)o);
 		case "access":
-			return CurrikiResource.staticSearchAccess(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrAccess(siteRequest_, (String)o);
 		case "memberRating":
-			return CurrikiResource.staticSearchMemberRating(siteRequest_, (BigDecimal)o);
+			return CurrikiResource.staticSolrMemberRating(siteRequest_, (BigDecimal)o);
 		case "aligned":
-			return CurrikiResource.staticSearchAligned(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrAligned(siteRequest_, (String)o);
 		case "pageUrl":
-			return CurrikiResource.staticSearchPageUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrPageUrl(siteRequest_, (String)o);
 		case "indexed":
-			return CurrikiResource.staticSearchIndexed(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrIndexed(siteRequest_, (String)o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSearchLastIndexDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrLastIndexDate(siteRequest_, (ZonedDateTime)o);
 		case "indexRequired":
-			return CurrikiResource.staticSearchIndexRequired(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrIndexRequired(siteRequest_, (String)o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSearchIndexRequiredDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrIndexRequiredDate(siteRequest_, (ZonedDateTime)o);
 		case "rescrape":
-			return CurrikiResource.staticSearchRescrape(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrRescrape(siteRequest_, (String)o);
 		case "goButton":
-			return CurrikiResource.staticSearchGoButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrGoButton(siteRequest_, (String)o);
 		case "downloadButton":
-			return CurrikiResource.staticSearchDownloadButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrDownloadButton(siteRequest_, (String)o);
 		case "topOfSearch":
-			return CurrikiResource.staticSearchTopOfSearch(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrTopOfSearch(siteRequest_, (String)o);
 		case "remove":
-			return CurrikiResource.staticSearchRemove(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrRemove(siteRequest_, (String)o);
 		case "spam":
-			return CurrikiResource.staticSearchSpam(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrSpam(siteRequest_, (String)o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSearchTopOfSearchInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrTopOfSearchInt(siteRequest_, (Integer)o);
 		case "partnerInt":
-			return CurrikiResource.staticSearchPartnerInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrPartnerInt(siteRequest_, (Integer)o);
 		case "reviewResource":
-			return CurrikiResource.staticSearchReviewResource(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrReviewResource(siteRequest_, (String)o);
 		case "oldUrl":
-			return CurrikiResource.staticSearchOldUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrOldUrl(siteRequest_, (String)o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSearchContentDisplayOk(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrContentDisplayOk(siteRequest_, (String)o);
 		case "metadata":
-			return CurrikiResource.staticSearchMetadata(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrMetadata(siteRequest_, (String)o);
 		case "approvalStatus":
-			return CurrikiResource.staticSearchApprovalStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrApprovalStatus(siteRequest_, (String)o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSearchApprovalStatusDate(siteRequest_, (ZonedDateTime)o);
+			return CurrikiResource.staticSolrApprovalStatusDate(siteRequest_, (ZonedDateTime)o);
 		case "spamUser":
-			return CurrikiResource.staticSearchSpamUser(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrSpamUser(siteRequest_, (String)o);
 		case "url":
-			return CurrikiResource.staticSearchUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrUrl(siteRequest_, (String)o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSearchDisplaySeqNo(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrDisplaySeqNo(siteRequest_, (Integer)o);
 		case "fileId":
-			return CurrikiResource.staticSearchFileId(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrFileId(siteRequest_, (Integer)o);
+		case "fileName":
+			return CurrikiResource.staticSolrFileName(siteRequest_, (String)o);
+		case "uploadDate":
+			return CurrikiResource.staticSolrUploadDate(siteRequest_, (String)o);
+		case "sequence":
+			return CurrikiResource.staticSolrSequence(siteRequest_, (Integer)o);
+		case "uniqueName":
+			return CurrikiResource.staticSolrUniqueName(siteRequest_, (String)o);
+		case "ext":
+			return CurrikiResource.staticSolrExt(siteRequest_, (String)o);
+		case "tempactive":
+			return CurrikiResource.staticSolrTempactive(siteRequest_, (String)o);
+		case "s3path":
+			return CurrikiResource.staticSolrS3path(siteRequest_, (String)o);
+		case "sdfStatus":
+			return CurrikiResource.staticSolrSdfStatus(siteRequest_, (String)o);
+		case "transcoded":
+			return CurrikiResource.staticSolrTranscoded(siteRequest_, (String)o);
+		case "lodestar":
+			return CurrikiResource.staticSolrLodestar(siteRequest_, (String)o);
+		case "archive":
+			return CurrikiResource.staticSolrArchive(siteRequest_, (String)o);
+		case "identifier":
+			return CurrikiResource.staticSolrIdentifier(siteRequest_, (String)o);
+		case "displayName":
+			return CurrikiResource.staticSolrDisplayName(siteRequest_, (String)o);
+		case "subjectArea":
+			return CurrikiResource.staticSolrSubjectArea(siteRequest_, (String)o);
+		case "name":
+			return CurrikiResource.staticSolrName(siteRequest_, (String)o);
 			default:
-				return BaseModel.staticSearchBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrCurrikiResource(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSearchStrResourceId(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrResourceId(siteRequest_, (String)o);
 		case "licenseId":
-			return CurrikiResource.staticSearchStrLicenseId(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrLicenseId(siteRequest_, (String)o);
 		case "contributorId":
-			return CurrikiResource.staticSearchStrContributorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrStrContributorId(siteRequest_, (Long)o);
 		case "contributionDate":
-			return CurrikiResource.staticSearchStrContributionDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrContributionDate(siteRequest_, (Date)o);
 		case "description":
-			return CurrikiResource.staticSearchStrDescription(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrDescription(siteRequest_, (String)o);
 		case "title":
-			return CurrikiResource.staticSearchStrTitle(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrTitle(siteRequest_, (String)o);
 		case "keywordsStr":
-			return CurrikiResource.staticSearchStrKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrKeywordsStr(siteRequest_, (String)o);
 		case "keywords":
-			return CurrikiResource.staticSearchStrKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrKeywords(siteRequest_, (String)o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSearchStrGeneratedKeywordsStr(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrGeneratedKeywordsStr(siteRequest_, (String)o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSearchStrGeneratedKeywords(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrGeneratedKeywords(siteRequest_, (String)o);
 		case "language":
-			return CurrikiResource.staticSearchStrLanguage(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrLanguage(siteRequest_, (String)o);
 		case "lastEditorId":
-			return CurrikiResource.staticSearchStrLastEditorId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrStrLastEditorId(siteRequest_, (Long)o);
 		case "lastEditDate":
-			return CurrikiResource.staticSearchStrLastEditDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrLastEditDate(siteRequest_, (Date)o);
 		case "currikiLicense":
-			return CurrikiResource.staticSearchStrCurrikiLicense(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrCurrikiLicense(siteRequest_, (String)o);
 		case "externalUrl":
-			return CurrikiResource.staticSearchStrExternalUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrExternalUrl(siteRequest_, (String)o);
 		case "resourceChecked":
-			return CurrikiResource.staticSearchStrResourceChecked(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrResourceChecked(siteRequest_, (String)o);
 		case "content":
-			return CurrikiResource.staticSearchStrContent(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrContent(siteRequest_, (String)o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSearchStrResourceCheckRequestNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrResourceCheckRequestNote(siteRequest_, (String)o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSearchStrResourceCheckDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrResourceCheckDate(siteRequest_, (Date)o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSearchStrResourceCheckId(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrStrResourceCheckId(siteRequest_, (Long)o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSearchStrResourceCheckNote(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrResourceCheckNote(siteRequest_, (String)o);
 		case "studentFacing":
-			return CurrikiResource.staticSearchStrStudentFacing(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrStudentFacing(siteRequest_, (String)o);
 		case "source":
-			return CurrikiResource.staticSearchStrSource(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrSource(siteRequest_, (String)o);
 		case "reviewStatus":
-			return CurrikiResource.staticSearchStrReviewStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrReviewStatus(siteRequest_, (String)o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSearchStrLastReviewDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrLastReviewDate(siteRequest_, (Date)o);
 		case "reviewByID":
-			return CurrikiResource.staticSearchStrReviewByID(siteRequest_, (Long)o);
+			return CurrikiResource.staticSolrStrReviewByID(siteRequest_, (Long)o);
 		case "reviewRating":
-			return CurrikiResource.staticSearchStrReviewRating(siteRequest_, (Double)o);
+			return CurrikiResource.staticSolrStrReviewRating(siteRequest_, (Double)o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSearchStrTechnicalCompleteness(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrTechnicalCompleteness(siteRequest_, (Integer)o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSearchStrContentAccuracy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrContentAccuracy(siteRequest_, (Integer)o);
 		case "pedagogy":
-			return CurrikiResource.staticSearchStrPedagogy(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrPedagogy(siteRequest_, (Integer)o);
 		case "ratingComment":
-			return CurrikiResource.staticSearchStrRatingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrRatingComment(siteRequest_, (String)o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSearchStrStandardsAlignment(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrStandardsAlignment(siteRequest_, (Integer)o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSearchStrStandardsAlignmentComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrStandardsAlignmentComment(siteRequest_, (String)o);
 		case "subjectMatter":
-			return CurrikiResource.staticSearchStrSubjectMatter(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrSubjectMatter(siteRequest_, (Integer)o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSearchStrSubjectMatterComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrSubjectMatterComment(siteRequest_, (String)o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSearchStrSupportsTeaching(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrSupportsTeaching(siteRequest_, (Integer)o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSearchStrSupportsTeachingComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrSupportsTeachingComment(siteRequest_, (String)o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSearchStrAssessmentsQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrAssessmentsQuality(siteRequest_, (Integer)o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSearchStrAssessmentsQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrAssessmentsQualityComment(siteRequest_, (String)o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSearchStrInteractivityQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrInteractivityQuality(siteRequest_, (Integer)o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSearchStrInteractivityQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrInteractivityQualityComment(siteRequest_, (String)o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSearchStrInstructionalQuality(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrInstructionalQuality(siteRequest_, (Integer)o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSearchStrInstructionalQualityComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrInstructionalQualityComment(siteRequest_, (String)o);
 		case "deeperLearning":
-			return CurrikiResource.staticSearchStrDeeperLearning(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrDeeperLearning(siteRequest_, (Integer)o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSearchStrDeeperLearningComment(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrDeeperLearningComment(siteRequest_, (String)o);
 		case "partner":
-			return CurrikiResource.staticSearchStrPartner(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrPartner(siteRequest_, (String)o);
 		case "createDate":
-			return CurrikiResource.staticSearchStrCreateDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrCreateDate(siteRequest_, (Date)o);
 		case "type":
-			return CurrikiResource.staticSearchStrType(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrType(siteRequest_, (String)o);
 		case "featured":
-			return CurrikiResource.staticSearchStrFeatured(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrFeatured(siteRequest_, (String)o);
 		case "page":
-			return CurrikiResource.staticSearchStrPage(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrPage(siteRequest_, (String)o);
 		case "active":
-			return CurrikiResource.staticSearchStrActive(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrActive(siteRequest_, (String)o);
 		case "Public":
-			return CurrikiResource.staticSearchStrPublic(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrPublic(siteRequest_, (String)o);
 		case "xwd_id":
-			return CurrikiResource.staticSearchStrXwd_id(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrXwd_id(siteRequest_, (Integer)o);
 		case "mediaType":
-			return CurrikiResource.staticSearchStrMediaType(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrMediaType(siteRequest_, (String)o);
 		case "access":
-			return CurrikiResource.staticSearchStrAccess(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrAccess(siteRequest_, (String)o);
 		case "memberRating":
-			return CurrikiResource.staticSearchStrMemberRating(siteRequest_, (Double)o);
+			return CurrikiResource.staticSolrStrMemberRating(siteRequest_, (Double)o);
 		case "aligned":
-			return CurrikiResource.staticSearchStrAligned(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrAligned(siteRequest_, (String)o);
 		case "pageUrl":
-			return CurrikiResource.staticSearchStrPageUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrPageUrl(siteRequest_, (String)o);
 		case "indexed":
-			return CurrikiResource.staticSearchStrIndexed(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrIndexed(siteRequest_, (String)o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSearchStrLastIndexDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrLastIndexDate(siteRequest_, (Date)o);
 		case "indexRequired":
-			return CurrikiResource.staticSearchStrIndexRequired(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrIndexRequired(siteRequest_, (String)o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSearchStrIndexRequiredDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrIndexRequiredDate(siteRequest_, (Date)o);
 		case "rescrape":
-			return CurrikiResource.staticSearchStrRescrape(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrRescrape(siteRequest_, (String)o);
 		case "goButton":
-			return CurrikiResource.staticSearchStrGoButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrGoButton(siteRequest_, (String)o);
 		case "downloadButton":
-			return CurrikiResource.staticSearchStrDownloadButton(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrDownloadButton(siteRequest_, (String)o);
 		case "topOfSearch":
-			return CurrikiResource.staticSearchStrTopOfSearch(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrTopOfSearch(siteRequest_, (String)o);
 		case "remove":
-			return CurrikiResource.staticSearchStrRemove(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrRemove(siteRequest_, (String)o);
 		case "spam":
-			return CurrikiResource.staticSearchStrSpam(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrSpam(siteRequest_, (String)o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSearchStrTopOfSearchInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrTopOfSearchInt(siteRequest_, (Integer)o);
 		case "partnerInt":
-			return CurrikiResource.staticSearchStrPartnerInt(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrPartnerInt(siteRequest_, (Integer)o);
 		case "reviewResource":
-			return CurrikiResource.staticSearchStrReviewResource(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrReviewResource(siteRequest_, (String)o);
 		case "oldUrl":
-			return CurrikiResource.staticSearchStrOldUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrOldUrl(siteRequest_, (String)o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSearchStrContentDisplayOk(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrContentDisplayOk(siteRequest_, (String)o);
 		case "metadata":
-			return CurrikiResource.staticSearchStrMetadata(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrMetadata(siteRequest_, (String)o);
 		case "approvalStatus":
-			return CurrikiResource.staticSearchStrApprovalStatus(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrApprovalStatus(siteRequest_, (String)o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSearchStrApprovalStatusDate(siteRequest_, (Date)o);
+			return CurrikiResource.staticSolrStrApprovalStatusDate(siteRequest_, (Date)o);
 		case "spamUser":
-			return CurrikiResource.staticSearchStrSpamUser(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrSpamUser(siteRequest_, (String)o);
 		case "url":
-			return CurrikiResource.staticSearchStrUrl(siteRequest_, (String)o);
+			return CurrikiResource.staticSolrStrUrl(siteRequest_, (String)o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSearchStrDisplaySeqNo(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrDisplaySeqNo(siteRequest_, (Integer)o);
 		case "fileId":
-			return CurrikiResource.staticSearchStrFileId(siteRequest_, (Integer)o);
+			return CurrikiResource.staticSolrStrFileId(siteRequest_, (Integer)o);
+		case "fileName":
+			return CurrikiResource.staticSolrStrFileName(siteRequest_, (String)o);
+		case "uploadDate":
+			return CurrikiResource.staticSolrStrUploadDate(siteRequest_, (String)o);
+		case "sequence":
+			return CurrikiResource.staticSolrStrSequence(siteRequest_, (Integer)o);
+		case "uniqueName":
+			return CurrikiResource.staticSolrStrUniqueName(siteRequest_, (String)o);
+		case "ext":
+			return CurrikiResource.staticSolrStrExt(siteRequest_, (String)o);
+		case "tempactive":
+			return CurrikiResource.staticSolrStrTempactive(siteRequest_, (String)o);
+		case "s3path":
+			return CurrikiResource.staticSolrStrS3path(siteRequest_, (String)o);
+		case "sdfStatus":
+			return CurrikiResource.staticSolrStrSdfStatus(siteRequest_, (String)o);
+		case "transcoded":
+			return CurrikiResource.staticSolrStrTranscoded(siteRequest_, (String)o);
+		case "lodestar":
+			return CurrikiResource.staticSolrStrLodestar(siteRequest_, (String)o);
+		case "archive":
+			return CurrikiResource.staticSolrStrArchive(siteRequest_, (String)o);
+		case "identifier":
+			return CurrikiResource.staticSolrStrIdentifier(siteRequest_, (String)o);
+		case "displayName":
+			return CurrikiResource.staticSolrStrDisplayName(siteRequest_, (String)o);
+		case "subjectArea":
+			return CurrikiResource.staticSolrStrSubjectArea(siteRequest_, (String)o);
+		case "name":
+			return CurrikiResource.staticSolrStrName(siteRequest_, (String)o);
 			default:
-				return BaseModel.staticSearchStrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrStrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqCurrikiResource(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqCurrikiResource(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqCurrikiResource(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "resourceId":
-			return CurrikiResource.staticSearchFqResourceId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceId(siteRequest_, o);
 		case "licenseId":
-			return CurrikiResource.staticSearchFqLicenseId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLicenseId(siteRequest_, o);
 		case "contributorId":
-			return CurrikiResource.staticSearchFqContributorId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqContributorId(siteRequest_, o);
 		case "contributionDate":
-			return CurrikiResource.staticSearchFqContributionDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqContributionDate(siteRequest_, o);
 		case "description":
-			return CurrikiResource.staticSearchFqDescription(siteRequest_, o);
+			return CurrikiResource.staticSolrFqDescription(siteRequest_, o);
 		case "title":
-			return CurrikiResource.staticSearchFqTitle(siteRequest_, o);
+			return CurrikiResource.staticSolrFqTitle(siteRequest_, o);
 		case "keywordsStr":
-			return CurrikiResource.staticSearchFqKeywordsStr(siteRequest_, o);
+			return CurrikiResource.staticSolrFqKeywordsStr(siteRequest_, o);
 		case "keywords":
-			return CurrikiResource.staticSearchFqKeywords(siteRequest_, o);
+			return CurrikiResource.staticSolrFqKeywords(siteRequest_, o);
 		case "generatedKeywordsStr":
-			return CurrikiResource.staticSearchFqGeneratedKeywordsStr(siteRequest_, o);
+			return CurrikiResource.staticSolrFqGeneratedKeywordsStr(siteRequest_, o);
 		case "generatedKeywords":
-			return CurrikiResource.staticSearchFqGeneratedKeywords(siteRequest_, o);
+			return CurrikiResource.staticSolrFqGeneratedKeywords(siteRequest_, o);
 		case "language":
-			return CurrikiResource.staticSearchFqLanguage(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLanguage(siteRequest_, o);
 		case "lastEditorId":
-			return CurrikiResource.staticSearchFqLastEditorId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLastEditorId(siteRequest_, o);
 		case "lastEditDate":
-			return CurrikiResource.staticSearchFqLastEditDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLastEditDate(siteRequest_, o);
 		case "currikiLicense":
-			return CurrikiResource.staticSearchFqCurrikiLicense(siteRequest_, o);
+			return CurrikiResource.staticSolrFqCurrikiLicense(siteRequest_, o);
 		case "externalUrl":
-			return CurrikiResource.staticSearchFqExternalUrl(siteRequest_, o);
+			return CurrikiResource.staticSolrFqExternalUrl(siteRequest_, o);
 		case "resourceChecked":
-			return CurrikiResource.staticSearchFqResourceChecked(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceChecked(siteRequest_, o);
 		case "content":
-			return CurrikiResource.staticSearchFqContent(siteRequest_, o);
+			return CurrikiResource.staticSolrFqContent(siteRequest_, o);
 		case "resourceCheckRequestNote":
-			return CurrikiResource.staticSearchFqResourceCheckRequestNote(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceCheckRequestNote(siteRequest_, o);
 		case "resourceCheckDate":
-			return CurrikiResource.staticSearchFqResourceCheckDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceCheckDate(siteRequest_, o);
 		case "resourceCheckId":
-			return CurrikiResource.staticSearchFqResourceCheckId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceCheckId(siteRequest_, o);
 		case "resourceCheckNote":
-			return CurrikiResource.staticSearchFqResourceCheckNote(siteRequest_, o);
+			return CurrikiResource.staticSolrFqResourceCheckNote(siteRequest_, o);
 		case "studentFacing":
-			return CurrikiResource.staticSearchFqStudentFacing(siteRequest_, o);
+			return CurrikiResource.staticSolrFqStudentFacing(siteRequest_, o);
 		case "source":
-			return CurrikiResource.staticSearchFqSource(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSource(siteRequest_, o);
 		case "reviewStatus":
-			return CurrikiResource.staticSearchFqReviewStatus(siteRequest_, o);
+			return CurrikiResource.staticSolrFqReviewStatus(siteRequest_, o);
 		case "lastReviewDate":
-			return CurrikiResource.staticSearchFqLastReviewDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLastReviewDate(siteRequest_, o);
 		case "reviewByID":
-			return CurrikiResource.staticSearchFqReviewByID(siteRequest_, o);
+			return CurrikiResource.staticSolrFqReviewByID(siteRequest_, o);
 		case "reviewRating":
-			return CurrikiResource.staticSearchFqReviewRating(siteRequest_, o);
+			return CurrikiResource.staticSolrFqReviewRating(siteRequest_, o);
 		case "technicalCompleteness":
-			return CurrikiResource.staticSearchFqTechnicalCompleteness(siteRequest_, o);
+			return CurrikiResource.staticSolrFqTechnicalCompleteness(siteRequest_, o);
 		case "contentAccuracy":
-			return CurrikiResource.staticSearchFqContentAccuracy(siteRequest_, o);
+			return CurrikiResource.staticSolrFqContentAccuracy(siteRequest_, o);
 		case "pedagogy":
-			return CurrikiResource.staticSearchFqPedagogy(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPedagogy(siteRequest_, o);
 		case "ratingComment":
-			return CurrikiResource.staticSearchFqRatingComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqRatingComment(siteRequest_, o);
 		case "standardsAlignment":
-			return CurrikiResource.staticSearchFqStandardsAlignment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqStandardsAlignment(siteRequest_, o);
 		case "standardsAlignmentComment":
-			return CurrikiResource.staticSearchFqStandardsAlignmentComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqStandardsAlignmentComment(siteRequest_, o);
 		case "subjectMatter":
-			return CurrikiResource.staticSearchFqSubjectMatter(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSubjectMatter(siteRequest_, o);
 		case "subjectMatterComment":
-			return CurrikiResource.staticSearchFqSubjectMatterComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSubjectMatterComment(siteRequest_, o);
 		case "supportsTeaching":
-			return CurrikiResource.staticSearchFqSupportsTeaching(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSupportsTeaching(siteRequest_, o);
 		case "supportsTeachingComment":
-			return CurrikiResource.staticSearchFqSupportsTeachingComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSupportsTeachingComment(siteRequest_, o);
 		case "assessmentsQuality":
-			return CurrikiResource.staticSearchFqAssessmentsQuality(siteRequest_, o);
+			return CurrikiResource.staticSolrFqAssessmentsQuality(siteRequest_, o);
 		case "assessmentsQualityComment":
-			return CurrikiResource.staticSearchFqAssessmentsQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqAssessmentsQualityComment(siteRequest_, o);
 		case "interactivityQuality":
-			return CurrikiResource.staticSearchFqInteractivityQuality(siteRequest_, o);
+			return CurrikiResource.staticSolrFqInteractivityQuality(siteRequest_, o);
 		case "interactivityQualityComment":
-			return CurrikiResource.staticSearchFqInteractivityQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqInteractivityQualityComment(siteRequest_, o);
 		case "instructionalQuality":
-			return CurrikiResource.staticSearchFqInstructionalQuality(siteRequest_, o);
+			return CurrikiResource.staticSolrFqInstructionalQuality(siteRequest_, o);
 		case "instructionalQualityComment":
-			return CurrikiResource.staticSearchFqInstructionalQualityComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqInstructionalQualityComment(siteRequest_, o);
 		case "deeperLearning":
-			return CurrikiResource.staticSearchFqDeeperLearning(siteRequest_, o);
+			return CurrikiResource.staticSolrFqDeeperLearning(siteRequest_, o);
 		case "deeperLearningComment":
-			return CurrikiResource.staticSearchFqDeeperLearningComment(siteRequest_, o);
+			return CurrikiResource.staticSolrFqDeeperLearningComment(siteRequest_, o);
 		case "partner":
-			return CurrikiResource.staticSearchFqPartner(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPartner(siteRequest_, o);
 		case "createDate":
-			return CurrikiResource.staticSearchFqCreateDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqCreateDate(siteRequest_, o);
 		case "type":
-			return CurrikiResource.staticSearchFqType(siteRequest_, o);
+			return CurrikiResource.staticSolrFqType(siteRequest_, o);
 		case "featured":
-			return CurrikiResource.staticSearchFqFeatured(siteRequest_, o);
+			return CurrikiResource.staticSolrFqFeatured(siteRequest_, o);
 		case "page":
-			return CurrikiResource.staticSearchFqPage(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPage(siteRequest_, o);
 		case "active":
-			return CurrikiResource.staticSearchFqActive(siteRequest_, o);
+			return CurrikiResource.staticSolrFqActive(siteRequest_, o);
 		case "Public":
-			return CurrikiResource.staticSearchFqPublic(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPublic(siteRequest_, o);
 		case "xwd_id":
-			return CurrikiResource.staticSearchFqXwd_id(siteRequest_, o);
+			return CurrikiResource.staticSolrFqXwd_id(siteRequest_, o);
 		case "mediaType":
-			return CurrikiResource.staticSearchFqMediaType(siteRequest_, o);
+			return CurrikiResource.staticSolrFqMediaType(siteRequest_, o);
 		case "access":
-			return CurrikiResource.staticSearchFqAccess(siteRequest_, o);
+			return CurrikiResource.staticSolrFqAccess(siteRequest_, o);
 		case "memberRating":
-			return CurrikiResource.staticSearchFqMemberRating(siteRequest_, o);
+			return CurrikiResource.staticSolrFqMemberRating(siteRequest_, o);
 		case "aligned":
-			return CurrikiResource.staticSearchFqAligned(siteRequest_, o);
+			return CurrikiResource.staticSolrFqAligned(siteRequest_, o);
 		case "pageUrl":
-			return CurrikiResource.staticSearchFqPageUrl(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPageUrl(siteRequest_, o);
 		case "indexed":
-			return CurrikiResource.staticSearchFqIndexed(siteRequest_, o);
+			return CurrikiResource.staticSolrFqIndexed(siteRequest_, o);
 		case "lastIndexDate":
-			return CurrikiResource.staticSearchFqLastIndexDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqLastIndexDate(siteRequest_, o);
 		case "indexRequired":
-			return CurrikiResource.staticSearchFqIndexRequired(siteRequest_, o);
+			return CurrikiResource.staticSolrFqIndexRequired(siteRequest_, o);
 		case "indexRequiredDate":
-			return CurrikiResource.staticSearchFqIndexRequiredDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqIndexRequiredDate(siteRequest_, o);
 		case "rescrape":
-			return CurrikiResource.staticSearchFqRescrape(siteRequest_, o);
+			return CurrikiResource.staticSolrFqRescrape(siteRequest_, o);
 		case "goButton":
-			return CurrikiResource.staticSearchFqGoButton(siteRequest_, o);
+			return CurrikiResource.staticSolrFqGoButton(siteRequest_, o);
 		case "downloadButton":
-			return CurrikiResource.staticSearchFqDownloadButton(siteRequest_, o);
+			return CurrikiResource.staticSolrFqDownloadButton(siteRequest_, o);
 		case "topOfSearch":
-			return CurrikiResource.staticSearchFqTopOfSearch(siteRequest_, o);
+			return CurrikiResource.staticSolrFqTopOfSearch(siteRequest_, o);
 		case "remove":
-			return CurrikiResource.staticSearchFqRemove(siteRequest_, o);
+			return CurrikiResource.staticSolrFqRemove(siteRequest_, o);
 		case "spam":
-			return CurrikiResource.staticSearchFqSpam(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSpam(siteRequest_, o);
 		case "topOfSearchInt":
-			return CurrikiResource.staticSearchFqTopOfSearchInt(siteRequest_, o);
+			return CurrikiResource.staticSolrFqTopOfSearchInt(siteRequest_, o);
 		case "partnerInt":
-			return CurrikiResource.staticSearchFqPartnerInt(siteRequest_, o);
+			return CurrikiResource.staticSolrFqPartnerInt(siteRequest_, o);
 		case "reviewResource":
-			return CurrikiResource.staticSearchFqReviewResource(siteRequest_, o);
+			return CurrikiResource.staticSolrFqReviewResource(siteRequest_, o);
 		case "oldUrl":
-			return CurrikiResource.staticSearchFqOldUrl(siteRequest_, o);
+			return CurrikiResource.staticSolrFqOldUrl(siteRequest_, o);
 		case "contentDisplayOk":
-			return CurrikiResource.staticSearchFqContentDisplayOk(siteRequest_, o);
+			return CurrikiResource.staticSolrFqContentDisplayOk(siteRequest_, o);
 		case "metadata":
-			return CurrikiResource.staticSearchFqMetadata(siteRequest_, o);
+			return CurrikiResource.staticSolrFqMetadata(siteRequest_, o);
 		case "approvalStatus":
-			return CurrikiResource.staticSearchFqApprovalStatus(siteRequest_, o);
+			return CurrikiResource.staticSolrFqApprovalStatus(siteRequest_, o);
 		case "approvalStatusDate":
-			return CurrikiResource.staticSearchFqApprovalStatusDate(siteRequest_, o);
+			return CurrikiResource.staticSolrFqApprovalStatusDate(siteRequest_, o);
 		case "spamUser":
-			return CurrikiResource.staticSearchFqSpamUser(siteRequest_, o);
+			return CurrikiResource.staticSolrFqSpamUser(siteRequest_, o);
 		case "url":
-			return CurrikiResource.staticSearchFqUrl(siteRequest_, o);
+			return CurrikiResource.staticSolrFqUrl(siteRequest_, o);
 		case "displaySeqNo":
-			return CurrikiResource.staticSearchFqDisplaySeqNo(siteRequest_, o);
+			return CurrikiResource.staticSolrFqDisplaySeqNo(siteRequest_, o);
 		case "fileId":
-			return CurrikiResource.staticSearchFqFileId(siteRequest_, o);
+			return CurrikiResource.staticSolrFqFileId(siteRequest_, o);
+		case "fileName":
+			return CurrikiResource.staticSolrFqFileName(siteRequest_, o);
+		case "uploadDate":
+			return CurrikiResource.staticSolrFqUploadDate(siteRequest_, o);
+		case "sequence":
+			return CurrikiResource.staticSolrFqSequence(siteRequest_, o);
+		case "uniqueName":
+			return CurrikiResource.staticSolrFqUniqueName(siteRequest_, o);
+		case "ext":
+			return CurrikiResource.staticSolrFqExt(siteRequest_, o);
+		case "tempactive":
+			return CurrikiResource.staticSolrFqTempactive(siteRequest_, o);
+		case "s3path":
+			return CurrikiResource.staticSolrFqS3path(siteRequest_, o);
+		case "sdfStatus":
+			return CurrikiResource.staticSolrFqSdfStatus(siteRequest_, o);
+		case "transcoded":
+			return CurrikiResource.staticSolrFqTranscoded(siteRequest_, o);
+		case "lodestar":
+			return CurrikiResource.staticSolrFqLodestar(siteRequest_, o);
+		case "archive":
+			return CurrikiResource.staticSolrFqArchive(siteRequest_, o);
+		case "identifier":
+			return CurrikiResource.staticSolrFqIdentifier(siteRequest_, o);
+		case "displayName":
+			return CurrikiResource.staticSolrFqDisplayName(siteRequest_, o);
+		case "subjectArea":
+			return CurrikiResource.staticSolrFqSubjectArea(siteRequest_, o);
+		case "name":
+			return CurrikiResource.staticSolrFqName(siteRequest_, o);
 			default:
-				return BaseModel.staticSearchFqBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrFqBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	/////////////
-	// persist //
+	// define //
 	/////////////
 
-	@Override public boolean persistForClass(String var, Object val) {
+	@Override public boolean defineForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = persistCurrikiResource(v, val);
+					o = defineCurrikiResource(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.persistForClass(v, val);
+					o = oBaseModel.defineForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object persistCurrikiResource(String var, Object val) {
+	public Object defineCurrikiResource(String var, Object val) {
 		switch(var.toLowerCase()) {
-			case "resourceid":
-				if(val instanceof String)
-					setResourceId((String)val);
-				saves.add("resourceId");
-				return val;
-			case "licenseid":
-				if(val instanceof String)
-					setLicenseId((String)val);
-				saves.add("licenseId");
-				return val;
-			case "contributorid":
-				if(val instanceof Long)
-					setContributorId((Long)val);
-				else if(val instanceof String)
-					setContributorId((String)val);
-				saves.add("contributorId");
-				return val;
-			case "contributiondate":
-				if(val instanceof ZonedDateTime)
-					setContributionDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setContributionDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setContributionDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("contributionDate");
-				return val;
-			case "description":
-				if(val instanceof String)
-					setDescription((String)val);
-				saves.add("description");
-				return val;
-			case "title":
-				if(val instanceof String)
-					setTitle((String)val);
-				saves.add("title");
-				return val;
-			case "keywordsstr":
-				if(val instanceof String)
-					setKeywordsStr((String)val);
-				saves.add("keywordsStr");
-				return val;
-			case "generatedkeywordsstr":
-				if(val instanceof String)
-					setGeneratedKeywordsStr((String)val);
-				saves.add("generatedKeywordsStr");
-				return val;
-			case "language":
-				if(val instanceof String)
-					setLanguage((String)val);
-				saves.add("language");
-				return val;
-			case "lasteditorid":
-				if(val instanceof Long)
-					setLastEditorId((Long)val);
-				else if(val instanceof String)
-					setLastEditorId((String)val);
-				saves.add("lastEditorId");
-				return val;
-			case "lasteditdate":
-				if(val instanceof ZonedDateTime)
-					setLastEditDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setLastEditDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setLastEditDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("lastEditDate");
-				return val;
-			case "currikilicense":
-				if(val instanceof String)
-					setCurrikiLicense((String)val);
-				saves.add("currikiLicense");
-				return val;
-			case "externalurl":
-				if(val instanceof String)
-					setExternalUrl((String)val);
-				saves.add("externalUrl");
-				return val;
-			case "resourcechecked":
-				if(val instanceof String)
-					setResourceChecked((String)val);
-				saves.add("resourceChecked");
-				return val;
-			case "content":
-				if(val instanceof String)
-					setContent((String)val);
-				saves.add("content");
-				return val;
-			case "resourcecheckrequestnote":
-				if(val instanceof String)
-					setResourceCheckRequestNote((String)val);
-				saves.add("resourceCheckRequestNote");
-				return val;
-			case "resourcecheckdate":
-				if(val instanceof ZonedDateTime)
-					setResourceCheckDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setResourceCheckDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setResourceCheckDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("resourceCheckDate");
-				return val;
-			case "resourcecheckid":
-				if(val instanceof Long)
-					setResourceCheckId((Long)val);
-				else if(val instanceof String)
-					setResourceCheckId((String)val);
-				saves.add("resourceCheckId");
-				return val;
-			case "resourcechecknote":
-				if(val instanceof String)
-					setResourceCheckNote((String)val);
-				saves.add("resourceCheckNote");
-				return val;
-			case "studentfacing":
-				if(val instanceof String)
-					setStudentFacing((String)val);
-				saves.add("studentFacing");
-				return val;
-			case "source":
-				if(val instanceof String)
-					setSource((String)val);
-				saves.add("source");
-				return val;
-			case "reviewstatus":
-				if(val instanceof String)
-					setReviewStatus((String)val);
-				saves.add("reviewStatus");
-				return val;
-			case "lastreviewdate":
-				if(val instanceof ZonedDateTime)
-					setLastReviewDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setLastReviewDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setLastReviewDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("lastReviewDate");
-				return val;
-			case "reviewbyid":
-				if(val instanceof Long)
-					setReviewByID((Long)val);
-				else if(val instanceof String)
-					setReviewByID((String)val);
-				saves.add("reviewByID");
-				return val;
-			case "reviewrating":
-				if(val instanceof String)
-					setReviewRating((String)val);
-				else if(val instanceof Number)
-					setReviewRating(new BigDecimal(((Number)val).doubleValue()));
-				saves.add("reviewRating");
-				return val;
-			case "technicalcompleteness":
-				if(val instanceof Integer)
-					setTechnicalCompleteness((Integer)val);
-				else if(val instanceof String)
-					setTechnicalCompleteness((String)val);
-				saves.add("technicalCompleteness");
-				return val;
-			case "contentaccuracy":
-				if(val instanceof Integer)
-					setContentAccuracy((Integer)val);
-				else if(val instanceof String)
-					setContentAccuracy((String)val);
-				saves.add("contentAccuracy");
-				return val;
-			case "pedagogy":
-				if(val instanceof Integer)
-					setPedagogy((Integer)val);
-				else if(val instanceof String)
-					setPedagogy((String)val);
-				saves.add("pedagogy");
-				return val;
-			case "ratingcomment":
-				if(val instanceof String)
-					setRatingComment((String)val);
-				saves.add("ratingComment");
-				return val;
-			case "standardsalignment":
-				if(val instanceof Integer)
-					setStandardsAlignment((Integer)val);
-				else if(val instanceof String)
-					setStandardsAlignment((String)val);
-				saves.add("standardsAlignment");
-				return val;
-			case "standardsalignmentcomment":
-				if(val instanceof String)
-					setStandardsAlignmentComment((String)val);
-				saves.add("standardsAlignmentComment");
-				return val;
-			case "subjectmatter":
-				if(val instanceof Integer)
-					setSubjectMatter((Integer)val);
-				else if(val instanceof String)
-					setSubjectMatter((String)val);
-				saves.add("subjectMatter");
-				return val;
-			case "subjectmattercomment":
-				if(val instanceof String)
-					setSubjectMatterComment((String)val);
-				saves.add("subjectMatterComment");
-				return val;
-			case "supportsteaching":
-				if(val instanceof Integer)
-					setSupportsTeaching((Integer)val);
-				else if(val instanceof String)
-					setSupportsTeaching((String)val);
-				saves.add("supportsTeaching");
-				return val;
-			case "supportsteachingcomment":
-				if(val instanceof String)
-					setSupportsTeachingComment((String)val);
-				saves.add("supportsTeachingComment");
-				return val;
-			case "assessmentsquality":
-				if(val instanceof Integer)
-					setAssessmentsQuality((Integer)val);
-				else if(val instanceof String)
-					setAssessmentsQuality((String)val);
-				saves.add("assessmentsQuality");
-				return val;
-			case "assessmentsqualitycomment":
-				if(val instanceof String)
-					setAssessmentsQualityComment((String)val);
-				saves.add("assessmentsQualityComment");
-				return val;
-			case "interactivityquality":
-				if(val instanceof Integer)
-					setInteractivityQuality((Integer)val);
-				else if(val instanceof String)
-					setInteractivityQuality((String)val);
-				saves.add("interactivityQuality");
-				return val;
-			case "interactivityqualitycomment":
-				if(val instanceof String)
-					setInteractivityQualityComment((String)val);
-				saves.add("interactivityQualityComment");
-				return val;
-			case "instructionalquality":
-				if(val instanceof Integer)
-					setInstructionalQuality((Integer)val);
-				else if(val instanceof String)
-					setInstructionalQuality((String)val);
-				saves.add("instructionalQuality");
-				return val;
-			case "instructionalqualitycomment":
-				if(val instanceof String)
-					setInstructionalQualityComment((String)val);
-				saves.add("instructionalQualityComment");
-				return val;
-			case "deeperlearning":
-				if(val instanceof Integer)
-					setDeeperLearning((Integer)val);
-				else if(val instanceof String)
-					setDeeperLearning((String)val);
-				saves.add("deeperLearning");
-				return val;
-			case "deeperlearningcomment":
-				if(val instanceof String)
-					setDeeperLearningComment((String)val);
-				saves.add("deeperLearningComment");
-				return val;
-			case "partner":
-				if(val instanceof String)
-					setPartner((String)val);
-				saves.add("partner");
-				return val;
-			case "createdate":
-				if(val instanceof ZonedDateTime)
-					setCreateDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setCreateDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setCreateDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("createDate");
-				return val;
-			case "type":
-				if(val instanceof String)
-					setType((String)val);
-				saves.add("type");
-				return val;
-			case "featured":
-				if(val instanceof String)
-					setFeatured((String)val);
-				saves.add("featured");
-				return val;
-			case "page":
-				if(val instanceof String)
-					setPage((String)val);
-				saves.add("page");
-				return val;
-			case "active":
-				if(val instanceof String)
-					setActive((String)val);
-				saves.add("active");
-				return val;
-			case "public":
-				if(val instanceof String)
-					setPublic((String)val);
-				saves.add("Public");
-				return val;
-			case "xwd_id":
-				if(val instanceof Integer)
-					setXwd_id((Integer)val);
-				else if(val instanceof String)
-					setXwd_id((String)val);
-				saves.add("xwd_id");
-				return val;
-			case "mediatype":
-				if(val instanceof String)
-					setMediaType((String)val);
-				saves.add("mediaType");
-				return val;
-			case "access":
-				if(val instanceof String)
-					setAccess((String)val);
-				saves.add("access");
-				return val;
-			case "memberrating":
-				if(val instanceof String)
-					setMemberRating((String)val);
-				else if(val instanceof Number)
-					setMemberRating(new BigDecimal(((Number)val).doubleValue()));
-				saves.add("memberRating");
-				return val;
-			case "aligned":
-				if(val instanceof String)
-					setAligned((String)val);
-				saves.add("aligned");
-				return val;
-			case "pageurl":
-				if(val instanceof String)
-					setPageUrl((String)val);
-				saves.add("pageUrl");
-				return val;
-			case "indexed":
-				if(val instanceof String)
-					setIndexed((String)val);
-				saves.add("indexed");
-				return val;
-			case "lastindexdate":
-				if(val instanceof ZonedDateTime)
-					setLastIndexDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setLastIndexDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setLastIndexDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("lastIndexDate");
-				return val;
-			case "indexrequired":
-				if(val instanceof String)
-					setIndexRequired((String)val);
-				saves.add("indexRequired");
-				return val;
-			case "indexrequireddate":
-				if(val instanceof ZonedDateTime)
-					setIndexRequiredDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setIndexRequiredDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setIndexRequiredDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("indexRequiredDate");
-				return val;
-			case "rescrape":
-				if(val instanceof String)
-					setRescrape((String)val);
-				saves.add("rescrape");
-				return val;
-			case "gobutton":
-				if(val instanceof String)
-					setGoButton((String)val);
-				saves.add("goButton");
-				return val;
-			case "downloadbutton":
-				if(val instanceof String)
-					setDownloadButton((String)val);
-				saves.add("downloadButton");
-				return val;
-			case "topofsearch":
-				if(val instanceof String)
-					setTopOfSearch((String)val);
-				saves.add("topOfSearch");
-				return val;
-			case "remove":
-				if(val instanceof String)
-					setRemove((String)val);
-				saves.add("remove");
-				return val;
-			case "spam":
-				if(val instanceof String)
-					setSpam((String)val);
-				saves.add("spam");
-				return val;
-			case "topofsearchint":
-				if(val instanceof Integer)
-					setTopOfSearchInt((Integer)val);
-				else if(val instanceof String)
-					setTopOfSearchInt((String)val);
-				saves.add("topOfSearchInt");
-				return val;
-			case "partnerint":
-				if(val instanceof Integer)
-					setPartnerInt((Integer)val);
-				else if(val instanceof String)
-					setPartnerInt((String)val);
-				saves.add("partnerInt");
-				return val;
-			case "reviewresource":
-				if(val instanceof String)
-					setReviewResource((String)val);
-				saves.add("reviewResource");
-				return val;
-			case "oldurl":
-				if(val instanceof String)
-					setOldUrl((String)val);
-				saves.add("oldUrl");
-				return val;
-			case "contentdisplayok":
-				if(val instanceof String)
-					setContentDisplayOk((String)val);
-				saves.add("contentDisplayOk");
-				return val;
-			case "metadata":
-				if(val instanceof String)
-					setMetadata((String)val);
-				saves.add("metadata");
-				return val;
-			case "approvalstatus":
-				if(val instanceof String)
-					setApprovalStatus((String)val);
-				saves.add("approvalStatus");
-				return val;
-			case "approvalstatusdate":
-				if(val instanceof ZonedDateTime)
-					setApprovalStatusDate((ZonedDateTime)val);
-				else if(val instanceof String)
-					setApprovalStatusDate((String)val);
-				else if(val instanceof OffsetDateTime)
-					setApprovalStatusDate(((OffsetDateTime)val).atZoneSameInstant(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))));
-				saves.add("approvalStatusDate");
-				return val;
-			case "spamuser":
-				if(val instanceof String)
-					setSpamUser((String)val);
-				saves.add("spamUser");
-				return val;
-			case "url":
-				if(val instanceof String)
-					setUrl((String)val);
-				saves.add("url");
-				return val;
-			case "displayseqno":
-				if(val instanceof Integer)
-					setDisplaySeqNo((Integer)val);
-				else if(val instanceof String)
-					setDisplaySeqNo((String)val);
-				saves.add("displaySeqNo");
-				return val;
-			case "fileid":
-				if(val instanceof Integer)
-					setFileId((Integer)val);
-				else if(val instanceof String)
-					setFileId((String)val);
-				saves.add("fileId");
-				return val;
 			default:
-				return super.persistBaseModel(var, val);
+				return super.defineBaseModel(var, val);
 		}
 	}
 
@@ -6258,428 +6375,310 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	// populate //
 	/////////////
 
-	@Override public void populateForClass(SolrResponse.Doc doc) {
-		populateCurrikiResource(doc);
+	@Override public void populateForClass(SolrDocument solrDocument) {
+		populateCurrikiResource(solrDocument);
 	}
-	public void populateCurrikiResource(SolrResponse.Doc doc) {
+	public void populateCurrikiResource(SolrDocument solrDocument) {
 		CurrikiResource oCurrikiResource = (CurrikiResource)this;
-		saves = doc.get("saves_docvalues_strings");
+		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
 		if(saves != null) {
 
 			if(saves.contains("content")) {
-				String content = (String)doc.get("content_stored_string");
+				String content = (String)solrDocument.get("content_stored_string");
 				if(content != null)
 					oCurrikiResource.setContent(content);
 			}
 
 			if(saves.contains("ratingComment")) {
-				String ratingComment = (String)doc.get("ratingComment_stored_string");
+				String ratingComment = (String)solrDocument.get("ratingComment_stored_string");
 				if(ratingComment != null)
 					oCurrikiResource.setRatingComment(ratingComment);
 			}
 		}
 
-		super.populateBaseModel(doc);
+		super.populateBaseModel(solrDocument);
 	}
 
-	public void indexCurrikiResource(JsonObject doc) {
+	public void indexCurrikiResource(SolrInputDocument document) {
 		if(resourceId != null) {
-			doc.put("resourceId_docvalues_string", resourceId);
+			document.addField("resourceId_docvalues_string", resourceId);
 		}
 		if(licenseId != null) {
-			doc.put("licenseId_docvalues_string", licenseId);
+			document.addField("licenseId_docvalues_string", licenseId);
 		}
 		if(contributorId != null) {
-			doc.put("contributorId_docvalues_long", contributorId);
+			document.addField("contributorId_docvalues_long", contributorId);
 		}
 		if(contributionDate != null) {
-			doc.put("contributionDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(contributionDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("contributionDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(contributionDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(description != null) {
-			doc.put("description_docvalues_string", description);
+			document.addField("description_docvalues_string", description);
 		}
 		if(title != null) {
-			doc.put("title_docvalues_string", title);
+			document.addField("title_docvalues_string", title);
 		}
 		if(keywords != null) {
-			JsonArray l = new JsonArray();
-			doc.put("keywords_docvalues_strings", l);
-			for(String o : keywords) {
-				l.add(o);
+			for(java.lang.String o : keywords) {
+				document.addField("keywords_docvalues_strings", o);
 			}
 		}
 		if(generatedKeywords != null) {
-			JsonArray l = new JsonArray();
-			doc.put("generatedKeywords_docvalues_strings", l);
-			for(String o : generatedKeywords) {
-				l.add(o);
+			for(java.lang.String o : generatedKeywords) {
+				document.addField("generatedKeywords_docvalues_strings", o);
 			}
 		}
 		if(language != null) {
-			doc.put("language_docvalues_string", language);
+			document.addField("language_docvalues_string", language);
 		}
 		if(lastEditorId != null) {
-			doc.put("lastEditorId_docvalues_long", lastEditorId);
+			document.addField("lastEditorId_docvalues_long", lastEditorId);
 		}
 		if(lastEditDate != null) {
-			doc.put("lastEditDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastEditDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("lastEditDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastEditDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(currikiLicense != null) {
-			doc.put("currikiLicense_docvalues_string", currikiLicense);
+			document.addField("currikiLicense_docvalues_string", currikiLicense);
 		}
 		if(externalUrl != null) {
-			doc.put("externalUrl_docvalues_string", externalUrl);
+			document.addField("externalUrl_docvalues_string", externalUrl);
 		}
 		if(resourceChecked != null) {
-			doc.put("resourceChecked_docvalues_string", resourceChecked);
+			document.addField("resourceChecked_docvalues_string", resourceChecked);
 		}
 		if(content != null) {
-			doc.put("content_stored_string", content);
+			document.addField("content_stored_string", content);
 		}
 		if(resourceCheckDate != null) {
-			doc.put("resourceCheckDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(resourceCheckDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("resourceCheckDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(resourceCheckDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(resourceCheckId != null) {
-			doc.put("resourceCheckId_docvalues_long", resourceCheckId);
+			document.addField("resourceCheckId_docvalues_long", resourceCheckId);
 		}
 		if(studentFacing != null) {
-			doc.put("studentFacing_docvalues_string", studentFacing);
+			document.addField("studentFacing_docvalues_string", studentFacing);
 		}
 		if(source != null) {
-			doc.put("source_docvalues_string", source);
+			document.addField("source_docvalues_string", source);
 		}
 		if(reviewStatus != null) {
-			doc.put("reviewStatus_docvalues_string", reviewStatus);
+			document.addField("reviewStatus_docvalues_string", reviewStatus);
 		}
 		if(lastReviewDate != null) {
-			doc.put("lastReviewDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastReviewDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("lastReviewDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastReviewDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(reviewByID != null) {
-			doc.put("reviewByID_docvalues_long", reviewByID);
+			document.addField("reviewByID_docvalues_long", reviewByID);
 		}
 		if(reviewRating != null) {
-			doc.put("reviewRating_docvalues_double", reviewRating.doubleValue());
+			document.addField("reviewRating_docvalues_double", reviewRating.doubleValue());
 		}
 		if(technicalCompleteness != null) {
-			doc.put("technicalCompleteness_docvalues_int", technicalCompleteness);
+			document.addField("technicalCompleteness_docvalues_int", technicalCompleteness);
 		}
 		if(contentAccuracy != null) {
-			doc.put("contentAccuracy_docvalues_int", contentAccuracy);
+			document.addField("contentAccuracy_docvalues_int", contentAccuracy);
 		}
 		if(pedagogy != null) {
-			doc.put("pedagogy_docvalues_int", pedagogy);
+			document.addField("pedagogy_docvalues_int", pedagogy);
 		}
 		if(ratingComment != null) {
-			doc.put("ratingComment_stored_string", ratingComment);
+			document.addField("ratingComment_stored_string", ratingComment);
 		}
 		if(standardsAlignment != null) {
-			doc.put("standardsAlignment_docvalues_int", standardsAlignment);
+			document.addField("standardsAlignment_docvalues_int", standardsAlignment);
 		}
 		if(standardsAlignmentComment != null) {
-			doc.put("standardsAlignmentComment_docvalues_string", standardsAlignmentComment);
+			document.addField("standardsAlignmentComment_docvalues_string", standardsAlignmentComment);
 		}
 		if(subjectMatter != null) {
-			doc.put("subjectMatter_docvalues_int", subjectMatter);
+			document.addField("subjectMatter_docvalues_int", subjectMatter);
 		}
 		if(subjectMatterComment != null) {
-			doc.put("subjectMatterComment_docvalues_string", subjectMatterComment);
+			document.addField("subjectMatterComment_docvalues_string", subjectMatterComment);
 		}
 		if(supportsTeaching != null) {
-			doc.put("supportsTeaching_docvalues_int", supportsTeaching);
+			document.addField("supportsTeaching_docvalues_int", supportsTeaching);
 		}
 		if(supportsTeachingComment != null) {
-			doc.put("supportsTeachingComment_docvalues_string", supportsTeachingComment);
+			document.addField("supportsTeachingComment_docvalues_string", supportsTeachingComment);
 		}
 		if(assessmentsQuality != null) {
-			doc.put("assessmentsQuality_docvalues_int", assessmentsQuality);
+			document.addField("assessmentsQuality_docvalues_int", assessmentsQuality);
 		}
 		if(assessmentsQualityComment != null) {
-			doc.put("assessmentsQualityComment_docvalues_string", assessmentsQualityComment);
+			document.addField("assessmentsQualityComment_docvalues_string", assessmentsQualityComment);
 		}
 		if(interactivityQuality != null) {
-			doc.put("interactivityQuality_docvalues_int", interactivityQuality);
+			document.addField("interactivityQuality_docvalues_int", interactivityQuality);
 		}
 		if(interactivityQualityComment != null) {
-			doc.put("interactivityQualityComment_docvalues_string", interactivityQualityComment);
+			document.addField("interactivityQualityComment_docvalues_string", interactivityQualityComment);
 		}
 		if(instructionalQuality != null) {
-			doc.put("instructionalQuality_docvalues_int", instructionalQuality);
+			document.addField("instructionalQuality_docvalues_int", instructionalQuality);
 		}
 		if(instructionalQualityComment != null) {
-			doc.put("instructionalQualityComment_docvalues_string", instructionalQualityComment);
+			document.addField("instructionalQualityComment_docvalues_string", instructionalQualityComment);
 		}
 		if(deeperLearning != null) {
-			doc.put("deeperLearning_docvalues_int", deeperLearning);
+			document.addField("deeperLearning_docvalues_int", deeperLearning);
 		}
 		if(deeperLearningComment != null) {
-			doc.put("deeperLearningComment_docvalues_string", deeperLearningComment);
+			document.addField("deeperLearningComment_docvalues_string", deeperLearningComment);
 		}
 		if(partner != null) {
-			doc.put("partner_docvalues_string", partner);
+			document.addField("partner_docvalues_string", partner);
 		}
 		if(createDate != null) {
-			doc.put("createDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(createDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("createDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(createDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(type != null) {
-			doc.put("type_docvalues_string", type);
+			document.addField("type_docvalues_string", type);
 		}
 		if(featured != null) {
-			doc.put("featured_docvalues_string", featured);
+			document.addField("featured_docvalues_string", featured);
 		}
 		if(page != null) {
-			doc.put("page_docvalues_string", page);
+			document.addField("page_docvalues_string", page);
 		}
 		if(active != null) {
-			doc.put("active_docvalues_string", active);
+			document.addField("active_docvalues_string", active);
 		}
 		if(Public != null) {
-			doc.put("Public_docvalues_string", Public);
+			document.addField("Public_docvalues_string", Public);
 		}
 		if(xwd_id != null) {
-			doc.put("xwd_id_docvalues_int", xwd_id);
+			document.addField("xwd_id_docvalues_int", xwd_id);
 		}
 		if(mediaType != null) {
-			doc.put("mediaType_docvalues_string", mediaType);
+			document.addField("mediaType_docvalues_string", mediaType);
 		}
 		if(access != null) {
-			doc.put("access_docvalues_string", access);
+			document.addField("access_docvalues_string", access);
 		}
 		if(memberRating != null) {
-			doc.put("memberRating_docvalues_double", memberRating.doubleValue());
+			document.addField("memberRating_docvalues_double", memberRating.doubleValue());
 		}
 		if(aligned != null) {
-			doc.put("aligned_docvalues_string", aligned);
+			document.addField("aligned_docvalues_string", aligned);
 		}
 		if(pageUrl != null) {
-			doc.put("pageUrl_docvalues_string", pageUrl);
+			document.addField("pageUrl_docvalues_string", pageUrl);
 		}
 		if(indexed != null) {
-			doc.put("indexed_docvalues_string", indexed);
+			document.addField("indexed_docvalues_string", indexed);
 		}
 		if(lastIndexDate != null) {
-			doc.put("lastIndexDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastIndexDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("lastIndexDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(lastIndexDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(indexRequired != null) {
-			doc.put("indexRequired_docvalues_string", indexRequired);
+			document.addField("indexRequired_docvalues_string", indexRequired);
 		}
 		if(indexRequiredDate != null) {
-			doc.put("indexRequiredDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(indexRequiredDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("indexRequiredDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(indexRequiredDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(rescrape != null) {
-			doc.put("rescrape_docvalues_string", rescrape);
+			document.addField("rescrape_docvalues_string", rescrape);
 		}
 		if(goButton != null) {
-			doc.put("goButton_docvalues_string", goButton);
+			document.addField("goButton_docvalues_string", goButton);
 		}
 		if(downloadButton != null) {
-			doc.put("downloadButton_docvalues_string", downloadButton);
+			document.addField("downloadButton_docvalues_string", downloadButton);
 		}
 		if(topOfSearch != null) {
-			doc.put("topOfSearch_docvalues_string", topOfSearch);
+			document.addField("topOfSearch_docvalues_string", topOfSearch);
 		}
 		if(remove != null) {
-			doc.put("remove_docvalues_string", remove);
+			document.addField("remove_docvalues_string", remove);
 		}
 		if(spam != null) {
-			doc.put("spam_docvalues_string", spam);
+			document.addField("spam_docvalues_string", spam);
 		}
 		if(topOfSearchInt != null) {
-			doc.put("topOfSearchInt_docvalues_int", topOfSearchInt);
+			document.addField("topOfSearchInt_docvalues_int", topOfSearchInt);
 		}
 		if(partnerInt != null) {
-			doc.put("partnerInt_docvalues_int", partnerInt);
+			document.addField("partnerInt_docvalues_int", partnerInt);
 		}
 		if(reviewResource != null) {
-			doc.put("reviewResource_docvalues_string", reviewResource);
+			document.addField("reviewResource_docvalues_string", reviewResource);
 		}
 		if(oldUrl != null) {
-			doc.put("oldUrl_docvalues_string", oldUrl);
+			document.addField("oldUrl_docvalues_string", oldUrl);
 		}
 		if(contentDisplayOk != null) {
-			doc.put("contentDisplayOk_docvalues_string", contentDisplayOk);
+			document.addField("contentDisplayOk_docvalues_string", contentDisplayOk);
 		}
 		if(metadata != null) {
-			doc.put("metadata_docvalues_string", metadata);
+			document.addField("metadata_docvalues_string", metadata);
 		}
 		if(approvalStatus != null) {
-			doc.put("approvalStatus_docvalues_string", approvalStatus);
+			document.addField("approvalStatus_docvalues_string", approvalStatus);
 		}
 		if(approvalStatusDate != null) {
-			doc.put("approvalStatusDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(approvalStatusDate.toInstant(), ZoneId.of("UTC"))));
+			document.addField("approvalStatusDate_docvalues_date", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").format(ZonedDateTime.ofInstant(approvalStatusDate.toInstant(), ZoneId.of("UTC"))));
 		}
 		if(spamUser != null) {
-			doc.put("spamUser_docvalues_string", spamUser);
+			document.addField("spamUser_docvalues_string", spamUser);
 		}
 		if(url != null) {
-			doc.put("url_docvalues_string", url);
+			document.addField("url_docvalues_string", url);
 		}
 		if(displaySeqNo != null) {
-			doc.put("displaySeqNo_docvalues_int", displaySeqNo);
+			document.addField("displaySeqNo_docvalues_int", displaySeqNo);
 		}
 		if(fileId != null) {
-			doc.put("fileId_docvalues_int", fileId);
+			document.addField("fileId_docvalues_int", fileId);
 		}
-		super.indexBaseModel(doc);
-
-	}
-
-	public static String varStoredCurrikiResource(String entityVar) {
-		switch(entityVar) {
-			case "resourceId":
-				return "resourceId_docvalues_string";
-			case "licenseId":
-				return "licenseId_docvalues_string";
-			case "contributorId":
-				return "contributorId_docvalues_long";
-			case "contributionDate":
-				return "contributionDate_docvalues_date";
-			case "description":
-				return "description_docvalues_string";
-			case "title":
-				return "title_docvalues_string";
-			case "keywords":
-				return "keywords_docvalues_strings";
-			case "generatedKeywords":
-				return "generatedKeywords_docvalues_strings";
-			case "language":
-				return "language_docvalues_string";
-			case "lastEditorId":
-				return "lastEditorId_docvalues_long";
-			case "lastEditDate":
-				return "lastEditDate_docvalues_date";
-			case "currikiLicense":
-				return "currikiLicense_docvalues_string";
-			case "externalUrl":
-				return "externalUrl_docvalues_string";
-			case "resourceChecked":
-				return "resourceChecked_docvalues_string";
-			case "content":
-				return "content_stored_string";
-			case "resourceCheckDate":
-				return "resourceCheckDate_docvalues_date";
-			case "resourceCheckId":
-				return "resourceCheckId_docvalues_long";
-			case "studentFacing":
-				return "studentFacing_docvalues_string";
-			case "source":
-				return "source_docvalues_string";
-			case "reviewStatus":
-				return "reviewStatus_docvalues_string";
-			case "lastReviewDate":
-				return "lastReviewDate_docvalues_date";
-			case "reviewByID":
-				return "reviewByID_docvalues_long";
-			case "reviewRating":
-				return "reviewRating_docvalues_double";
-			case "technicalCompleteness":
-				return "technicalCompleteness_docvalues_int";
-			case "contentAccuracy":
-				return "contentAccuracy_docvalues_int";
-			case "pedagogy":
-				return "pedagogy_docvalues_int";
-			case "ratingComment":
-				return "ratingComment_stored_string";
-			case "standardsAlignment":
-				return "standardsAlignment_docvalues_int";
-			case "standardsAlignmentComment":
-				return "standardsAlignmentComment_docvalues_string";
-			case "subjectMatter":
-				return "subjectMatter_docvalues_int";
-			case "subjectMatterComment":
-				return "subjectMatterComment_docvalues_string";
-			case "supportsTeaching":
-				return "supportsTeaching_docvalues_int";
-			case "supportsTeachingComment":
-				return "supportsTeachingComment_docvalues_string";
-			case "assessmentsQuality":
-				return "assessmentsQuality_docvalues_int";
-			case "assessmentsQualityComment":
-				return "assessmentsQualityComment_docvalues_string";
-			case "interactivityQuality":
-				return "interactivityQuality_docvalues_int";
-			case "interactivityQualityComment":
-				return "interactivityQualityComment_docvalues_string";
-			case "instructionalQuality":
-				return "instructionalQuality_docvalues_int";
-			case "instructionalQualityComment":
-				return "instructionalQualityComment_docvalues_string";
-			case "deeperLearning":
-				return "deeperLearning_docvalues_int";
-			case "deeperLearningComment":
-				return "deeperLearningComment_docvalues_string";
-			case "partner":
-				return "partner_docvalues_string";
-			case "createDate":
-				return "createDate_docvalues_date";
-			case "type":
-				return "type_docvalues_string";
-			case "featured":
-				return "featured_docvalues_string";
-			case "page":
-				return "page_docvalues_string";
-			case "active":
-				return "active_docvalues_string";
-			case "Public":
-				return "Public_docvalues_string";
-			case "xwd_id":
-				return "xwd_id_docvalues_int";
-			case "mediaType":
-				return "mediaType_docvalues_string";
-			case "access":
-				return "access_docvalues_string";
-			case "memberRating":
-				return "memberRating_docvalues_double";
-			case "aligned":
-				return "aligned_docvalues_string";
-			case "pageUrl":
-				return "pageUrl_docvalues_string";
-			case "indexed":
-				return "indexed_docvalues_string";
-			case "lastIndexDate":
-				return "lastIndexDate_docvalues_date";
-			case "indexRequired":
-				return "indexRequired_docvalues_string";
-			case "indexRequiredDate":
-				return "indexRequiredDate_docvalues_date";
-			case "rescrape":
-				return "rescrape_docvalues_string";
-			case "goButton":
-				return "goButton_docvalues_string";
-			case "downloadButton":
-				return "downloadButton_docvalues_string";
-			case "topOfSearch":
-				return "topOfSearch_docvalues_string";
-			case "remove":
-				return "remove_docvalues_string";
-			case "spam":
-				return "spam_docvalues_string";
-			case "topOfSearchInt":
-				return "topOfSearchInt_docvalues_int";
-			case "partnerInt":
-				return "partnerInt_docvalues_int";
-			case "reviewResource":
-				return "reviewResource_docvalues_string";
-			case "oldUrl":
-				return "oldUrl_docvalues_string";
-			case "contentDisplayOk":
-				return "contentDisplayOk_docvalues_string";
-			case "metadata":
-				return "metadata_docvalues_string";
-			case "approvalStatus":
-				return "approvalStatus_docvalues_string";
-			case "approvalStatusDate":
-				return "approvalStatusDate_docvalues_date";
-			case "spamUser":
-				return "spamUser_docvalues_string";
-			case "url":
-				return "url_docvalues_string";
-			case "displaySeqNo":
-				return "displaySeqNo_docvalues_int";
-			case "fileId":
-				return "fileId_docvalues_int";
-			default:
-				return BaseModel.varStoredBaseModel(entityVar);
+		if(fileName != null) {
+			document.addField("fileName_docvalues_string", fileName);
 		}
+		if(uploadDate != null) {
+			document.addField("uploadDate_docvalues_string", uploadDate);
+		}
+		if(sequence != null) {
+			document.addField("sequence_docvalues_int", sequence);
+		}
+		if(uniqueName != null) {
+			document.addField("uniqueName_docvalues_string", uniqueName);
+		}
+		if(ext != null) {
+			document.addField("ext_docvalues_string", ext);
+		}
+		if(tempactive != null) {
+			document.addField("tempactive_docvalues_string", tempactive);
+		}
+		if(s3path != null) {
+			document.addField("s3path_docvalues_string", s3path);
+		}
+		if(sdfStatus != null) {
+			document.addField("sdfStatus_docvalues_string", sdfStatus);
+		}
+		if(transcoded != null) {
+			document.addField("transcoded_docvalues_string", transcoded);
+		}
+		if(lodestar != null) {
+			document.addField("lodestar_docvalues_string", lodestar);
+		}
+		if(archive != null) {
+			document.addField("archive_docvalues_string", archive);
+		}
+		if(identifier != null) {
+			document.addField("identifier_docvalues_string", identifier);
+		}
+		if(displayName != null) {
+			document.addField("displayName_docvalues_string", displayName);
+		}
+		if(subjectArea != null) {
+			document.addField("subjectArea_docvalues_string", subjectArea);
+		}
+		if(name != null) {
+			document.addField("name_docvalues_string", name);
+		}
+		super.indexBaseModel(document);
+
 	}
 
 	public static String varIndexedCurrikiResource(String entityVar) {
@@ -6832,6 +6831,36 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				return "displaySeqNo_docvalues_int";
 			case "fileId":
 				return "fileId_docvalues_int";
+			case "fileName":
+				return "fileName_docvalues_string";
+			case "uploadDate":
+				return "uploadDate_docvalues_string";
+			case "sequence":
+				return "sequence_docvalues_int";
+			case "uniqueName":
+				return "uniqueName_docvalues_string";
+			case "ext":
+				return "ext_docvalues_string";
+			case "tempactive":
+				return "tempactive_docvalues_string";
+			case "s3path":
+				return "s3path_docvalues_string";
+			case "sdfStatus":
+				return "sdfStatus_docvalues_string";
+			case "transcoded":
+				return "transcoded_docvalues_string";
+			case "lodestar":
+				return "lodestar_docvalues_string";
+			case "archive":
+				return "archive_docvalues_string";
+			case "identifier":
+				return "identifier_docvalues_string";
+			case "displayName":
+				return "displayName_docvalues_string";
+			case "subjectArea":
+				return "subjectArea_docvalues_string";
+			case "name":
+				return "name_docvalues_string";
 			default:
 				return BaseModel.varIndexedBaseModel(entityVar);
 		}
@@ -6855,94 +6884,109 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	// store //
 	/////////////
 
-	@Override public void storeForClass(SolrResponse.Doc doc) {
-		storeCurrikiResource(doc);
+	@Override public void storeForClass(SolrDocument solrDocument) {
+		storeCurrikiResource(solrDocument);
 	}
-	public void storeCurrikiResource(SolrResponse.Doc doc) {
+	public void storeCurrikiResource(SolrDocument solrDocument) {
 		CurrikiResource oCurrikiResource = (CurrikiResource)this;
 
-		oCurrikiResource.setResourceId(Optional.ofNullable(doc.get("resourceId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLicenseId(Optional.ofNullable(doc.get("licenseId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContributorId(Optional.ofNullable(doc.get("contributorId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContributionDate(Optional.ofNullable(doc.get("contributionDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDescription(Optional.ofNullable(doc.get("description_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTitle(Optional.ofNullable(doc.get("title_docvalues_string")).map(v -> v.toString()).orElse(null));
-		Optional.ofNullable((List<?>)doc.get("keywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		oCurrikiResource.setResourceId(Optional.ofNullable(solrDocument.get("resourceId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLicenseId(Optional.ofNullable(solrDocument.get("licenseId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContributorId(Optional.ofNullable(solrDocument.get("contributorId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContributionDate(Optional.ofNullable(solrDocument.get("contributionDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDescription(Optional.ofNullable(solrDocument.get("description_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTitle(Optional.ofNullable(solrDocument.get("title_docvalues_string")).map(v -> v.toString()).orElse(null));
+		Optional.ofNullable((List<?>)solrDocument.get("keywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oCurrikiResource.addKeywords(v.toString());
 		});
-		Optional.ofNullable((List<?>)doc.get("generatedKeywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		Optional.ofNullable((List<?>)solrDocument.get("generatedKeywords_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oCurrikiResource.addGeneratedKeywords(v.toString());
 		});
-		oCurrikiResource.setLanguage(Optional.ofNullable(doc.get("language_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastEditorId(Optional.ofNullable(doc.get("lastEditorId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastEditDate(Optional.ofNullable(doc.get("lastEditDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setCurrikiLicense(Optional.ofNullable(doc.get("currikiLicense_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setExternalUrl(Optional.ofNullable(doc.get("externalUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceChecked(Optional.ofNullable(doc.get("resourceChecked_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContent(Optional.ofNullable(doc.get("content_stored_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceCheckDate(Optional.ofNullable(doc.get("resourceCheckDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setResourceCheckId(Optional.ofNullable(doc.get("resourceCheckId_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStudentFacing(Optional.ofNullable(doc.get("studentFacing_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSource(Optional.ofNullable(doc.get("source_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewStatus(Optional.ofNullable(doc.get("reviewStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastReviewDate(Optional.ofNullable(doc.get("lastReviewDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewByID(Optional.ofNullable(doc.get("reviewByID_docvalues_long")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewRating(Optional.ofNullable(doc.get("reviewRating_docvalues_double")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTechnicalCompleteness(Optional.ofNullable(doc.get("technicalCompleteness_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContentAccuracy(Optional.ofNullable(doc.get("contentAccuracy_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPedagogy(Optional.ofNullable(doc.get("pedagogy_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRatingComment(Optional.ofNullable(doc.get("ratingComment_stored_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStandardsAlignment(Optional.ofNullable(doc.get("standardsAlignment_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setStandardsAlignmentComment(Optional.ofNullable(doc.get("standardsAlignmentComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectMatter(Optional.ofNullable(doc.get("subjectMatter_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSubjectMatterComment(Optional.ofNullable(doc.get("subjectMatterComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSupportsTeaching(Optional.ofNullable(doc.get("supportsTeaching_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSupportsTeachingComment(Optional.ofNullable(doc.get("supportsTeachingComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAssessmentsQuality(Optional.ofNullable(doc.get("assessmentsQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAssessmentsQualityComment(Optional.ofNullable(doc.get("assessmentsQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInteractivityQuality(Optional.ofNullable(doc.get("interactivityQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInteractivityQualityComment(Optional.ofNullable(doc.get("interactivityQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionalQuality(Optional.ofNullable(doc.get("instructionalQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setInstructionalQualityComment(Optional.ofNullable(doc.get("instructionalQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDeeperLearning(Optional.ofNullable(doc.get("deeperLearning_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDeeperLearningComment(Optional.ofNullable(doc.get("deeperLearningComment_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPartner(Optional.ofNullable(doc.get("partner_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setCreateDate(Optional.ofNullable(doc.get("createDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setType(Optional.ofNullable(doc.get("type_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setFeatured(Optional.ofNullable(doc.get("featured_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPage(Optional.ofNullable(doc.get("page_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setActive(Optional.ofNullable(doc.get("active_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPublic(Optional.ofNullable(doc.get("Public_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setXwd_id(Optional.ofNullable(doc.get("xwd_id_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMediaType(Optional.ofNullable(doc.get("mediaType_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAccess(Optional.ofNullable(doc.get("access_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMemberRating(Optional.ofNullable(doc.get("memberRating_docvalues_double")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setAligned(Optional.ofNullable(doc.get("aligned_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPageUrl(Optional.ofNullable(doc.get("pageUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexed(Optional.ofNullable(doc.get("indexed_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setLastIndexDate(Optional.ofNullable(doc.get("lastIndexDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexRequired(Optional.ofNullable(doc.get("indexRequired_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setIndexRequiredDate(Optional.ofNullable(doc.get("indexRequiredDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRescrape(Optional.ofNullable(doc.get("rescrape_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setGoButton(Optional.ofNullable(doc.get("goButton_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDownloadButton(Optional.ofNullable(doc.get("downloadButton_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTopOfSearch(Optional.ofNullable(doc.get("topOfSearch_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setRemove(Optional.ofNullable(doc.get("remove_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSpam(Optional.ofNullable(doc.get("spam_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setTopOfSearchInt(Optional.ofNullable(doc.get("topOfSearchInt_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setPartnerInt(Optional.ofNullable(doc.get("partnerInt_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setReviewResource(Optional.ofNullable(doc.get("reviewResource_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setOldUrl(Optional.ofNullable(doc.get("oldUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setContentDisplayOk(Optional.ofNullable(doc.get("contentDisplayOk_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setMetadata(Optional.ofNullable(doc.get("metadata_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setApprovalStatus(Optional.ofNullable(doc.get("approvalStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setApprovalStatusDate(Optional.ofNullable(doc.get("approvalStatusDate_docvalues_date")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setSpamUser(Optional.ofNullable(doc.get("spamUser_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setUrl(Optional.ofNullable(doc.get("url_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setDisplaySeqNo(Optional.ofNullable(doc.get("displaySeqNo_docvalues_int")).map(v -> v.toString()).orElse(null));
-		oCurrikiResource.setFileId(Optional.ofNullable(doc.get("fileId_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLanguage(Optional.ofNullable(solrDocument.get("language_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastEditorId(Optional.ofNullable(solrDocument.get("lastEditorId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastEditDate(Optional.ofNullable(solrDocument.get("lastEditDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setCurrikiLicense(Optional.ofNullable(solrDocument.get("currikiLicense_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setExternalUrl(Optional.ofNullable(solrDocument.get("externalUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceChecked(Optional.ofNullable(solrDocument.get("resourceChecked_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContent(Optional.ofNullable(solrDocument.get("content_stored_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceCheckDate(Optional.ofNullable(solrDocument.get("resourceCheckDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setResourceCheckId(Optional.ofNullable(solrDocument.get("resourceCheckId_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStudentFacing(Optional.ofNullable(solrDocument.get("studentFacing_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSource(Optional.ofNullable(solrDocument.get("source_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewStatus(Optional.ofNullable(solrDocument.get("reviewStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastReviewDate(Optional.ofNullable(solrDocument.get("lastReviewDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewByID(Optional.ofNullable(solrDocument.get("reviewByID_docvalues_long")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewRating(Optional.ofNullable(solrDocument.get("reviewRating_docvalues_double")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTechnicalCompleteness(Optional.ofNullable(solrDocument.get("technicalCompleteness_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContentAccuracy(Optional.ofNullable(solrDocument.get("contentAccuracy_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPedagogy(Optional.ofNullable(solrDocument.get("pedagogy_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRatingComment(Optional.ofNullable(solrDocument.get("ratingComment_stored_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStandardsAlignment(Optional.ofNullable(solrDocument.get("standardsAlignment_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setStandardsAlignmentComment(Optional.ofNullable(solrDocument.get("standardsAlignmentComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectMatter(Optional.ofNullable(solrDocument.get("subjectMatter_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectMatterComment(Optional.ofNullable(solrDocument.get("subjectMatterComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSupportsTeaching(Optional.ofNullable(solrDocument.get("supportsTeaching_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSupportsTeachingComment(Optional.ofNullable(solrDocument.get("supportsTeachingComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAssessmentsQuality(Optional.ofNullable(solrDocument.get("assessmentsQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAssessmentsQualityComment(Optional.ofNullable(solrDocument.get("assessmentsQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInteractivityQuality(Optional.ofNullable(solrDocument.get("interactivityQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInteractivityQualityComment(Optional.ofNullable(solrDocument.get("interactivityQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionalQuality(Optional.ofNullable(solrDocument.get("instructionalQuality_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setInstructionalQualityComment(Optional.ofNullable(solrDocument.get("instructionalQualityComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDeeperLearning(Optional.ofNullable(solrDocument.get("deeperLearning_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDeeperLearningComment(Optional.ofNullable(solrDocument.get("deeperLearningComment_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPartner(Optional.ofNullable(solrDocument.get("partner_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setCreateDate(Optional.ofNullable(solrDocument.get("createDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setType(Optional.ofNullable(solrDocument.get("type_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFeatured(Optional.ofNullable(solrDocument.get("featured_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPage(Optional.ofNullable(solrDocument.get("page_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setActive(Optional.ofNullable(solrDocument.get("active_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPublic(Optional.ofNullable(solrDocument.get("Public_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setXwd_id(Optional.ofNullable(solrDocument.get("xwd_id_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMediaType(Optional.ofNullable(solrDocument.get("mediaType_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAccess(Optional.ofNullable(solrDocument.get("access_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMemberRating(Optional.ofNullable(solrDocument.get("memberRating_docvalues_double")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setAligned(Optional.ofNullable(solrDocument.get("aligned_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPageUrl(Optional.ofNullable(solrDocument.get("pageUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexed(Optional.ofNullable(solrDocument.get("indexed_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLastIndexDate(Optional.ofNullable(solrDocument.get("lastIndexDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexRequired(Optional.ofNullable(solrDocument.get("indexRequired_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIndexRequiredDate(Optional.ofNullable(solrDocument.get("indexRequiredDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRescrape(Optional.ofNullable(solrDocument.get("rescrape_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setGoButton(Optional.ofNullable(solrDocument.get("goButton_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDownloadButton(Optional.ofNullable(solrDocument.get("downloadButton_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTopOfSearch(Optional.ofNullable(solrDocument.get("topOfSearch_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setRemove(Optional.ofNullable(solrDocument.get("remove_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSpam(Optional.ofNullable(solrDocument.get("spam_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTopOfSearchInt(Optional.ofNullable(solrDocument.get("topOfSearchInt_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setPartnerInt(Optional.ofNullable(solrDocument.get("partnerInt_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setReviewResource(Optional.ofNullable(solrDocument.get("reviewResource_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setOldUrl(Optional.ofNullable(solrDocument.get("oldUrl_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setContentDisplayOk(Optional.ofNullable(solrDocument.get("contentDisplayOk_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setMetadata(Optional.ofNullable(solrDocument.get("metadata_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setApprovalStatus(Optional.ofNullable(solrDocument.get("approvalStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setApprovalStatusDate(Optional.ofNullable(solrDocument.get("approvalStatusDate_docvalues_date")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSpamUser(Optional.ofNullable(solrDocument.get("spamUser_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUrl(Optional.ofNullable(solrDocument.get("url_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDisplaySeqNo(Optional.ofNullable(solrDocument.get("displaySeqNo_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFileId(Optional.ofNullable(solrDocument.get("fileId_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setFileName(Optional.ofNullable(solrDocument.get("fileName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUploadDate(Optional.ofNullable(solrDocument.get("uploadDate_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSequence(Optional.ofNullable(solrDocument.get("sequence_docvalues_int")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setUniqueName(Optional.ofNullable(solrDocument.get("uniqueName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setExt(Optional.ofNullable(solrDocument.get("ext_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTempactive(Optional.ofNullable(solrDocument.get("tempactive_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setS3path(Optional.ofNullable(solrDocument.get("s3path_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSdfStatus(Optional.ofNullable(solrDocument.get("sdfStatus_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setTranscoded(Optional.ofNullable(solrDocument.get("transcoded_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setLodestar(Optional.ofNullable(solrDocument.get("lodestar_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setArchive(Optional.ofNullable(solrDocument.get("archive_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setIdentifier(Optional.ofNullable(solrDocument.get("identifier_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setDisplayName(Optional.ofNullable(solrDocument.get("displayName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setSubjectArea(Optional.ofNullable(solrDocument.get("subjectArea_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oCurrikiResource.setName(Optional.ofNullable(solrDocument.get("name_docvalues_string")).map(v -> v.toString()).orElse(null));
 
-		super.storeBaseModel(doc);
+		super.storeBaseModel(solrDocument);
 	}
 
 	//////////////////
@@ -6950,7 +6994,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	//////////////////
 
 	public void apiRequestCurrikiResource() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof CurrikiResource) {
 			CurrikiResource original = (CurrikiResource)o;
@@ -6966,12 +7010,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("description");
 			if(!Objects.equals(title, original.getTitle()))
 				apiRequest.addVars("title");
-			if(!Objects.equals(keywordsStr, original.getKeywordsStr()))
-				apiRequest.addVars("keywordsStr");
 			if(!Objects.equals(keywords, original.getKeywords()))
 				apiRequest.addVars("keywords");
-			if(!Objects.equals(generatedKeywordsStr, original.getGeneratedKeywordsStr()))
-				apiRequest.addVars("generatedKeywordsStr");
 			if(!Objects.equals(generatedKeywords, original.getGeneratedKeywords()))
 				apiRequest.addVars("generatedKeywords");
 			if(!Objects.equals(language, original.getLanguage()))
@@ -6988,14 +7028,10 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("resourceChecked");
 			if(!Objects.equals(content, original.getContent()))
 				apiRequest.addVars("content");
-			if(!Objects.equals(resourceCheckRequestNote, original.getResourceCheckRequestNote()))
-				apiRequest.addVars("resourceCheckRequestNote");
 			if(!Objects.equals(resourceCheckDate, original.getResourceCheckDate()))
 				apiRequest.addVars("resourceCheckDate");
 			if(!Objects.equals(resourceCheckId, original.getResourceCheckId()))
 				apiRequest.addVars("resourceCheckId");
-			if(!Objects.equals(resourceCheckNote, original.getResourceCheckNote()))
-				apiRequest.addVars("resourceCheckNote");
 			if(!Objects.equals(studentFacing, original.getStudentFacing()))
 				apiRequest.addVars("studentFacing");
 			if(!Objects.equals(source, original.getSource()))
@@ -7114,6 +7150,36 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 				apiRequest.addVars("displaySeqNo");
 			if(!Objects.equals(fileId, original.getFileId()))
 				apiRequest.addVars("fileId");
+			if(!Objects.equals(fileName, original.getFileName()))
+				apiRequest.addVars("fileName");
+			if(!Objects.equals(uploadDate, original.getUploadDate()))
+				apiRequest.addVars("uploadDate");
+			if(!Objects.equals(sequence, original.getSequence()))
+				apiRequest.addVars("sequence");
+			if(!Objects.equals(uniqueName, original.getUniqueName()))
+				apiRequest.addVars("uniqueName");
+			if(!Objects.equals(ext, original.getExt()))
+				apiRequest.addVars("ext");
+			if(!Objects.equals(tempactive, original.getTempactive()))
+				apiRequest.addVars("tempactive");
+			if(!Objects.equals(s3path, original.getS3path()))
+				apiRequest.addVars("s3path");
+			if(!Objects.equals(sdfStatus, original.getSdfStatus()))
+				apiRequest.addVars("sdfStatus");
+			if(!Objects.equals(transcoded, original.getTranscoded()))
+				apiRequest.addVars("transcoded");
+			if(!Objects.equals(lodestar, original.getLodestar()))
+				apiRequest.addVars("lodestar");
+			if(!Objects.equals(archive, original.getArchive()))
+				apiRequest.addVars("archive");
+			if(!Objects.equals(identifier, original.getIdentifier()))
+				apiRequest.addVars("identifier");
+			if(!Objects.equals(displayName, original.getDisplayName()))
+				apiRequest.addVars("displayName");
+			if(!Objects.equals(subjectArea, original.getSubjectArea()))
+				apiRequest.addVars("subjectArea");
+			if(!Objects.equals(name, original.getName()))
+				apiRequest.addVars("name");
 			super.apiRequestBaseModel();
 		}
 	}
@@ -7131,9 +7197,7 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(contributionDate).map(v -> "contributionDate: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(description).map(v -> "description: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(title).map(v -> "title: \"" + v + "\"\n" ).orElse(""));
-		sb.append(Optional.ofNullable(keywordsStr).map(v -> "keywordsStr: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(keywords).map(v -> "keywords: " + v + "\n").orElse(""));
-		sb.append(Optional.ofNullable(generatedKeywordsStr).map(v -> "generatedKeywordsStr: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(generatedKeywords).map(v -> "generatedKeywords: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(language).map(v -> "language: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(lastEditorId).map(v -> "lastEditorId: " + v + "\n").orElse(""));
@@ -7142,10 +7206,8 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(externalUrl).map(v -> "externalUrl: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(resourceChecked).map(v -> "resourceChecked: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(content).map(v -> "content: \"" + v + "\"\n" ).orElse(""));
-		sb.append(Optional.ofNullable(resourceCheckRequestNote).map(v -> "resourceCheckRequestNote: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(resourceCheckDate).map(v -> "resourceCheckDate: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(resourceCheckId).map(v -> "resourceCheckId: " + v + "\n").orElse(""));
-		sb.append(Optional.ofNullable(resourceCheckNote).map(v -> "resourceCheckNote: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(studentFacing).map(v -> "studentFacing: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(source).map(v -> "source: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(reviewStatus).map(v -> "reviewStatus: \"" + v + "\"\n" ).orElse(""));
@@ -7205,10 +7267,24 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 		sb.append(Optional.ofNullable(url).map(v -> "url: \"" + v + "\"\n" ).orElse(""));
 		sb.append(Optional.ofNullable(displaySeqNo).map(v -> "displaySeqNo: " + v + "\n").orElse(""));
 		sb.append(Optional.ofNullable(fileId).map(v -> "fileId: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(fileName).map(v -> "fileName: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(uploadDate).map(v -> "uploadDate: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(sequence).map(v -> "sequence: " + v + "\n").orElse(""));
+		sb.append(Optional.ofNullable(uniqueName).map(v -> "uniqueName: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(ext).map(v -> "ext: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(tempactive).map(v -> "tempactive: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(s3path).map(v -> "s3path: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(sdfStatus).map(v -> "sdfStatus: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(transcoded).map(v -> "transcoded: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(lodestar).map(v -> "lodestar: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(archive).map(v -> "archive: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(identifier).map(v -> "identifier: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(displayName).map(v -> "displayName: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(subjectArea).map(v -> "subjectArea: \"" + v + "\"\n" ).orElse(""));
+		sb.append(Optional.ofNullable(name).map(v -> "name: \"" + v + "\"\n" ).orElse(""));
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "CurrikiResource";
 	public static final String VAR_resourceId = "resourceId";
 	public static final String VAR_licenseId = "licenseId";
 	public static final String VAR_contributorId = "contributorId";
@@ -7289,925 +7365,19 @@ public abstract class CurrikiResourceGen<DEV> extends BaseModel {
 	public static final String VAR_url = "url";
 	public static final String VAR_displaySeqNo = "displaySeqNo";
 	public static final String VAR_fileId = "fileId";
-
-	public static List<String> varsQForClass() {
-		return CurrikiResource.varsQCurrikiResource(new ArrayList<String>());
-	}
-	public static List<String> varsQCurrikiResource(List<String> vars) {
-		BaseModel.varsQBaseModel(vars);
-		return vars;
-	}
-
-	public static List<String> varsFqForClass() {
-		return CurrikiResource.varsFqCurrikiResource(new ArrayList<String>());
-	}
-	public static List<String> varsFqCurrikiResource(List<String> vars) {
-		vars.add(VAR_resourceId);
-		vars.add(VAR_licenseId);
-		vars.add(VAR_contributorId);
-		vars.add(VAR_contributionDate);
-		vars.add(VAR_description);
-		vars.add(VAR_title);
-		vars.add(VAR_keywords);
-		vars.add(VAR_generatedKeywords);
-		vars.add(VAR_language);
-		vars.add(VAR_lastEditorId);
-		vars.add(VAR_lastEditDate);
-		vars.add(VAR_currikiLicense);
-		vars.add(VAR_externalUrl);
-		vars.add(VAR_resourceChecked);
-		vars.add(VAR_resourceCheckDate);
-		vars.add(VAR_resourceCheckId);
-		vars.add(VAR_studentFacing);
-		vars.add(VAR_source);
-		vars.add(VAR_reviewStatus);
-		vars.add(VAR_lastReviewDate);
-		vars.add(VAR_reviewByID);
-		vars.add(VAR_reviewRating);
-		vars.add(VAR_technicalCompleteness);
-		vars.add(VAR_contentAccuracy);
-		vars.add(VAR_pedagogy);
-		vars.add(VAR_standardsAlignment);
-		vars.add(VAR_standardsAlignmentComment);
-		vars.add(VAR_subjectMatter);
-		vars.add(VAR_subjectMatterComment);
-		vars.add(VAR_supportsTeaching);
-		vars.add(VAR_supportsTeachingComment);
-		vars.add(VAR_assessmentsQuality);
-		vars.add(VAR_assessmentsQualityComment);
-		vars.add(VAR_interactivityQuality);
-		vars.add(VAR_interactivityQualityComment);
-		vars.add(VAR_instructionalQuality);
-		vars.add(VAR_instructionalQualityComment);
-		vars.add(VAR_deeperLearning);
-		vars.add(VAR_deeperLearningComment);
-		vars.add(VAR_partner);
-		vars.add(VAR_createDate);
-		vars.add(VAR_type);
-		vars.add(VAR_featured);
-		vars.add(VAR_page);
-		vars.add(VAR_active);
-		vars.add(VAR_Public);
-		vars.add(VAR_xwd_id);
-		vars.add(VAR_mediaType);
-		vars.add(VAR_access);
-		vars.add(VAR_memberRating);
-		vars.add(VAR_aligned);
-		vars.add(VAR_pageUrl);
-		vars.add(VAR_indexed);
-		vars.add(VAR_lastIndexDate);
-		vars.add(VAR_indexRequired);
-		vars.add(VAR_indexRequiredDate);
-		vars.add(VAR_rescrape);
-		vars.add(VAR_goButton);
-		vars.add(VAR_downloadButton);
-		vars.add(VAR_topOfSearch);
-		vars.add(VAR_remove);
-		vars.add(VAR_spam);
-		vars.add(VAR_topOfSearchInt);
-		vars.add(VAR_partnerInt);
-		vars.add(VAR_reviewResource);
-		vars.add(VAR_oldUrl);
-		vars.add(VAR_contentDisplayOk);
-		vars.add(VAR_metadata);
-		vars.add(VAR_approvalStatus);
-		vars.add(VAR_approvalStatusDate);
-		vars.add(VAR_spamUser);
-		vars.add(VAR_url);
-		vars.add(VAR_displaySeqNo);
-		vars.add(VAR_fileId);
-		BaseModel.varsFqBaseModel(vars);
-		return vars;
-	}
-
-	public static List<String> varsRangeForClass() {
-		return CurrikiResource.varsRangeCurrikiResource(new ArrayList<String>());
-	}
-	public static List<String> varsRangeCurrikiResource(List<String> vars) {
-		vars.add(VAR_contributorId);
-		vars.add(VAR_contributionDate);
-		vars.add(VAR_lastEditorId);
-		vars.add(VAR_lastEditDate);
-		vars.add(VAR_resourceCheckDate);
-		vars.add(VAR_resourceCheckId);
-		vars.add(VAR_lastReviewDate);
-		vars.add(VAR_reviewByID);
-		vars.add(VAR_reviewRating);
-		vars.add(VAR_technicalCompleteness);
-		vars.add(VAR_contentAccuracy);
-		vars.add(VAR_pedagogy);
-		vars.add(VAR_standardsAlignment);
-		vars.add(VAR_subjectMatter);
-		vars.add(VAR_supportsTeaching);
-		vars.add(VAR_assessmentsQuality);
-		vars.add(VAR_interactivityQuality);
-		vars.add(VAR_instructionalQuality);
-		vars.add(VAR_deeperLearning);
-		vars.add(VAR_createDate);
-		vars.add(VAR_xwd_id);
-		vars.add(VAR_memberRating);
-		vars.add(VAR_lastIndexDate);
-		vars.add(VAR_indexRequiredDate);
-		vars.add(VAR_topOfSearchInt);
-		vars.add(VAR_partnerInt);
-		vars.add(VAR_approvalStatusDate);
-		vars.add(VAR_displaySeqNo);
-		vars.add(VAR_fileId);
-		BaseModel.varsRangeBaseModel(vars);
-		return vars;
-	}
-
-	public static final String DISPLAY_NAME_resourceId = "resource ID";
-	public static final String DISPLAY_NAME_licenseId = "license ID";
-	public static final String DISPLAY_NAME_contributorId = "contributor ID";
-	public static final String DISPLAY_NAME_contributionDate = "contribution Date";
-	public static final String DISPLAY_NAME_description = "description";
-	public static final String DISPLAY_NAME_title = "title";
-	public static final String DISPLAY_NAME_keywordsStr = "Keywords String";
-	public static final String DISPLAY_NAME_keywords = "Keywords List";
-	public static final String DISPLAY_NAME_generatedKeywordsStr = "Generated Keywords String";
-	public static final String DISPLAY_NAME_generatedKeywords = "Generated Keywords List";
-	public static final String DISPLAY_NAME_language = "Language";
-	public static final String DISPLAY_NAME_lastEditorId = "Last Editor ID";
-	public static final String DISPLAY_NAME_lastEditDate = "Last Edit Date";
-	public static final String DISPLAY_NAME_currikiLicense = "Curriki License";
-	public static final String DISPLAY_NAME_externalUrl = "External URL";
-	public static final String DISPLAY_NAME_resourceChecked = "Resource Checked";
-	public static final String DISPLAY_NAME_content = "External URL";
-	public static final String DISPLAY_NAME_resourceCheckRequestNote = "Resource Check Request Note";
-	public static final String DISPLAY_NAME_resourceCheckDate = "Resource Check Date";
-	public static final String DISPLAY_NAME_resourceCheckId = "Resource Check ID";
-	public static final String DISPLAY_NAME_resourceCheckNote = "Resource Check Note";
-	public static final String DISPLAY_NAME_studentFacing = "Student Facing";
-	public static final String DISPLAY_NAME_source = "Source";
-	public static final String DISPLAY_NAME_reviewStatus = "Review Status";
-	public static final String DISPLAY_NAME_lastReviewDate = "Last Review Date";
-	public static final String DISPLAY_NAME_reviewByID = "Review By ID";
-	public static final String DISPLAY_NAME_reviewRating = "Review Rating";
-	public static final String DISPLAY_NAME_technicalCompleteness = "Technical Completeness";
-	public static final String DISPLAY_NAME_contentAccuracy = "Content Accuracy";
-	public static final String DISPLAY_NAME_pedagogy = "Pedagogy";
-	public static final String DISPLAY_NAME_ratingComment = "Rating Comment";
-	public static final String DISPLAY_NAME_standardsAlignment = "Standards Alignment";
-	public static final String DISPLAY_NAME_standardsAlignmentComment = "Standards Alignment Comment";
-	public static final String DISPLAY_NAME_subjectMatter = "Subject Matter";
-	public static final String DISPLAY_NAME_subjectMatterComment = "Subject Matter Comment";
-	public static final String DISPLAY_NAME_supportsTeaching = "Supports Teaching";
-	public static final String DISPLAY_NAME_supportsTeachingComment = "Supports Teaching Comment";
-	public static final String DISPLAY_NAME_assessmentsQuality = "Assessments Quality";
-	public static final String DISPLAY_NAME_assessmentsQualityComment = "Assessments Quality Comment";
-	public static final String DISPLAY_NAME_interactivityQuality = "Interactivity Quality";
-	public static final String DISPLAY_NAME_interactivityQualityComment = "Interactivity Quality Comment";
-	public static final String DISPLAY_NAME_instructionalQuality = "Instructional Quality";
-	public static final String DISPLAY_NAME_instructionalQualityComment = "Instructional Quality Comment";
-	public static final String DISPLAY_NAME_deeperLearning = "Deeper Learning";
-	public static final String DISPLAY_NAME_deeperLearningComment = "Deeper Learning Comment";
-	public static final String DISPLAY_NAME_partner = "Partner";
-	public static final String DISPLAY_NAME_createDate = "Create Date";
-	public static final String DISPLAY_NAME_type = "Type";
-	public static final String DISPLAY_NAME_featured = "Featured";
-	public static final String DISPLAY_NAME_page = "Page";
-	public static final String DISPLAY_NAME_active = "Active";
-	public static final String DISPLAY_NAME_Public = "Public";
-	public static final String DISPLAY_NAME_xwd_id = "xwd ID";
-	public static final String DISPLAY_NAME_mediaType = "Media Type";
-	public static final String DISPLAY_NAME_access = "Access";
-	public static final String DISPLAY_NAME_memberRating = "Member Rating";
-	public static final String DISPLAY_NAME_aligned = "Aligned";
-	public static final String DISPLAY_NAME_pageUrl = "Page URL";
-	public static final String DISPLAY_NAME_indexed = "Indexed";
-	public static final String DISPLAY_NAME_lastIndexDate = "Last Index Date";
-	public static final String DISPLAY_NAME_indexRequired = "Index Required";
-	public static final String DISPLAY_NAME_indexRequiredDate = "IndexRequiredDate";
-	public static final String DISPLAY_NAME_rescrape = "rescrape";
-	public static final String DISPLAY_NAME_goButton = "Go Button";
-	public static final String DISPLAY_NAME_downloadButton = "Download Button";
-	public static final String DISPLAY_NAME_topOfSearch = "Top of Search";
-	public static final String DISPLAY_NAME_remove = "Remove";
-	public static final String DISPLAY_NAME_spam = "Spam";
-	public static final String DISPLAY_NAME_topOfSearchInt = "Top of search int";
-	public static final String DISPLAY_NAME_partnerInt = "Partner Int";
-	public static final String DISPLAY_NAME_reviewResource = "Review Resource";
-	public static final String DISPLAY_NAME_oldUrl = "Old URL";
-	public static final String DISPLAY_NAME_contentDisplayOk = "Content Display OK";
-	public static final String DISPLAY_NAME_metadata = "Metadata";
-	public static final String DISPLAY_NAME_approvalStatus = "Approval Status";
-	public static final String DISPLAY_NAME_approvalStatusDate = "Approval Status Date";
-	public static final String DISPLAY_NAME_spamUser = "Spam User";
-	public static final String DISPLAY_NAME_url = "URL";
-	public static final String DISPLAY_NAME_displaySeqNo = "Display Sequence Number";
-	public static final String DISPLAY_NAME_fileId = "File ID";
-
-	public static String displayNameForClass(String var) {
-		return CurrikiResource.displayNameCurrikiResource(var);
-	}
-	public static String displayNameCurrikiResource(String var) {
-		switch(var) {
-		case VAR_resourceId:
-			return DISPLAY_NAME_resourceId;
-		case VAR_licenseId:
-			return DISPLAY_NAME_licenseId;
-		case VAR_contributorId:
-			return DISPLAY_NAME_contributorId;
-		case VAR_contributionDate:
-			return DISPLAY_NAME_contributionDate;
-		case VAR_description:
-			return DISPLAY_NAME_description;
-		case VAR_title:
-			return DISPLAY_NAME_title;
-		case VAR_keywordsStr:
-			return DISPLAY_NAME_keywordsStr;
-		case VAR_keywords:
-			return DISPLAY_NAME_keywords;
-		case VAR_generatedKeywordsStr:
-			return DISPLAY_NAME_generatedKeywordsStr;
-		case VAR_generatedKeywords:
-			return DISPLAY_NAME_generatedKeywords;
-		case VAR_language:
-			return DISPLAY_NAME_language;
-		case VAR_lastEditorId:
-			return DISPLAY_NAME_lastEditorId;
-		case VAR_lastEditDate:
-			return DISPLAY_NAME_lastEditDate;
-		case VAR_currikiLicense:
-			return DISPLAY_NAME_currikiLicense;
-		case VAR_externalUrl:
-			return DISPLAY_NAME_externalUrl;
-		case VAR_resourceChecked:
-			return DISPLAY_NAME_resourceChecked;
-		case VAR_content:
-			return DISPLAY_NAME_content;
-		case VAR_resourceCheckRequestNote:
-			return DISPLAY_NAME_resourceCheckRequestNote;
-		case VAR_resourceCheckDate:
-			return DISPLAY_NAME_resourceCheckDate;
-		case VAR_resourceCheckId:
-			return DISPLAY_NAME_resourceCheckId;
-		case VAR_resourceCheckNote:
-			return DISPLAY_NAME_resourceCheckNote;
-		case VAR_studentFacing:
-			return DISPLAY_NAME_studentFacing;
-		case VAR_source:
-			return DISPLAY_NAME_source;
-		case VAR_reviewStatus:
-			return DISPLAY_NAME_reviewStatus;
-		case VAR_lastReviewDate:
-			return DISPLAY_NAME_lastReviewDate;
-		case VAR_reviewByID:
-			return DISPLAY_NAME_reviewByID;
-		case VAR_reviewRating:
-			return DISPLAY_NAME_reviewRating;
-		case VAR_technicalCompleteness:
-			return DISPLAY_NAME_technicalCompleteness;
-		case VAR_contentAccuracy:
-			return DISPLAY_NAME_contentAccuracy;
-		case VAR_pedagogy:
-			return DISPLAY_NAME_pedagogy;
-		case VAR_ratingComment:
-			return DISPLAY_NAME_ratingComment;
-		case VAR_standardsAlignment:
-			return DISPLAY_NAME_standardsAlignment;
-		case VAR_standardsAlignmentComment:
-			return DISPLAY_NAME_standardsAlignmentComment;
-		case VAR_subjectMatter:
-			return DISPLAY_NAME_subjectMatter;
-		case VAR_subjectMatterComment:
-			return DISPLAY_NAME_subjectMatterComment;
-		case VAR_supportsTeaching:
-			return DISPLAY_NAME_supportsTeaching;
-		case VAR_supportsTeachingComment:
-			return DISPLAY_NAME_supportsTeachingComment;
-		case VAR_assessmentsQuality:
-			return DISPLAY_NAME_assessmentsQuality;
-		case VAR_assessmentsQualityComment:
-			return DISPLAY_NAME_assessmentsQualityComment;
-		case VAR_interactivityQuality:
-			return DISPLAY_NAME_interactivityQuality;
-		case VAR_interactivityQualityComment:
-			return DISPLAY_NAME_interactivityQualityComment;
-		case VAR_instructionalQuality:
-			return DISPLAY_NAME_instructionalQuality;
-		case VAR_instructionalQualityComment:
-			return DISPLAY_NAME_instructionalQualityComment;
-		case VAR_deeperLearning:
-			return DISPLAY_NAME_deeperLearning;
-		case VAR_deeperLearningComment:
-			return DISPLAY_NAME_deeperLearningComment;
-		case VAR_partner:
-			return DISPLAY_NAME_partner;
-		case VAR_createDate:
-			return DISPLAY_NAME_createDate;
-		case VAR_type:
-			return DISPLAY_NAME_type;
-		case VAR_featured:
-			return DISPLAY_NAME_featured;
-		case VAR_page:
-			return DISPLAY_NAME_page;
-		case VAR_active:
-			return DISPLAY_NAME_active;
-		case VAR_Public:
-			return DISPLAY_NAME_Public;
-		case VAR_xwd_id:
-			return DISPLAY_NAME_xwd_id;
-		case VAR_mediaType:
-			return DISPLAY_NAME_mediaType;
-		case VAR_access:
-			return DISPLAY_NAME_access;
-		case VAR_memberRating:
-			return DISPLAY_NAME_memberRating;
-		case VAR_aligned:
-			return DISPLAY_NAME_aligned;
-		case VAR_pageUrl:
-			return DISPLAY_NAME_pageUrl;
-		case VAR_indexed:
-			return DISPLAY_NAME_indexed;
-		case VAR_lastIndexDate:
-			return DISPLAY_NAME_lastIndexDate;
-		case VAR_indexRequired:
-			return DISPLAY_NAME_indexRequired;
-		case VAR_indexRequiredDate:
-			return DISPLAY_NAME_indexRequiredDate;
-		case VAR_rescrape:
-			return DISPLAY_NAME_rescrape;
-		case VAR_goButton:
-			return DISPLAY_NAME_goButton;
-		case VAR_downloadButton:
-			return DISPLAY_NAME_downloadButton;
-		case VAR_topOfSearch:
-			return DISPLAY_NAME_topOfSearch;
-		case VAR_remove:
-			return DISPLAY_NAME_remove;
-		case VAR_spam:
-			return DISPLAY_NAME_spam;
-		case VAR_topOfSearchInt:
-			return DISPLAY_NAME_topOfSearchInt;
-		case VAR_partnerInt:
-			return DISPLAY_NAME_partnerInt;
-		case VAR_reviewResource:
-			return DISPLAY_NAME_reviewResource;
-		case VAR_oldUrl:
-			return DISPLAY_NAME_oldUrl;
-		case VAR_contentDisplayOk:
-			return DISPLAY_NAME_contentDisplayOk;
-		case VAR_metadata:
-			return DISPLAY_NAME_metadata;
-		case VAR_approvalStatus:
-			return DISPLAY_NAME_approvalStatus;
-		case VAR_approvalStatusDate:
-			return DISPLAY_NAME_approvalStatusDate;
-		case VAR_spamUser:
-			return DISPLAY_NAME_spamUser;
-		case VAR_url:
-			return DISPLAY_NAME_url;
-		case VAR_displaySeqNo:
-			return DISPLAY_NAME_displaySeqNo;
-		case VAR_fileId:
-			return DISPLAY_NAME_fileId;
-		default:
-			return BaseModel.displayNameBaseModel(var);
-		}
-	}
-
-	public static String descriptionCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.descriptionBaseModel(var);
-		}
-	}
-
-	public static String classSimpleNameCurrikiResource(String var) {
-		switch(var) {
-		case VAR_resourceId:
-			return "String";
-		case VAR_licenseId:
-			return "String";
-		case VAR_contributorId:
-			return "Long";
-		case VAR_contributionDate:
-			return "ZonedDateTime";
-		case VAR_description:
-			return "String";
-		case VAR_title:
-			return "String";
-		case VAR_keywordsStr:
-			return "String";
-		case VAR_keywords:
-			return "List";
-		case VAR_generatedKeywordsStr:
-			return "String";
-		case VAR_generatedKeywords:
-			return "List";
-		case VAR_language:
-			return "String";
-		case VAR_lastEditorId:
-			return "Long";
-		case VAR_lastEditDate:
-			return "ZonedDateTime";
-		case VAR_currikiLicense:
-			return "String";
-		case VAR_externalUrl:
-			return "String";
-		case VAR_resourceChecked:
-			return "String";
-		case VAR_content:
-			return "String";
-		case VAR_resourceCheckRequestNote:
-			return "String";
-		case VAR_resourceCheckDate:
-			return "ZonedDateTime";
-		case VAR_resourceCheckId:
-			return "Long";
-		case VAR_resourceCheckNote:
-			return "String";
-		case VAR_studentFacing:
-			return "String";
-		case VAR_source:
-			return "String";
-		case VAR_reviewStatus:
-			return "String";
-		case VAR_lastReviewDate:
-			return "ZonedDateTime";
-		case VAR_reviewByID:
-			return "Long";
-		case VAR_reviewRating:
-			return "BigDecimal";
-		case VAR_technicalCompleteness:
-			return "Integer";
-		case VAR_contentAccuracy:
-			return "Integer";
-		case VAR_pedagogy:
-			return "Integer";
-		case VAR_ratingComment:
-			return "String";
-		case VAR_standardsAlignment:
-			return "Integer";
-		case VAR_standardsAlignmentComment:
-			return "String";
-		case VAR_subjectMatter:
-			return "Integer";
-		case VAR_subjectMatterComment:
-			return "String";
-		case VAR_supportsTeaching:
-			return "Integer";
-		case VAR_supportsTeachingComment:
-			return "String";
-		case VAR_assessmentsQuality:
-			return "Integer";
-		case VAR_assessmentsQualityComment:
-			return "String";
-		case VAR_interactivityQuality:
-			return "Integer";
-		case VAR_interactivityQualityComment:
-			return "String";
-		case VAR_instructionalQuality:
-			return "Integer";
-		case VAR_instructionalQualityComment:
-			return "String";
-		case VAR_deeperLearning:
-			return "Integer";
-		case VAR_deeperLearningComment:
-			return "String";
-		case VAR_partner:
-			return "String";
-		case VAR_createDate:
-			return "ZonedDateTime";
-		case VAR_type:
-			return "String";
-		case VAR_featured:
-			return "String";
-		case VAR_page:
-			return "String";
-		case VAR_active:
-			return "String";
-		case VAR_Public:
-			return "String";
-		case VAR_xwd_id:
-			return "Integer";
-		case VAR_mediaType:
-			return "String";
-		case VAR_access:
-			return "String";
-		case VAR_memberRating:
-			return "BigDecimal";
-		case VAR_aligned:
-			return "String";
-		case VAR_pageUrl:
-			return "String";
-		case VAR_indexed:
-			return "String";
-		case VAR_lastIndexDate:
-			return "ZonedDateTime";
-		case VAR_indexRequired:
-			return "String";
-		case VAR_indexRequiredDate:
-			return "ZonedDateTime";
-		case VAR_rescrape:
-			return "String";
-		case VAR_goButton:
-			return "String";
-		case VAR_downloadButton:
-			return "String";
-		case VAR_topOfSearch:
-			return "String";
-		case VAR_remove:
-			return "String";
-		case VAR_spam:
-			return "String";
-		case VAR_topOfSearchInt:
-			return "Integer";
-		case VAR_partnerInt:
-			return "Integer";
-		case VAR_reviewResource:
-			return "String";
-		case VAR_oldUrl:
-			return "String";
-		case VAR_contentDisplayOk:
-			return "String";
-		case VAR_metadata:
-			return "String";
-		case VAR_approvalStatus:
-			return "String";
-		case VAR_approvalStatusDate:
-			return "ZonedDateTime";
-		case VAR_spamUser:
-			return "String";
-		case VAR_url:
-			return "String";
-		case VAR_displaySeqNo:
-			return "Integer";
-		case VAR_fileId:
-			return "Integer";
-			default:
-				return BaseModel.classSimpleNameBaseModel(var);
-		}
-	}
-
-	public static Integer htmlColumnCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.htmlColumnBaseModel(var);
-		}
-	}
-
-	public static Integer htmlRowCurrikiResource(String var) {
-		switch(var) {
-		case VAR_resourceId:
-			return 3;
-		case VAR_licenseId:
-			return 3;
-		case VAR_contributorId:
-			return 3;
-		case VAR_contributionDate:
-			return 4;
-		case VAR_description:
-			return 4;
-		case VAR_title:
-			return 4;
-		case VAR_keywordsStr:
-			return 5;
-		case VAR_keywords:
-			return 5;
-		case VAR_generatedKeywordsStr:
-			return 5;
-		case VAR_generatedKeywords:
-			return 6;
-		case VAR_language:
-			return 6;
-		case VAR_lastEditorId:
-			return 6;
-		case VAR_lastEditDate:
-			return 7;
-		case VAR_currikiLicense:
-			return 7;
-		case VAR_externalUrl:
-			return 7;
-		case VAR_resourceChecked:
-			return 8;
-		case VAR_content:
-			return 8;
-		case VAR_resourceCheckRequestNote:
-			return 8;
-		case VAR_resourceCheckDate:
-			return 9;
-		case VAR_resourceCheckId:
-			return 9;
-		case VAR_resourceCheckNote:
-			return 9;
-		case VAR_studentFacing:
-			return 10;
-		case VAR_source:
-			return 10;
-		case VAR_reviewStatus:
-			return 10;
-		case VAR_lastReviewDate:
-			return 11;
-		case VAR_reviewByID:
-			return 11;
-		case VAR_reviewRating:
-			return 11;
-		case VAR_technicalCompleteness:
-			return 12;
-		case VAR_contentAccuracy:
-			return 12;
-		case VAR_pedagogy:
-			return 12;
-		case VAR_ratingComment:
-			return 13;
-		case VAR_standardsAlignment:
-			return 13;
-		case VAR_standardsAlignmentComment:
-			return 13;
-		case VAR_subjectMatter:
-			return 14;
-		case VAR_subjectMatterComment:
-			return 14;
-		case VAR_supportsTeaching:
-			return 14;
-		case VAR_supportsTeachingComment:
-			return 15;
-		case VAR_assessmentsQuality:
-			return 15;
-		case VAR_assessmentsQualityComment:
-			return 15;
-		case VAR_interactivityQuality:
-			return 16;
-		case VAR_interactivityQualityComment:
-			return 16;
-		case VAR_instructionalQuality:
-			return 16;
-		case VAR_instructionalQualityComment:
-			return 17;
-		case VAR_deeperLearning:
-			return 17;
-		case VAR_deeperLearningComment:
-			return 17;
-		case VAR_partner:
-			return 18;
-		case VAR_createDate:
-			return 18;
-		case VAR_type:
-			return 18;
-		case VAR_featured:
-			return 19;
-		case VAR_page:
-			return 19;
-		case VAR_active:
-			return 19;
-		case VAR_Public:
-			return 20;
-		case VAR_xwd_id:
-			return 20;
-		case VAR_mediaType:
-			return 20;
-		case VAR_access:
-			return 21;
-		case VAR_memberRating:
-			return 21;
-		case VAR_aligned:
-			return 21;
-		case VAR_pageUrl:
-			return 22;
-		case VAR_indexed:
-			return 22;
-		case VAR_lastIndexDate:
-			return 22;
-		case VAR_indexRequired:
-			return 23;
-		case VAR_indexRequiredDate:
-			return 23;
-		case VAR_rescrape:
-			return 24;
-		case VAR_goButton:
-			return 25;
-		case VAR_downloadButton:
-			return 25;
-		case VAR_topOfSearch:
-			return 25;
-		case VAR_remove:
-			return 26;
-		case VAR_spam:
-			return 26;
-		case VAR_topOfSearchInt:
-			return 26;
-		case VAR_partnerInt:
-			return 27;
-		case VAR_reviewResource:
-			return 27;
-		case VAR_oldUrl:
-			return 27;
-		case VAR_contentDisplayOk:
-			return 28;
-		case VAR_metadata:
-			return 28;
-		case VAR_approvalStatus:
-			return 28;
-		case VAR_approvalStatusDate:
-			return 29;
-		case VAR_spamUser:
-			return 29;
-		case VAR_url:
-			return 30;
-		case VAR_displaySeqNo:
-			return 30;
-		case VAR_fileId:
-			return 30;
-			default:
-				return BaseModel.htmlRowBaseModel(var);
-		}
-	}
-
-	public static Integer htmlCellCurrikiResource(String var) {
-		switch(var) {
-		case VAR_resourceId:
-			return 1;
-		case VAR_licenseId:
-			return 2;
-		case VAR_contributorId:
-			return 3;
-		case VAR_contributionDate:
-			return 1;
-		case VAR_description:
-			return 2;
-		case VAR_title:
-			return 3;
-		case VAR_keywordsStr:
-			return 1;
-		case VAR_keywords:
-			return 2;
-		case VAR_generatedKeywordsStr:
-			return 3;
-		case VAR_generatedKeywords:
-			return 1;
-		case VAR_language:
-			return 2;
-		case VAR_lastEditorId:
-			return 3;
-		case VAR_lastEditDate:
-			return 1;
-		case VAR_currikiLicense:
-			return 2;
-		case VAR_externalUrl:
-			return 3;
-		case VAR_resourceChecked:
-			return 1;
-		case VAR_content:
-			return 2;
-		case VAR_resourceCheckRequestNote:
-			return 3;
-		case VAR_resourceCheckDate:
-			return 1;
-		case VAR_resourceCheckId:
-			return 2;
-		case VAR_resourceCheckNote:
-			return 3;
-		case VAR_studentFacing:
-			return 1;
-		case VAR_source:
-			return 2;
-		case VAR_reviewStatus:
-			return 3;
-		case VAR_lastReviewDate:
-			return 1;
-		case VAR_reviewByID:
-			return 2;
-		case VAR_reviewRating:
-			return 3;
-		case VAR_technicalCompleteness:
-			return 1;
-		case VAR_contentAccuracy:
-			return 2;
-		case VAR_pedagogy:
-			return 3;
-		case VAR_ratingComment:
-			return 1;
-		case VAR_standardsAlignment:
-			return 2;
-		case VAR_standardsAlignmentComment:
-			return 3;
-		case VAR_subjectMatter:
-			return 1;
-		case VAR_subjectMatterComment:
-			return 2;
-		case VAR_supportsTeaching:
-			return 3;
-		case VAR_supportsTeachingComment:
-			return 1;
-		case VAR_assessmentsQuality:
-			return 2;
-		case VAR_assessmentsQualityComment:
-			return 3;
-		case VAR_interactivityQuality:
-			return 1;
-		case VAR_interactivityQualityComment:
-			return 2;
-		case VAR_instructionalQuality:
-			return 3;
-		case VAR_instructionalQualityComment:
-			return 1;
-		case VAR_deeperLearning:
-			return 2;
-		case VAR_deeperLearningComment:
-			return 3;
-		case VAR_partner:
-			return 1;
-		case VAR_createDate:
-			return 2;
-		case VAR_type:
-			return 3;
-		case VAR_featured:
-			return 1;
-		case VAR_page:
-			return 2;
-		case VAR_active:
-			return 3;
-		case VAR_Public:
-			return 1;
-		case VAR_xwd_id:
-			return 2;
-		case VAR_mediaType:
-			return 3;
-		case VAR_access:
-			return 1;
-		case VAR_memberRating:
-			return 2;
-		case VAR_aligned:
-			return 3;
-		case VAR_pageUrl:
-			return 1;
-		case VAR_indexed:
-			return 2;
-		case VAR_lastIndexDate:
-			return 3;
-		case VAR_indexRequired:
-			return 1;
-		case VAR_indexRequiredDate:
-			return 2;
-		case VAR_rescrape:
-			return 3;
-		case VAR_goButton:
-			return 1;
-		case VAR_downloadButton:
-			return 2;
-		case VAR_topOfSearch:
-			return 3;
-		case VAR_remove:
-			return 1;
-		case VAR_spam:
-			return 2;
-		case VAR_topOfSearchInt:
-			return 3;
-		case VAR_partnerInt:
-			return 1;
-		case VAR_reviewResource:
-			return 2;
-		case VAR_oldUrl:
-			return 3;
-		case VAR_contentDisplayOk:
-			return 1;
-		case VAR_metadata:
-			return 2;
-		case VAR_approvalStatus:
-			return 3;
-		case VAR_approvalStatusDate:
-			return 1;
-		case VAR_spamUser:
-			return 2;
-		case VAR_url:
-			return 1;
-		case VAR_displaySeqNo:
-			return 2;
-		case VAR_fileId:
-			return 3;
-			default:
-				return BaseModel.htmlCellBaseModel(var);
-		}
-	}
-
-	public static Integer lengthMinCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.lengthMinBaseModel(var);
-		}
-	}
-
-	public static Integer lengthMaxCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.lengthMaxBaseModel(var);
-		}
-	}
-
-	public static Integer maxCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.maxBaseModel(var);
-		}
-	}
-
-	public static Integer minCurrikiResource(String var) {
-		switch(var) {
-			default:
-				return BaseModel.minBaseModel(var);
-		}
-	}
+	public static final String VAR_fileName = "fileName";
+	public static final String VAR_uploadDate = "uploadDate";
+	public static final String VAR_sequence = "sequence";
+	public static final String VAR_uniqueName = "uniqueName";
+	public static final String VAR_ext = "ext";
+	public static final String VAR_tempactive = "tempactive";
+	public static final String VAR_s3path = "s3path";
+	public static final String VAR_sdfStatus = "sdfStatus";
+	public static final String VAR_transcoded = "transcoded";
+	public static final String VAR_lodestar = "lodestar";
+	public static final String VAR_archive = "archive";
+	public static final String VAR_identifier = "identifier";
+	public static final String VAR_displayName = "displayName";
+	public static final String VAR_subjectArea = "subjectArea";
+	public static final String VAR_name = "name";
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPageGen.java
@@ -1,66 +1,49 @@
 package org.curriki.api.enus.model.resource;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import org.curriki.api.enus.model.base.BaseModelPage;
-import org.computate.vertx.search.list.SearchList;
+import java.util.HashMap;
 import org.curriki.api.enus.model.resource.CurrikiResource;
-import java.lang.String;
-import java.time.ZoneId;
-import java.util.Locale;
-import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-import java.time.format.DateTimeFormatter;
-import java.time.Instant;
-import java.time.OffsetDateTime;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
-import io.vertx.core.json.JsonArray;
-import org.computate.search.response.solr.SolrResponse.FacetCounts;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
 import java.lang.Long;
-import org.computate.search.wrap.Wrap;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import java.math.RoundingMode;
+import org.curriki.api.enus.search.SearchList;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
+import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.curriki.api.enus.base.BaseModelPage;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage">Find the class CurrikiResourceGenPage in Solr. </a>
- * <br><br>Delete the class CurrikiResourceGenPage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.resource in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.resource&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResourceGenPage.class);
@@ -76,10 +59,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<CurrikiResource> searchListCurrikiResource_;
 
-	/**	<br> The entity searchListCurrikiResource_
+	/**	<br/> The entity searchListCurrikiResource_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:searchListCurrikiResource_">Find the entity searchListCurrikiResource_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListCurrikiResource_">Find the entity searchListCurrikiResource_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListCurrikiResource_(Wrap<SearchList<CurrikiResource>> w);
@@ -103,704 +86,21 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	//////////////////
-	// pageResponse //
-	//////////////////
-
-	/**	 The entity pageResponse
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String pageResponse;
-
-	/**	<br> The entity pageResponse
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _pageResponse(Wrap<String> w);
-
-	public String getPageResponse() {
-		return pageResponse;
-	}
-	public void setPageResponse(String o) {
-		this.pageResponse = CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o);
-	}
-	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage pageResponseInit() {
-		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
-		if(pageResponse == null) {
-			_pageResponse(pageResponseWrap);
-			setPageResponse(pageResponseWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrPageResponse(siteRequest_, CurrikiResourceGenPage.staticSearchPageResponse(siteRequest_, CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o)));
-	}
-
-	///////////////////
-	// defaultZoneId //
-	///////////////////
-
-	/**	 The entity defaultZoneId
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultZoneId;
-
-	/**	<br> The entity defaultZoneId
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultZoneId">Find the entity defaultZoneId in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultZoneId(Wrap<String> w);
-
-	public String getDefaultZoneId() {
-		return defaultZoneId;
-	}
-	public void setDefaultZoneId(String o) {
-		this.defaultZoneId = CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o);
-	}
-	public static String staticSetDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage defaultZoneIdInit() {
-		Wrap<String> defaultZoneIdWrap = new Wrap<String>().var("defaultZoneId");
-		if(defaultZoneId == null) {
-			_defaultZoneId(defaultZoneIdWrap);
-			setDefaultZoneId(defaultZoneIdWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultZoneId(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultZoneId(siteRequest_, CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultTimeZone //
-	/////////////////////
-
-	/**	 The entity defaultTimeZone
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonIgnore
-	@JsonInclude(Include.NON_NULL)
-	protected ZoneId defaultTimeZone;
-
-	/**	<br> The entity defaultTimeZone
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultTimeZone">Find the entity defaultTimeZone in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultTimeZone(Wrap<ZoneId> w);
-
-	public ZoneId getDefaultTimeZone() {
-		return defaultTimeZone;
-	}
-
-	public void setDefaultTimeZone(ZoneId defaultTimeZone) {
-		this.defaultTimeZone = defaultTimeZone;
-	}
-	public static ZoneId staticSetDefaultTimeZone(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected CurrikiResourceGenPage defaultTimeZoneInit() {
-		Wrap<ZoneId> defaultTimeZoneWrap = new Wrap<ZoneId>().var("defaultTimeZone");
-		if(defaultTimeZone == null) {
-			_defaultTimeZone(defaultTimeZoneWrap);
-			setDefaultTimeZone(defaultTimeZoneWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	/////////////////////
-	// defaultLocaleId //
-	/////////////////////
-
-	/**	 The entity defaultLocaleId
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultLocaleId;
-
-	/**	<br> The entity defaultLocaleId
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultLocaleId">Find the entity defaultLocaleId in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultLocaleId(Wrap<String> w);
-
-	public String getDefaultLocaleId() {
-		return defaultLocaleId;
-	}
-	public void setDefaultLocaleId(String o) {
-		this.defaultLocaleId = CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o);
-	}
-	public static String staticSetDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage defaultLocaleIdInit() {
-		Wrap<String> defaultLocaleIdWrap = new Wrap<String>().var("defaultLocaleId");
-		if(defaultLocaleId == null) {
-			_defaultLocaleId(defaultLocaleIdWrap);
-			setDefaultLocaleId(defaultLocaleIdWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultLocaleId(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultLocaleId(siteRequest_, CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o)));
-	}
-
-	///////////////////
-	// defaultLocale //
-	///////////////////
-
-	/**	 The entity defaultLocale
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonIgnore
-	@JsonInclude(Include.NON_NULL)
-	protected Locale defaultLocale;
-
-	/**	<br> The entity defaultLocale
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultLocale">Find the entity defaultLocale in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultLocale(Wrap<Locale> w);
-
-	public Locale getDefaultLocale() {
-		return defaultLocale;
-	}
-
-	public void setDefaultLocale(Locale defaultLocale) {
-		this.defaultLocale = defaultLocale;
-	}
-	public static Locale staticSetDefaultLocale(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected CurrikiResourceGenPage defaultLocaleInit() {
-		Wrap<Locale> defaultLocaleWrap = new Wrap<Locale>().var("defaultLocale");
-		if(defaultLocale == null) {
-			_defaultLocale(defaultLocaleWrap);
-			setDefaultLocale(defaultLocaleWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	/////////////////////
-	// defaultRangeGap //
-	/////////////////////
-
-	/**	 The entity defaultRangeGap
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultRangeGap;
-
-	/**	<br> The entity defaultRangeGap
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeGap">Find the entity defaultRangeGap in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeGap(Wrap<String> w);
-
-	public String getDefaultRangeGap() {
-		return defaultRangeGap;
-	}
-	public void setDefaultRangeGap(String o) {
-		this.defaultRangeGap = CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o);
-	}
-	public static String staticSetDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage defaultRangeGapInit() {
-		Wrap<String> defaultRangeGapWrap = new Wrap<String>().var("defaultRangeGap");
-		if(defaultRangeGap == null) {
-			_defaultRangeGap(defaultRangeGapWrap);
-			setDefaultRangeGap(defaultRangeGapWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultRangeGap(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeGap(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultRangeEnd //
-	/////////////////////
-
-	/**	 The entity defaultRangeEnd
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
-	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
-	@JsonInclude(Include.NON_NULL)
-	protected ZonedDateTime defaultRangeEnd;
-
-	/**	<br> The entity defaultRangeEnd
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeEnd">Find the entity defaultRangeEnd in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeEnd(Wrap<ZonedDateTime> w);
-
-	public ZonedDateTime getDefaultRangeEnd() {
-		return defaultRangeEnd;
-	}
-
-	public void setDefaultRangeEnd(ZonedDateTime defaultRangeEnd) {
-		this.defaultRangeEnd = defaultRangeEnd;
-	}
-	@JsonIgnore
-	public void setDefaultRangeEnd(Instant o) {
-		this.defaultRangeEnd = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
-	}
-	/** Example: 2011-12-03T10:15:30+01:00 **/
-	@JsonIgnore
-	public void setDefaultRangeEnd(String o) {
-		this.defaultRangeEnd = CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
-	}
-	public static ZonedDateTime staticSetDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
-		if(StringUtils.endsWith(o, "Z"))
-			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-		else
-			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
-	}
-	@JsonIgnore
-	public void setDefaultRangeEnd(Date o) {
-		this.defaultRangeEnd = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-	}
-	protected CurrikiResourceGenPage defaultRangeEndInit() {
-		Wrap<ZonedDateTime> defaultRangeEndWrap = new Wrap<ZonedDateTime>().var("defaultRangeEnd");
-		if(defaultRangeEnd == null) {
-			_defaultRangeEnd(defaultRangeEndWrap);
-			setDefaultRangeEnd(defaultRangeEndWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static Date staticSearchDefaultRangeEnd(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
-		return o == null ? null : Date.from(o.toInstant());
-	}
-
-	public static String staticSearchStrDefaultRangeEnd(SiteRequestEnUS siteRequest_, Date o) {
-		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
-	}
-
-	public static String staticSearchFqDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeEnd(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o)));
-	}
-
-	///////////////////////
-	// defaultRangeStart //
-	///////////////////////
-
-	/**	 The entity defaultRangeStart
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
-	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
-	@JsonInclude(Include.NON_NULL)
-	protected ZonedDateTime defaultRangeStart;
-
-	/**	<br> The entity defaultRangeStart
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeStart">Find the entity defaultRangeStart in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeStart(Wrap<ZonedDateTime> w);
-
-	public ZonedDateTime getDefaultRangeStart() {
-		return defaultRangeStart;
-	}
-
-	public void setDefaultRangeStart(ZonedDateTime defaultRangeStart) {
-		this.defaultRangeStart = defaultRangeStart;
-	}
-	@JsonIgnore
-	public void setDefaultRangeStart(Instant o) {
-		this.defaultRangeStart = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
-	}
-	/** Example: 2011-12-03T10:15:30+01:00 **/
-	@JsonIgnore
-	public void setDefaultRangeStart(String o) {
-		this.defaultRangeStart = CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o);
-	}
-	public static ZonedDateTime staticSetDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
-		if(StringUtils.endsWith(o, "Z"))
-			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-		else
-			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
-	}
-	@JsonIgnore
-	public void setDefaultRangeStart(Date o) {
-		this.defaultRangeStart = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-	}
-	protected CurrikiResourceGenPage defaultRangeStartInit() {
-		Wrap<ZonedDateTime> defaultRangeStartWrap = new Wrap<ZonedDateTime>().var("defaultRangeStart");
-		if(defaultRangeStart == null) {
-			_defaultRangeStart(defaultRangeStartWrap);
-			setDefaultRangeStart(defaultRangeStartWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static Date staticSearchDefaultRangeStart(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
-		return o == null ? null : Date.from(o.toInstant());
-	}
-
-	public static String staticSearchStrDefaultRangeStart(SiteRequestEnUS siteRequest_, Date o) {
-		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
-	}
-
-	public static String staticSearchFqDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultRangeStart(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeStart(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultRangeVar //
-	/////////////////////
-
-	/**	 The entity defaultRangeVar
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultRangeVar;
-
-	/**	<br> The entity defaultRangeVar
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeVar">Find the entity defaultRangeVar in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeVar(Wrap<String> w);
-
-	public String getDefaultRangeVar() {
-		return defaultRangeVar;
-	}
-	public void setDefaultRangeVar(String o) {
-		this.defaultRangeVar = CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o);
-	}
-	public static String staticSetDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage defaultRangeVarInit() {
-		Wrap<String> defaultRangeVarWrap = new Wrap<String>().var("defaultRangeVar");
-		if(defaultRangeVar == null) {
-			_defaultRangeVar(defaultRangeVarWrap);
-			setDefaultRangeVar(defaultRangeVarWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultRangeVar(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeVar(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o)));
-	}
-
-	//////////////////////
-	// defaultFacetSort //
-	//////////////////////
-
-	/**	 The entity defaultFacetSort
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultFacetSort;
-
-	/**	<br> The entity defaultFacetSort
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetSort">Find the entity defaultFacetSort in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetSort(Wrap<String> w);
-
-	public String getDefaultFacetSort() {
-		return defaultFacetSort;
-	}
-	public void setDefaultFacetSort(String o) {
-		this.defaultFacetSort = CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o);
-	}
-	public static String staticSetDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage defaultFacetSortInit() {
-		Wrap<String> defaultFacetSortWrap = new Wrap<String>().var("defaultFacetSort");
-		if(defaultFacetSort == null) {
-			_defaultFacetSort(defaultFacetSortWrap);
-			setDefaultFacetSort(defaultFacetSortWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultFacetSort(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetSort(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o)));
-	}
-
-	///////////////////////
-	// defaultFacetLimit //
-	///////////////////////
-
-	/**	 The entity defaultFacetLimit
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultFacetLimit;
-
-	/**	<br> The entity defaultFacetLimit
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetLimit">Find the entity defaultFacetLimit in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetLimit(Wrap<Integer> w);
-
-	public Integer getDefaultFacetLimit() {
-		return defaultFacetLimit;
-	}
-
-	public void setDefaultFacetLimit(Integer defaultFacetLimit) {
-		this.defaultFacetLimit = defaultFacetLimit;
-	}
-	@JsonIgnore
-	public void setDefaultFacetLimit(String o) {
-		this.defaultFacetLimit = CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected CurrikiResourceGenPage defaultFacetLimitInit() {
-		Wrap<Integer> defaultFacetLimitWrap = new Wrap<Integer>().var("defaultFacetLimit");
-		if(defaultFacetLimit == null) {
-			_defaultFacetLimit(defaultFacetLimitWrap);
-			setDefaultFacetLimit(defaultFacetLimitWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetLimit(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o)));
-	}
-
-	//////////////////////////
-	// defaultFacetMinCount //
-	//////////////////////////
-
-	/**	 The entity defaultFacetMinCount
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultFacetMinCount;
-
-	/**	<br> The entity defaultFacetMinCount
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetMinCount">Find the entity defaultFacetMinCount in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetMinCount(Wrap<Integer> w);
-
-	public Integer getDefaultFacetMinCount() {
-		return defaultFacetMinCount;
-	}
-
-	public void setDefaultFacetMinCount(Integer defaultFacetMinCount) {
-		this.defaultFacetMinCount = defaultFacetMinCount;
-	}
-	@JsonIgnore
-	public void setDefaultFacetMinCount(String o) {
-		this.defaultFacetMinCount = CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected CurrikiResourceGenPage defaultFacetMinCountInit() {
-		Wrap<Integer> defaultFacetMinCountWrap = new Wrap<Integer>().var("defaultFacetMinCount");
-		if(defaultFacetMinCount == null) {
-			_defaultFacetMinCount(defaultFacetMinCountWrap);
-			setDefaultFacetMinCount(defaultFacetMinCountWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetMinCount(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o)));
-	}
-
-	//////////////////////////
-	// defaultPivotMinCount //
-	//////////////////////////
-
-	/**	 The entity defaultPivotMinCount
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultPivotMinCount;
-
-	/**	<br> The entity defaultPivotMinCount
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:defaultPivotMinCount">Find the entity defaultPivotMinCount in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultPivotMinCount(Wrap<Integer> w);
-
-	public Integer getDefaultPivotMinCount() {
-		return defaultPivotMinCount;
-	}
-
-	public void setDefaultPivotMinCount(Integer defaultPivotMinCount) {
-		this.defaultPivotMinCount = defaultPivotMinCount;
-	}
-	@JsonIgnore
-	public void setDefaultPivotMinCount(String o) {
-		this.defaultPivotMinCount = CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected CurrikiResourceGenPage defaultPivotMinCountInit() {
-		Wrap<Integer> defaultPivotMinCountWrap = new Wrap<Integer>().var("defaultPivotMinCount");
-		if(defaultPivotMinCount == null) {
-			_defaultPivotMinCount(defaultPivotMinCountWrap);
-			setDefaultPivotMinCount(defaultPivotMinCountWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultPivotMinCount(siteRequest_, CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o)));
-	}
-
 	/////////////////////////
 	// listCurrikiResource //
 	/////////////////////////
 
 	/**	 The entity listCurrikiResource
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listCurrikiResource = new JsonArray();
 
-	/**	<br> The entity listCurrikiResource
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:listCurrikiResource">Find the entity listCurrikiResource in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity listCurrikiResource
+	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listCurrikiResource">Find the entity listCurrikiResource in Solr</a>
+	 * <br/>
+	 * @param listCurrikiResource is the entity already constructed. 
 	 **/
 	protected abstract void _listCurrikiResource(JsonArray l);
 
@@ -819,44 +119,6 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	/////////////////
-	// facetCounts //
-	/////////////////
-
-	/**	 The entity facetCounts
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected FacetCounts facetCounts;
-
-	/**	<br> The entity facetCounts
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _facetCounts(Wrap<FacetCounts> w);
-
-	public FacetCounts getFacetCounts() {
-		return facetCounts;
-	}
-
-	public void setFacetCounts(FacetCounts facetCounts) {
-		this.facetCounts = facetCounts;
-	}
-	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected CurrikiResourceGenPage facetCountsInit() {
-		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
-		if(facetCounts == null) {
-			_facetCounts(facetCountsWrap);
-			setFacetCounts(facetCountsWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
 	//////////////////////////
 	// currikiResourceCount //
 	//////////////////////////
@@ -869,10 +131,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer currikiResourceCount;
 
-	/**	<br> The entity currikiResourceCount
+	/**	<br/> The entity currikiResourceCount
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:currikiResourceCount">Find the entity currikiResourceCount in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResourceCount">Find the entity currikiResourceCount in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiResourceCount(Wrap<Integer> w);
@@ -902,16 +164,16 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	public static Integer staticSearchCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqCurrikiResourceCount(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSearchCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o)));
+	public static String staticSolrFqCurrikiResourceCount(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSolrStrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSolrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -925,10 +187,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected CurrikiResource currikiResource_;
 
-	/**	<br> The entity currikiResource_
+	/**	<br/> The entity currikiResource_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:currikiResource_">Find the entity currikiResource_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResource_">Find the entity currikiResource_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiResource_(Wrap<CurrikiResource> w);
@@ -964,10 +226,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br> The entity pk
+	/**	<br/> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -997,65 +259,16 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrPk(siteRequest_, CurrikiResourceGenPage.staticSearchPk(siteRequest_, CurrikiResourceGenPage.staticSetPk(siteRequest_, o)));
-	}
-
-	////////
-	// id //
-	////////
-
-	/**	 The entity id
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String id;
-
-	/**	<br> The entity id
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _id(Wrap<String> w);
-
-	public String getId() {
-		return id;
-	}
-	public void setId(String o) {
-		this.id = CurrikiResourceGenPage.staticSetId(siteRequest_, o);
-	}
-	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected CurrikiResourceGenPage idInit() {
-		Wrap<String> idWrap = new Wrap<String>().var("id");
-		if(id == null) {
-			_id(idWrap);
-			setId(idWrap.o);
-		}
-		return (CurrikiResourceGenPage)this;
-	}
-
-	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSearchStrId(siteRequest_, CurrikiResourceGenPage.staticSearchId(siteRequest_, CurrikiResourceGenPage.staticSetId(siteRequest_, o)));
+	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSolrStrPk(siteRequest_, CurrikiResourceGenPage.staticSolrPk(siteRequest_, CurrikiResourceGenPage.staticSetPk(siteRequest_, o)));
 	}
 
 	//////////////
@@ -1088,25 +301,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListCurrikiResource_Init();
-				pageResponseInit();
-				defaultZoneIdInit();
-				defaultTimeZoneInit();
-				defaultLocaleIdInit();
-				defaultLocaleInit();
-				defaultRangeGapInit();
-				defaultRangeEndInit();
-				defaultRangeStartInit();
-				defaultRangeVarInit();
-				defaultFacetSortInit();
-				defaultFacetLimitInit();
-				defaultFacetMinCountInit();
-				defaultPivotMinCountInit();
 				listCurrikiResourceInit();
-				facetCountsInit();
 				currikiResourceCountInit();
 				currikiResource_Init();
 				pkInit();
-				idInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -1162,44 +360,14 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		switch(var) {
 			case "searchListCurrikiResource_":
 				return oCurrikiResourceGenPage.searchListCurrikiResource_;
-			case "pageResponse":
-				return oCurrikiResourceGenPage.pageResponse;
-			case "defaultZoneId":
-				return oCurrikiResourceGenPage.defaultZoneId;
-			case "defaultTimeZone":
-				return oCurrikiResourceGenPage.defaultTimeZone;
-			case "defaultLocaleId":
-				return oCurrikiResourceGenPage.defaultLocaleId;
-			case "defaultLocale":
-				return oCurrikiResourceGenPage.defaultLocale;
-			case "defaultRangeGap":
-				return oCurrikiResourceGenPage.defaultRangeGap;
-			case "defaultRangeEnd":
-				return oCurrikiResourceGenPage.defaultRangeEnd;
-			case "defaultRangeStart":
-				return oCurrikiResourceGenPage.defaultRangeStart;
-			case "defaultRangeVar":
-				return oCurrikiResourceGenPage.defaultRangeVar;
-			case "defaultFacetSort":
-				return oCurrikiResourceGenPage.defaultFacetSort;
-			case "defaultFacetLimit":
-				return oCurrikiResourceGenPage.defaultFacetLimit;
-			case "defaultFacetMinCount":
-				return oCurrikiResourceGenPage.defaultFacetMinCount;
-			case "defaultPivotMinCount":
-				return oCurrikiResourceGenPage.defaultPivotMinCount;
 			case "listCurrikiResource":
 				return oCurrikiResourceGenPage.listCurrikiResource;
-			case "facetCounts":
-				return oCurrikiResourceGenPage.facetCounts;
 			case "currikiResourceCount":
 				return oCurrikiResourceGenPage.currikiResourceCount;
 			case "currikiResource_":
 				return oCurrikiResourceGenPage.currikiResource_;
 			case "pk":
 				return oCurrikiResourceGenPage.pk;
-			case "id":
-				return oCurrikiResourceGenPage.id;
 			default:
 				return super.obtainBaseModelPage(var);
 		}
@@ -1239,162 +407,105 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	}
 	public static Object staticSetCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o);
-		case "defaultZoneId":
-			return CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o);
-		case "defaultLocaleId":
-			return CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o);
-		case "defaultRangeGap":
-			return CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o);
-		case "defaultRangeEnd":
-			return CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
-		case "defaultRangeStart":
-			return CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o);
-		case "defaultRangeVar":
-			return CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o);
-		case "defaultFacetSort":
-			return CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o);
-		case "defaultFacetLimit":
-			return CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
-		case "defaultFacetMinCount":
-			return CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
-		case "defaultPivotMinCount":
-			return CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
 		case "currikiResourceCount":
 			return CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o);
 		case "pk":
 			return CurrikiResourceGenPage.staticSetPk(siteRequest_, o);
-		case "id":
-			return CurrikiResourceGenPage.staticSetId(siteRequest_, o);
 			default:
 				return BaseModelPage.staticSetBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return CurrikiResourceGenPage.staticSearchPageResponse(siteRequest_, (String)o);
-		case "defaultZoneId":
-			return CurrikiResourceGenPage.staticSearchDefaultZoneId(siteRequest_, (String)o);
-		case "defaultLocaleId":
-			return CurrikiResourceGenPage.staticSearchDefaultLocaleId(siteRequest_, (String)o);
-		case "defaultRangeGap":
-			return CurrikiResourceGenPage.staticSearchDefaultRangeGap(siteRequest_, (String)o);
-		case "defaultRangeEnd":
-			return CurrikiResourceGenPage.staticSearchDefaultRangeEnd(siteRequest_, (ZonedDateTime)o);
-		case "defaultRangeStart":
-			return CurrikiResourceGenPage.staticSearchDefaultRangeStart(siteRequest_, (ZonedDateTime)o);
-		case "defaultRangeVar":
-			return CurrikiResourceGenPage.staticSearchDefaultRangeVar(siteRequest_, (String)o);
-		case "defaultFacetSort":
-			return CurrikiResourceGenPage.staticSearchDefaultFacetSort(siteRequest_, (String)o);
-		case "defaultFacetLimit":
-			return CurrikiResourceGenPage.staticSearchDefaultFacetLimit(siteRequest_, (Integer)o);
-		case "defaultFacetMinCount":
-			return CurrikiResourceGenPage.staticSearchDefaultFacetMinCount(siteRequest_, (Integer)o);
-		case "defaultPivotMinCount":
-			return CurrikiResourceGenPage.staticSearchDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSearchCurrikiResourceCount(siteRequest_, (Integer)o);
+			return CurrikiResourceGenPage.staticSolrCurrikiResourceCount(siteRequest_, (Integer)o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSearchPk(siteRequest_, (Long)o);
-		case "id":
-			return CurrikiResourceGenPage.staticSearchId(siteRequest_, (String)o);
+			return CurrikiResourceGenPage.staticSolrPk(siteRequest_, (Long)o);
 			default:
-				return BaseModelPage.staticSearchBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return CurrikiResourceGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
-		case "defaultZoneId":
-			return CurrikiResourceGenPage.staticSearchStrDefaultZoneId(siteRequest_, (String)o);
-		case "defaultLocaleId":
-			return CurrikiResourceGenPage.staticSearchStrDefaultLocaleId(siteRequest_, (String)o);
-		case "defaultRangeGap":
-			return CurrikiResourceGenPage.staticSearchStrDefaultRangeGap(siteRequest_, (String)o);
-		case "defaultRangeEnd":
-			return CurrikiResourceGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, (Date)o);
-		case "defaultRangeStart":
-			return CurrikiResourceGenPage.staticSearchStrDefaultRangeStart(siteRequest_, (Date)o);
-		case "defaultRangeVar":
-			return CurrikiResourceGenPage.staticSearchStrDefaultRangeVar(siteRequest_, (String)o);
-		case "defaultFacetSort":
-			return CurrikiResourceGenPage.staticSearchStrDefaultFacetSort(siteRequest_, (String)o);
-		case "defaultFacetLimit":
-			return CurrikiResourceGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, (Integer)o);
-		case "defaultFacetMinCount":
-			return CurrikiResourceGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, (Integer)o);
-		case "defaultPivotMinCount":
-			return CurrikiResourceGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSearchStrCurrikiResourceCount(siteRequest_, (Integer)o);
+			return CurrikiResourceGenPage.staticSolrStrCurrikiResourceCount(siteRequest_, (Integer)o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSearchStrPk(siteRequest_, (Long)o);
-		case "id":
-			return CurrikiResourceGenPage.staticSearchStrId(siteRequest_, (String)o);
+			return CurrikiResourceGenPage.staticSolrStrPk(siteRequest_, (Long)o);
 			default:
-				return BaseModelPage.staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return CurrikiResourceGenPage.staticSearchFqPageResponse(siteRequest_, o);
-		case "defaultZoneId":
-			return CurrikiResourceGenPage.staticSearchFqDefaultZoneId(siteRequest_, o);
-		case "defaultLocaleId":
-			return CurrikiResourceGenPage.staticSearchFqDefaultLocaleId(siteRequest_, o);
-		case "defaultRangeGap":
-			return CurrikiResourceGenPage.staticSearchFqDefaultRangeGap(siteRequest_, o);
-		case "defaultRangeEnd":
-			return CurrikiResourceGenPage.staticSearchFqDefaultRangeEnd(siteRequest_, o);
-		case "defaultRangeStart":
-			return CurrikiResourceGenPage.staticSearchFqDefaultRangeStart(siteRequest_, o);
-		case "defaultRangeVar":
-			return CurrikiResourceGenPage.staticSearchFqDefaultRangeVar(siteRequest_, o);
-		case "defaultFacetSort":
-			return CurrikiResourceGenPage.staticSearchFqDefaultFacetSort(siteRequest_, o);
-		case "defaultFacetLimit":
-			return CurrikiResourceGenPage.staticSearchFqDefaultFacetLimit(siteRequest_, o);
-		case "defaultFacetMinCount":
-			return CurrikiResourceGenPage.staticSearchFqDefaultFacetMinCount(siteRequest_, o);
-		case "defaultPivotMinCount":
-			return CurrikiResourceGenPage.staticSearchFqDefaultPivotMinCount(siteRequest_, o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSearchFqCurrikiResourceCount(siteRequest_, o);
+			return CurrikiResourceGenPage.staticSolrFqCurrikiResourceCount(siteRequest_, o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSearchFqPk(siteRequest_, o);
-		case "id":
-			return CurrikiResourceGenPage.staticSearchFqId(siteRequest_, o);
+			return CurrikiResourceGenPage.staticSolrFqPk(siteRequest_, o);
 			default:
-				return BaseModelPage.staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineCurrikiResourceGenPage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineCurrikiResourceGenPage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.defineBaseModelPage(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestCurrikiResourceGenPage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof CurrikiResourceGenPage) {
+			CurrikiResourceGenPage original = (CurrikiResourceGenPage)o;
+			super.apiRequestBaseModelPage();
 		}
 	}
 
@@ -1408,96 +519,9 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "CurrikiResourceGenPage";
 	public static final String VAR_searchListCurrikiResource_ = "searchListCurrikiResource_";
-	public static final String VAR_pageResponse = "pageResponse";
-	public static final String VAR_defaultZoneId = "defaultZoneId";
-	public static final String VAR_defaultTimeZone = "defaultTimeZone";
-	public static final String VAR_defaultLocaleId = "defaultLocaleId";
-	public static final String VAR_defaultLocale = "defaultLocale";
-	public static final String VAR_defaultRangeGap = "defaultRangeGap";
-	public static final String VAR_defaultRangeEnd = "defaultRangeEnd";
-	public static final String VAR_defaultRangeStart = "defaultRangeStart";
-	public static final String VAR_defaultRangeVar = "defaultRangeVar";
-	public static final String VAR_defaultFacetSort = "defaultFacetSort";
-	public static final String VAR_defaultFacetLimit = "defaultFacetLimit";
-	public static final String VAR_defaultFacetMinCount = "defaultFacetMinCount";
-	public static final String VAR_defaultPivotMinCount = "defaultPivotMinCount";
 	public static final String VAR_listCurrikiResource = "listCurrikiResource";
-	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_currikiResourceCount = "currikiResourceCount";
 	public static final String VAR_currikiResource_ = "currikiResource_";
 	public static final String VAR_pk = "pk";
-	public static final String VAR_id = "id";
-
-	public static final String DISPLAY_NAME_searchListCurrikiResource_ = "";
-	public static final String DISPLAY_NAME_pageResponse = "";
-	public static final String DISPLAY_NAME_defaultZoneId = "";
-	public static final String DISPLAY_NAME_defaultTimeZone = "";
-	public static final String DISPLAY_NAME_defaultLocaleId = "";
-	public static final String DISPLAY_NAME_defaultLocale = "";
-	public static final String DISPLAY_NAME_defaultRangeGap = "";
-	public static final String DISPLAY_NAME_defaultRangeEnd = "";
-	public static final String DISPLAY_NAME_defaultRangeStart = "";
-	public static final String DISPLAY_NAME_defaultRangeVar = "";
-	public static final String DISPLAY_NAME_defaultFacetSort = "";
-	public static final String DISPLAY_NAME_defaultFacetLimit = "";
-	public static final String DISPLAY_NAME_defaultFacetMinCount = "";
-	public static final String DISPLAY_NAME_defaultPivotMinCount = "";
-	public static final String DISPLAY_NAME_listCurrikiResource = "";
-	public static final String DISPLAY_NAME_facetCounts = "";
-	public static final String DISPLAY_NAME_currikiResourceCount = "";
-	public static final String DISPLAY_NAME_currikiResource_ = "";
-	public static final String DISPLAY_NAME_pk = "";
-	public static final String DISPLAY_NAME_id = "";
-
-	public static String displayNameForClass(String var) {
-		return CurrikiResourceGenPage.displayNameCurrikiResourceGenPage(var);
-	}
-	public static String displayNameCurrikiResourceGenPage(String var) {
-		switch(var) {
-		case VAR_searchListCurrikiResource_:
-			return DISPLAY_NAME_searchListCurrikiResource_;
-		case VAR_pageResponse:
-			return DISPLAY_NAME_pageResponse;
-		case VAR_defaultZoneId:
-			return DISPLAY_NAME_defaultZoneId;
-		case VAR_defaultTimeZone:
-			return DISPLAY_NAME_defaultTimeZone;
-		case VAR_defaultLocaleId:
-			return DISPLAY_NAME_defaultLocaleId;
-		case VAR_defaultLocale:
-			return DISPLAY_NAME_defaultLocale;
-		case VAR_defaultRangeGap:
-			return DISPLAY_NAME_defaultRangeGap;
-		case VAR_defaultRangeEnd:
-			return DISPLAY_NAME_defaultRangeEnd;
-		case VAR_defaultRangeStart:
-			return DISPLAY_NAME_defaultRangeStart;
-		case VAR_defaultRangeVar:
-			return DISPLAY_NAME_defaultRangeVar;
-		case VAR_defaultFacetSort:
-			return DISPLAY_NAME_defaultFacetSort;
-		case VAR_defaultFacetLimit:
-			return DISPLAY_NAME_defaultFacetLimit;
-		case VAR_defaultFacetMinCount:
-			return DISPLAY_NAME_defaultFacetMinCount;
-		case VAR_defaultPivotMinCount:
-			return DISPLAY_NAME_defaultPivotMinCount;
-		case VAR_listCurrikiResource:
-			return DISPLAY_NAME_listCurrikiResource;
-		case VAR_facetCounts:
-			return DISPLAY_NAME_facetCounts;
-		case VAR_currikiResourceCount:
-			return DISPLAY_NAME_currikiResourceCount;
-		case VAR_currikiResource_:
-			return DISPLAY_NAME_currikiResource_;
-		case VAR_pk:
-			return DISPLAY_NAME_pk;
-		case VAR_id:
-			return DISPLAY_NAME_id;
-		default:
-			return BaseModelPage.displayNameBaseModelPage(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPageGen.java
@@ -2,48 +2,59 @@ package org.curriki.api.enus.model.resource;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
+import java.util.Date;
+import java.time.ZonedDateTime;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
+import org.apache.commons.lang3.StringUtils;
+import org.curriki.api.enus.model.base.BaseModelPage;
+import java.lang.Integer;
+import java.lang.Long;
+import java.util.Locale;
+import java.util.Map;
+import java.time.ZoneOffset;
+import org.curriki.api.enus.model.base.BaseModel;
+import java.math.RoundingMode;
+import java.math.MathContext;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
+import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
+import java.time.ZoneId;
+import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
+import org.computate.vertx.search.list.SearchList;
+import java.util.List;
+import java.time.OffsetDateTime;
+import org.computate.search.wrap.Wrap;
+import java.util.Optional;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.computate.search.response.solr.SolrResponse.FacetCounts;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import org.curriki.api.enus.model.resource.CurrikiResource;
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.apache.commons.lang3.StringUtils;
-import java.lang.Integer;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
-import java.lang.Long;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
-import java.math.RoundingMode;
-import org.curriki.api.enus.search.SearchList;
 import org.slf4j.Logger;
-import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
-import io.vertx.core.Future;
-import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import java.time.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
 import org.apache.commons.lang3.math.NumberUtils;
-import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.curriki.api.enus.base.BaseModelPage;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResourceGenPage.class);
@@ -59,10 +70,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<CurrikiResource> searchListCurrikiResource_;
 
-	/**	<br/> The entity searchListCurrikiResource_
+	/**	<br> The entity searchListCurrikiResource_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListCurrikiResource_">Find the entity searchListCurrikiResource_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListCurrikiResource_">Find the entity searchListCurrikiResource_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListCurrikiResource_(Wrap<SearchList<CurrikiResource>> w);
@@ -86,21 +97,704 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
+	//////////////////
+	// pageResponse //
+	//////////////////
+
+	/**	 The entity pageResponse
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String pageResponse;
+
+	/**	<br> The entity pageResponse
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _pageResponse(Wrap<String> w);
+
+	public String getPageResponse() {
+		return pageResponse;
+	}
+	public void setPageResponse(String o) {
+		this.pageResponse = CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o);
+	}
+	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage pageResponseInit() {
+		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
+		if(pageResponse == null) {
+			_pageResponse(pageResponseWrap);
+			setPageResponse(pageResponseWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrPageResponse(siteRequest_, CurrikiResourceGenPage.staticSearchPageResponse(siteRequest_, CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o)));
+	}
+
+	///////////////////
+	// defaultZoneId //
+	///////////////////
+
+	/**	 The entity defaultZoneId
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultZoneId;
+
+	/**	<br> The entity defaultZoneId
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultZoneId">Find the entity defaultZoneId in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultZoneId(Wrap<String> w);
+
+	public String getDefaultZoneId() {
+		return defaultZoneId;
+	}
+	public void setDefaultZoneId(String o) {
+		this.defaultZoneId = CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o);
+	}
+	public static String staticSetDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage defaultZoneIdInit() {
+		Wrap<String> defaultZoneIdWrap = new Wrap<String>().var("defaultZoneId");
+		if(defaultZoneId == null) {
+			_defaultZoneId(defaultZoneIdWrap);
+			setDefaultZoneId(defaultZoneIdWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultZoneId(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultZoneId(siteRequest_, CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultTimeZone //
+	/////////////////////
+
+	/**	 The entity defaultTimeZone
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected ZoneId defaultTimeZone;
+
+	/**	<br> The entity defaultTimeZone
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultTimeZone">Find the entity defaultTimeZone in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultTimeZone(Wrap<ZoneId> w);
+
+	public ZoneId getDefaultTimeZone() {
+		return defaultTimeZone;
+	}
+
+	public void setDefaultTimeZone(ZoneId defaultTimeZone) {
+		this.defaultTimeZone = defaultTimeZone;
+	}
+	public static ZoneId staticSetDefaultTimeZone(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected CurrikiResourceGenPage defaultTimeZoneInit() {
+		Wrap<ZoneId> defaultTimeZoneWrap = new Wrap<ZoneId>().var("defaultTimeZone");
+		if(defaultTimeZone == null) {
+			_defaultTimeZone(defaultTimeZoneWrap);
+			setDefaultTimeZone(defaultTimeZoneWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	/////////////////////
+	// defaultLocaleId //
+	/////////////////////
+
+	/**	 The entity defaultLocaleId
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultLocaleId;
+
+	/**	<br> The entity defaultLocaleId
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultLocaleId">Find the entity defaultLocaleId in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultLocaleId(Wrap<String> w);
+
+	public String getDefaultLocaleId() {
+		return defaultLocaleId;
+	}
+	public void setDefaultLocaleId(String o) {
+		this.defaultLocaleId = CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o);
+	}
+	public static String staticSetDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage defaultLocaleIdInit() {
+		Wrap<String> defaultLocaleIdWrap = new Wrap<String>().var("defaultLocaleId");
+		if(defaultLocaleId == null) {
+			_defaultLocaleId(defaultLocaleIdWrap);
+			setDefaultLocaleId(defaultLocaleIdWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultLocaleId(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultLocaleId(siteRequest_, CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o)));
+	}
+
+	///////////////////
+	// defaultLocale //
+	///////////////////
+
+	/**	 The entity defaultLocale
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected Locale defaultLocale;
+
+	/**	<br> The entity defaultLocale
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultLocale">Find the entity defaultLocale in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultLocale(Wrap<Locale> w);
+
+	public Locale getDefaultLocale() {
+		return defaultLocale;
+	}
+
+	public void setDefaultLocale(Locale defaultLocale) {
+		this.defaultLocale = defaultLocale;
+	}
+	public static Locale staticSetDefaultLocale(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected CurrikiResourceGenPage defaultLocaleInit() {
+		Wrap<Locale> defaultLocaleWrap = new Wrap<Locale>().var("defaultLocale");
+		if(defaultLocale == null) {
+			_defaultLocale(defaultLocaleWrap);
+			setDefaultLocale(defaultLocaleWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	/////////////////////
+	// defaultRangeGap //
+	/////////////////////
+
+	/**	 The entity defaultRangeGap
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultRangeGap;
+
+	/**	<br> The entity defaultRangeGap
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeGap">Find the entity defaultRangeGap in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeGap(Wrap<String> w);
+
+	public String getDefaultRangeGap() {
+		return defaultRangeGap;
+	}
+	public void setDefaultRangeGap(String o) {
+		this.defaultRangeGap = CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o);
+	}
+	public static String staticSetDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage defaultRangeGapInit() {
+		Wrap<String> defaultRangeGapWrap = new Wrap<String>().var("defaultRangeGap");
+		if(defaultRangeGap == null) {
+			_defaultRangeGap(defaultRangeGapWrap);
+			setDefaultRangeGap(defaultRangeGapWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultRangeGap(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeGap(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultRangeEnd //
+	/////////////////////
+
+	/**	 The entity defaultRangeEnd
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
+	@JsonInclude(Include.NON_NULL)
+	protected ZonedDateTime defaultRangeEnd;
+
+	/**	<br> The entity defaultRangeEnd
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeEnd">Find the entity defaultRangeEnd in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeEnd(Wrap<ZonedDateTime> w);
+
+	public ZonedDateTime getDefaultRangeEnd() {
+		return defaultRangeEnd;
+	}
+
+	public void setDefaultRangeEnd(ZonedDateTime defaultRangeEnd) {
+		this.defaultRangeEnd = defaultRangeEnd;
+	}
+	@JsonIgnore
+	public void setDefaultRangeEnd(Instant o) {
+		this.defaultRangeEnd = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
+	}
+	/** Example: 2011-12-03T10:15:30+01:00 **/
+	@JsonIgnore
+	public void setDefaultRangeEnd(String o) {
+		this.defaultRangeEnd = CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
+	}
+	public static ZonedDateTime staticSetDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
+		if(StringUtils.endsWith(o, "Z"))
+			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+		else
+			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
+	}
+	@JsonIgnore
+	public void setDefaultRangeEnd(Date o) {
+		this.defaultRangeEnd = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+	}
+	protected CurrikiResourceGenPage defaultRangeEndInit() {
+		Wrap<ZonedDateTime> defaultRangeEndWrap = new Wrap<ZonedDateTime>().var("defaultRangeEnd");
+		if(defaultRangeEnd == null) {
+			_defaultRangeEnd(defaultRangeEndWrap);
+			setDefaultRangeEnd(defaultRangeEndWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static Date staticSearchDefaultRangeEnd(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+		return o == null ? null : Date.from(o.toInstant());
+	}
+
+	public static String staticSearchStrDefaultRangeEnd(SiteRequestEnUS siteRequest_, Date o) {
+		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
+	}
+
+	public static String staticSearchFqDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeEnd(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o)));
+	}
+
+	///////////////////////
+	// defaultRangeStart //
+	///////////////////////
+
+	/**	 The entity defaultRangeStart
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
+	@JsonInclude(Include.NON_NULL)
+	protected ZonedDateTime defaultRangeStart;
+
+	/**	<br> The entity defaultRangeStart
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeStart">Find the entity defaultRangeStart in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeStart(Wrap<ZonedDateTime> w);
+
+	public ZonedDateTime getDefaultRangeStart() {
+		return defaultRangeStart;
+	}
+
+	public void setDefaultRangeStart(ZonedDateTime defaultRangeStart) {
+		this.defaultRangeStart = defaultRangeStart;
+	}
+	@JsonIgnore
+	public void setDefaultRangeStart(Instant o) {
+		this.defaultRangeStart = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
+	}
+	/** Example: 2011-12-03T10:15:30+01:00 **/
+	@JsonIgnore
+	public void setDefaultRangeStart(String o) {
+		this.defaultRangeStart = CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o);
+	}
+	public static ZonedDateTime staticSetDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
+		if(StringUtils.endsWith(o, "Z"))
+			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+		else
+			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
+	}
+	@JsonIgnore
+	public void setDefaultRangeStart(Date o) {
+		this.defaultRangeStart = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+	}
+	protected CurrikiResourceGenPage defaultRangeStartInit() {
+		Wrap<ZonedDateTime> defaultRangeStartWrap = new Wrap<ZonedDateTime>().var("defaultRangeStart");
+		if(defaultRangeStart == null) {
+			_defaultRangeStart(defaultRangeStartWrap);
+			setDefaultRangeStart(defaultRangeStartWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static Date staticSearchDefaultRangeStart(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+		return o == null ? null : Date.from(o.toInstant());
+	}
+
+	public static String staticSearchStrDefaultRangeStart(SiteRequestEnUS siteRequest_, Date o) {
+		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
+	}
+
+	public static String staticSearchFqDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultRangeStart(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeStart(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultRangeVar //
+	/////////////////////
+
+	/**	 The entity defaultRangeVar
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultRangeVar;
+
+	/**	<br> The entity defaultRangeVar
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeVar">Find the entity defaultRangeVar in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeVar(Wrap<String> w);
+
+	public String getDefaultRangeVar() {
+		return defaultRangeVar;
+	}
+	public void setDefaultRangeVar(String o) {
+		this.defaultRangeVar = CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o);
+	}
+	public static String staticSetDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage defaultRangeVarInit() {
+		Wrap<String> defaultRangeVarWrap = new Wrap<String>().var("defaultRangeVar");
+		if(defaultRangeVar == null) {
+			_defaultRangeVar(defaultRangeVarWrap);
+			setDefaultRangeVar(defaultRangeVarWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultRangeVar(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultRangeVar(siteRequest_, CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o)));
+	}
+
+	//////////////////////
+	// defaultFacetSort //
+	//////////////////////
+
+	/**	 The entity defaultFacetSort
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultFacetSort;
+
+	/**	<br> The entity defaultFacetSort
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetSort">Find the entity defaultFacetSort in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetSort(Wrap<String> w);
+
+	public String getDefaultFacetSort() {
+		return defaultFacetSort;
+	}
+	public void setDefaultFacetSort(String o) {
+		this.defaultFacetSort = CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o);
+	}
+	public static String staticSetDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage defaultFacetSortInit() {
+		Wrap<String> defaultFacetSortWrap = new Wrap<String>().var("defaultFacetSort");
+		if(defaultFacetSort == null) {
+			_defaultFacetSort(defaultFacetSortWrap);
+			setDefaultFacetSort(defaultFacetSortWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultFacetSort(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetSort(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o)));
+	}
+
+	///////////////////////
+	// defaultFacetLimit //
+	///////////////////////
+
+	/**	 The entity defaultFacetLimit
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultFacetLimit;
+
+	/**	<br> The entity defaultFacetLimit
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetLimit">Find the entity defaultFacetLimit in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetLimit(Wrap<Integer> w);
+
+	public Integer getDefaultFacetLimit() {
+		return defaultFacetLimit;
+	}
+
+	public void setDefaultFacetLimit(Integer defaultFacetLimit) {
+		this.defaultFacetLimit = defaultFacetLimit;
+	}
+	@JsonIgnore
+	public void setDefaultFacetLimit(String o) {
+		this.defaultFacetLimit = CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResourceGenPage defaultFacetLimitInit() {
+		Wrap<Integer> defaultFacetLimitWrap = new Wrap<Integer>().var("defaultFacetLimit");
+		if(defaultFacetLimit == null) {
+			_defaultFacetLimit(defaultFacetLimitWrap);
+			setDefaultFacetLimit(defaultFacetLimitWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetLimit(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o)));
+	}
+
+	//////////////////////////
+	// defaultFacetMinCount //
+	//////////////////////////
+
+	/**	 The entity defaultFacetMinCount
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultFacetMinCount;
+
+	/**	<br> The entity defaultFacetMinCount
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetMinCount">Find the entity defaultFacetMinCount in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetMinCount(Wrap<Integer> w);
+
+	public Integer getDefaultFacetMinCount() {
+		return defaultFacetMinCount;
+	}
+
+	public void setDefaultFacetMinCount(Integer defaultFacetMinCount) {
+		this.defaultFacetMinCount = defaultFacetMinCount;
+	}
+	@JsonIgnore
+	public void setDefaultFacetMinCount(String o) {
+		this.defaultFacetMinCount = CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResourceGenPage defaultFacetMinCountInit() {
+		Wrap<Integer> defaultFacetMinCountWrap = new Wrap<Integer>().var("defaultFacetMinCount");
+		if(defaultFacetMinCount == null) {
+			_defaultFacetMinCount(defaultFacetMinCountWrap);
+			setDefaultFacetMinCount(defaultFacetMinCountWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultFacetMinCount(siteRequest_, CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o)));
+	}
+
+	//////////////////////////
+	// defaultPivotMinCount //
+	//////////////////////////
+
+	/**	 The entity defaultPivotMinCount
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultPivotMinCount;
+
+	/**	<br> The entity defaultPivotMinCount
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultPivotMinCount">Find the entity defaultPivotMinCount in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultPivotMinCount(Wrap<Integer> w);
+
+	public Integer getDefaultPivotMinCount() {
+		return defaultPivotMinCount;
+	}
+
+	public void setDefaultPivotMinCount(Integer defaultPivotMinCount) {
+		this.defaultPivotMinCount = defaultPivotMinCount;
+	}
+	@JsonIgnore
+	public void setDefaultPivotMinCount(String o) {
+		this.defaultPivotMinCount = CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected CurrikiResourceGenPage defaultPivotMinCountInit() {
+		Wrap<Integer> defaultPivotMinCountWrap = new Wrap<Integer>().var("defaultPivotMinCount");
+		if(defaultPivotMinCount == null) {
+			_defaultPivotMinCount(defaultPivotMinCountWrap);
+			setDefaultPivotMinCount(defaultPivotMinCountWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, CurrikiResourceGenPage.staticSearchDefaultPivotMinCount(siteRequest_, CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o)));
+	}
+
 	/////////////////////////
 	// listCurrikiResource //
 	/////////////////////////
 
 	/**	 The entity listCurrikiResource
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listCurrikiResource = new JsonArray();
 
-	/**	<br/> The entity listCurrikiResource
-	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listCurrikiResource">Find the entity listCurrikiResource in Solr</a>
-	 * <br/>
-	 * @param listCurrikiResource is the entity already constructed. 
+	/**	<br> The entity listCurrikiResource
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listCurrikiResource">Find the entity listCurrikiResource in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _listCurrikiResource(JsonArray l);
 
@@ -119,6 +813,44 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
+	/////////////////
+	// facetCounts //
+	/////////////////
+
+	/**	 The entity facetCounts
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected FacetCounts facetCounts;
+
+	/**	<br> The entity facetCounts
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _facetCounts(Wrap<FacetCounts> w);
+
+	public FacetCounts getFacetCounts() {
+		return facetCounts;
+	}
+
+	public void setFacetCounts(FacetCounts facetCounts) {
+		this.facetCounts = facetCounts;
+	}
+	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected CurrikiResourceGenPage facetCountsInit() {
+		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
+		if(facetCounts == null) {
+			_facetCounts(facetCountsWrap);
+			setFacetCounts(facetCountsWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
 	//////////////////////////
 	// currikiResourceCount //
 	//////////////////////////
@@ -131,10 +863,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer currikiResourceCount;
 
-	/**	<br/> The entity currikiResourceCount
+	/**	<br> The entity currikiResourceCount
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResourceCount">Find the entity currikiResourceCount in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResourceCount">Find the entity currikiResourceCount in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiResourceCount(Wrap<Integer> w);
@@ -164,16 +896,16 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	public static Integer staticSolrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrCurrikiResourceCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqCurrikiResourceCount(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSolrStrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSolrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o)));
+	public static String staticSearchFqCurrikiResourceCount(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSearchCurrikiResourceCount(siteRequest_, CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -187,10 +919,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected CurrikiResource currikiResource_;
 
-	/**	<br/> The entity currikiResource_
+	/**	<br> The entity currikiResource_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResource_">Find the entity currikiResource_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:currikiResource_">Find the entity currikiResource_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _currikiResource_(Wrap<CurrikiResource> w);
@@ -226,10 +958,10 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br/> The entity pk
+	/**	<br> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -259,16 +991,65 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		return (CurrikiResourceGenPage)this;
 	}
 
-	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return CurrikiResourceGenPage.staticSolrStrPk(siteRequest_, CurrikiResourceGenPage.staticSolrPk(siteRequest_, CurrikiResourceGenPage.staticSetPk(siteRequest_, o)));
+	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrPk(siteRequest_, CurrikiResourceGenPage.staticSearchPk(siteRequest_, CurrikiResourceGenPage.staticSetPk(siteRequest_, o)));
+	}
+
+	////////
+	// id //
+	////////
+
+	/**	 The entity id
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String id;
+
+	/**	<br> The entity id
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourceGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _id(Wrap<String> w);
+
+	public String getId() {
+		return id;
+	}
+	public void setId(String o) {
+		this.id = CurrikiResourceGenPage.staticSetId(siteRequest_, o);
+	}
+	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected CurrikiResourceGenPage idInit() {
+		Wrap<String> idWrap = new Wrap<String>().var("id");
+		if(id == null) {
+			_id(idWrap);
+			setId(idWrap.o);
+		}
+		return (CurrikiResourceGenPage)this;
+	}
+
+	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
+		return CurrikiResourceGenPage.staticSearchStrId(siteRequest_, CurrikiResourceGenPage.staticSearchId(siteRequest_, CurrikiResourceGenPage.staticSetId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -301,10 +1082,25 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListCurrikiResource_Init();
+				pageResponseInit();
+				defaultZoneIdInit();
+				defaultTimeZoneInit();
+				defaultLocaleIdInit();
+				defaultLocaleInit();
+				defaultRangeGapInit();
+				defaultRangeEndInit();
+				defaultRangeStartInit();
+				defaultRangeVarInit();
+				defaultFacetSortInit();
+				defaultFacetLimitInit();
+				defaultFacetMinCountInit();
+				defaultPivotMinCountInit();
 				listCurrikiResourceInit();
+				facetCountsInit();
 				currikiResourceCountInit();
 				currikiResource_Init();
 				pkInit();
+				idInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -360,14 +1156,44 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 		switch(var) {
 			case "searchListCurrikiResource_":
 				return oCurrikiResourceGenPage.searchListCurrikiResource_;
+			case "pageResponse":
+				return oCurrikiResourceGenPage.pageResponse;
+			case "defaultZoneId":
+				return oCurrikiResourceGenPage.defaultZoneId;
+			case "defaultTimeZone":
+				return oCurrikiResourceGenPage.defaultTimeZone;
+			case "defaultLocaleId":
+				return oCurrikiResourceGenPage.defaultLocaleId;
+			case "defaultLocale":
+				return oCurrikiResourceGenPage.defaultLocale;
+			case "defaultRangeGap":
+				return oCurrikiResourceGenPage.defaultRangeGap;
+			case "defaultRangeEnd":
+				return oCurrikiResourceGenPage.defaultRangeEnd;
+			case "defaultRangeStart":
+				return oCurrikiResourceGenPage.defaultRangeStart;
+			case "defaultRangeVar":
+				return oCurrikiResourceGenPage.defaultRangeVar;
+			case "defaultFacetSort":
+				return oCurrikiResourceGenPage.defaultFacetSort;
+			case "defaultFacetLimit":
+				return oCurrikiResourceGenPage.defaultFacetLimit;
+			case "defaultFacetMinCount":
+				return oCurrikiResourceGenPage.defaultFacetMinCount;
+			case "defaultPivotMinCount":
+				return oCurrikiResourceGenPage.defaultPivotMinCount;
 			case "listCurrikiResource":
 				return oCurrikiResourceGenPage.listCurrikiResource;
+			case "facetCounts":
+				return oCurrikiResourceGenPage.facetCounts;
 			case "currikiResourceCount":
 				return oCurrikiResourceGenPage.currikiResourceCount;
 			case "currikiResource_":
 				return oCurrikiResourceGenPage.currikiResource_;
 			case "pk":
 				return oCurrikiResourceGenPage.pk;
+			case "id":
+				return oCurrikiResourceGenPage.id;
 			default:
 				return super.obtainBaseModelPage(var);
 		}
@@ -407,105 +1233,162 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	}
 	public static Object staticSetCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return CurrikiResourceGenPage.staticSetPageResponse(siteRequest_, o);
+		case "defaultZoneId":
+			return CurrikiResourceGenPage.staticSetDefaultZoneId(siteRequest_, o);
+		case "defaultLocaleId":
+			return CurrikiResourceGenPage.staticSetDefaultLocaleId(siteRequest_, o);
+		case "defaultRangeGap":
+			return CurrikiResourceGenPage.staticSetDefaultRangeGap(siteRequest_, o);
+		case "defaultRangeEnd":
+			return CurrikiResourceGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
+		case "defaultRangeStart":
+			return CurrikiResourceGenPage.staticSetDefaultRangeStart(siteRequest_, o);
+		case "defaultRangeVar":
+			return CurrikiResourceGenPage.staticSetDefaultRangeVar(siteRequest_, o);
+		case "defaultFacetSort":
+			return CurrikiResourceGenPage.staticSetDefaultFacetSort(siteRequest_, o);
+		case "defaultFacetLimit":
+			return CurrikiResourceGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
+		case "defaultFacetMinCount":
+			return CurrikiResourceGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
+		case "defaultPivotMinCount":
+			return CurrikiResourceGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
 		case "currikiResourceCount":
 			return CurrikiResourceGenPage.staticSetCurrikiResourceCount(siteRequest_, o);
 		case "pk":
 			return CurrikiResourceGenPage.staticSetPk(siteRequest_, o);
+		case "id":
+			return CurrikiResourceGenPage.staticSetId(siteRequest_, o);
 			default:
 				return BaseModelPage.staticSetBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return CurrikiResourceGenPage.staticSearchPageResponse(siteRequest_, (String)o);
+		case "defaultZoneId":
+			return CurrikiResourceGenPage.staticSearchDefaultZoneId(siteRequest_, (String)o);
+		case "defaultLocaleId":
+			return CurrikiResourceGenPage.staticSearchDefaultLocaleId(siteRequest_, (String)o);
+		case "defaultRangeGap":
+			return CurrikiResourceGenPage.staticSearchDefaultRangeGap(siteRequest_, (String)o);
+		case "defaultRangeEnd":
+			return CurrikiResourceGenPage.staticSearchDefaultRangeEnd(siteRequest_, (ZonedDateTime)o);
+		case "defaultRangeStart":
+			return CurrikiResourceGenPage.staticSearchDefaultRangeStart(siteRequest_, (ZonedDateTime)o);
+		case "defaultRangeVar":
+			return CurrikiResourceGenPage.staticSearchDefaultRangeVar(siteRequest_, (String)o);
+		case "defaultFacetSort":
+			return CurrikiResourceGenPage.staticSearchDefaultFacetSort(siteRequest_, (String)o);
+		case "defaultFacetLimit":
+			return CurrikiResourceGenPage.staticSearchDefaultFacetLimit(siteRequest_, (Integer)o);
+		case "defaultFacetMinCount":
+			return CurrikiResourceGenPage.staticSearchDefaultFacetMinCount(siteRequest_, (Integer)o);
+		case "defaultPivotMinCount":
+			return CurrikiResourceGenPage.staticSearchDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSolrCurrikiResourceCount(siteRequest_, (Integer)o);
+			return CurrikiResourceGenPage.staticSearchCurrikiResourceCount(siteRequest_, (Integer)o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSolrPk(siteRequest_, (Long)o);
+			return CurrikiResourceGenPage.staticSearchPk(siteRequest_, (Long)o);
+		case "id":
+			return CurrikiResourceGenPage.staticSearchId(siteRequest_, (String)o);
 			default:
-				return BaseModelPage.staticSolrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSearchBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return CurrikiResourceGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
+		case "defaultZoneId":
+			return CurrikiResourceGenPage.staticSearchStrDefaultZoneId(siteRequest_, (String)o);
+		case "defaultLocaleId":
+			return CurrikiResourceGenPage.staticSearchStrDefaultLocaleId(siteRequest_, (String)o);
+		case "defaultRangeGap":
+			return CurrikiResourceGenPage.staticSearchStrDefaultRangeGap(siteRequest_, (String)o);
+		case "defaultRangeEnd":
+			return CurrikiResourceGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, (Date)o);
+		case "defaultRangeStart":
+			return CurrikiResourceGenPage.staticSearchStrDefaultRangeStart(siteRequest_, (Date)o);
+		case "defaultRangeVar":
+			return CurrikiResourceGenPage.staticSearchStrDefaultRangeVar(siteRequest_, (String)o);
+		case "defaultFacetSort":
+			return CurrikiResourceGenPage.staticSearchStrDefaultFacetSort(siteRequest_, (String)o);
+		case "defaultFacetLimit":
+			return CurrikiResourceGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, (Integer)o);
+		case "defaultFacetMinCount":
+			return CurrikiResourceGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, (Integer)o);
+		case "defaultPivotMinCount":
+			return CurrikiResourceGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSolrStrCurrikiResourceCount(siteRequest_, (Integer)o);
+			return CurrikiResourceGenPage.staticSearchStrCurrikiResourceCount(siteRequest_, (Integer)o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSolrStrPk(siteRequest_, (Long)o);
+			return CurrikiResourceGenPage.staticSearchStrPk(siteRequest_, (Long)o);
+		case "id":
+			return CurrikiResourceGenPage.staticSearchStrId(siteRequest_, (String)o);
 			default:
-				return BaseModelPage.staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqCurrikiResourceGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return CurrikiResourceGenPage.staticSearchFqPageResponse(siteRequest_, o);
+		case "defaultZoneId":
+			return CurrikiResourceGenPage.staticSearchFqDefaultZoneId(siteRequest_, o);
+		case "defaultLocaleId":
+			return CurrikiResourceGenPage.staticSearchFqDefaultLocaleId(siteRequest_, o);
+		case "defaultRangeGap":
+			return CurrikiResourceGenPage.staticSearchFqDefaultRangeGap(siteRequest_, o);
+		case "defaultRangeEnd":
+			return CurrikiResourceGenPage.staticSearchFqDefaultRangeEnd(siteRequest_, o);
+		case "defaultRangeStart":
+			return CurrikiResourceGenPage.staticSearchFqDefaultRangeStart(siteRequest_, o);
+		case "defaultRangeVar":
+			return CurrikiResourceGenPage.staticSearchFqDefaultRangeVar(siteRequest_, o);
+		case "defaultFacetSort":
+			return CurrikiResourceGenPage.staticSearchFqDefaultFacetSort(siteRequest_, o);
+		case "defaultFacetLimit":
+			return CurrikiResourceGenPage.staticSearchFqDefaultFacetLimit(siteRequest_, o);
+		case "defaultFacetMinCount":
+			return CurrikiResourceGenPage.staticSearchFqDefaultFacetMinCount(siteRequest_, o);
+		case "defaultPivotMinCount":
+			return CurrikiResourceGenPage.staticSearchFqDefaultPivotMinCount(siteRequest_, o);
 		case "currikiResourceCount":
-			return CurrikiResourceGenPage.staticSolrFqCurrikiResourceCount(siteRequest_, o);
+			return CurrikiResourceGenPage.staticSearchFqCurrikiResourceCount(siteRequest_, o);
 		case "pk":
-			return CurrikiResourceGenPage.staticSolrFqPk(siteRequest_, o);
+			return CurrikiResourceGenPage.staticSearchFqPk(siteRequest_, o);
+		case "id":
+			return CurrikiResourceGenPage.staticSearchFqId(siteRequest_, o);
 			default:
-				return BaseModelPage.staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineCurrikiResourceGenPage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineCurrikiResourceGenPage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.defineBaseModelPage(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestCurrikiResourceGenPage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof CurrikiResourceGenPage) {
-			CurrikiResourceGenPage original = (CurrikiResourceGenPage)o;
-			super.apiRequestBaseModelPage();
+				return BaseModelPage.staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -520,8 +1403,94 @@ public abstract class CurrikiResourceGenPageGen<DEV> extends BaseModelPage {
 	}
 
 	public static final String VAR_searchListCurrikiResource_ = "searchListCurrikiResource_";
+	public static final String VAR_pageResponse = "pageResponse";
+	public static final String VAR_defaultZoneId = "defaultZoneId";
+	public static final String VAR_defaultTimeZone = "defaultTimeZone";
+	public static final String VAR_defaultLocaleId = "defaultLocaleId";
+	public static final String VAR_defaultLocale = "defaultLocale";
+	public static final String VAR_defaultRangeGap = "defaultRangeGap";
+	public static final String VAR_defaultRangeEnd = "defaultRangeEnd";
+	public static final String VAR_defaultRangeStart = "defaultRangeStart";
+	public static final String VAR_defaultRangeVar = "defaultRangeVar";
+	public static final String VAR_defaultFacetSort = "defaultFacetSort";
+	public static final String VAR_defaultFacetLimit = "defaultFacetLimit";
+	public static final String VAR_defaultFacetMinCount = "defaultFacetMinCount";
+	public static final String VAR_defaultPivotMinCount = "defaultPivotMinCount";
 	public static final String VAR_listCurrikiResource = "listCurrikiResource";
+	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_currikiResourceCount = "currikiResourceCount";
 	public static final String VAR_currikiResource_ = "currikiResource_";
 	public static final String VAR_pk = "pk";
+	public static final String VAR_id = "id";
+
+	public static final String DISPLAY_NAME_searchListCurrikiResource_ = "";
+	public static final String DISPLAY_NAME_pageResponse = "";
+	public static final String DISPLAY_NAME_defaultZoneId = "";
+	public static final String DISPLAY_NAME_defaultTimeZone = "";
+	public static final String DISPLAY_NAME_defaultLocaleId = "";
+	public static final String DISPLAY_NAME_defaultLocale = "";
+	public static final String DISPLAY_NAME_defaultRangeGap = "";
+	public static final String DISPLAY_NAME_defaultRangeEnd = "";
+	public static final String DISPLAY_NAME_defaultRangeStart = "";
+	public static final String DISPLAY_NAME_defaultRangeVar = "";
+	public static final String DISPLAY_NAME_defaultFacetSort = "";
+	public static final String DISPLAY_NAME_defaultFacetLimit = "";
+	public static final String DISPLAY_NAME_defaultFacetMinCount = "";
+	public static final String DISPLAY_NAME_defaultPivotMinCount = "";
+	public static final String DISPLAY_NAME_listCurrikiResource = "";
+	public static final String DISPLAY_NAME_facetCounts = "";
+	public static final String DISPLAY_NAME_currikiResourceCount = "";
+	public static final String DISPLAY_NAME_currikiResource_ = "";
+	public static final String DISPLAY_NAME_pk = "";
+	public static final String DISPLAY_NAME_id = "";
+
+	public static String displayNameForClass(String var) {
+		return CurrikiResourceGenPage.displayNameCurrikiResourceGenPage(var);
+	}
+	public static String displayNameCurrikiResourceGenPage(String var) {
+		switch(var) {
+		case VAR_searchListCurrikiResource_:
+			return DISPLAY_NAME_searchListCurrikiResource_;
+		case VAR_pageResponse:
+			return DISPLAY_NAME_pageResponse;
+		case VAR_defaultZoneId:
+			return DISPLAY_NAME_defaultZoneId;
+		case VAR_defaultTimeZone:
+			return DISPLAY_NAME_defaultTimeZone;
+		case VAR_defaultLocaleId:
+			return DISPLAY_NAME_defaultLocaleId;
+		case VAR_defaultLocale:
+			return DISPLAY_NAME_defaultLocale;
+		case VAR_defaultRangeGap:
+			return DISPLAY_NAME_defaultRangeGap;
+		case VAR_defaultRangeEnd:
+			return DISPLAY_NAME_defaultRangeEnd;
+		case VAR_defaultRangeStart:
+			return DISPLAY_NAME_defaultRangeStart;
+		case VAR_defaultRangeVar:
+			return DISPLAY_NAME_defaultRangeVar;
+		case VAR_defaultFacetSort:
+			return DISPLAY_NAME_defaultFacetSort;
+		case VAR_defaultFacetLimit:
+			return DISPLAY_NAME_defaultFacetLimit;
+		case VAR_defaultFacetMinCount:
+			return DISPLAY_NAME_defaultFacetMinCount;
+		case VAR_defaultPivotMinCount:
+			return DISPLAY_NAME_defaultPivotMinCount;
+		case VAR_listCurrikiResource:
+			return DISPLAY_NAME_listCurrikiResource;
+		case VAR_facetCounts:
+			return DISPLAY_NAME_facetCounts;
+		case VAR_currikiResourceCount:
+			return DISPLAY_NAME_currikiResourceCount;
+		case VAR_currikiResource_:
+			return DISPLAY_NAME_currikiResource_;
+		case VAR_pk:
+			return DISPLAY_NAME_pk;
+		case VAR_id:
+			return DISPLAY_NAME_id;
+		default:
+			return BaseModelPage.displayNameBaseModelPage(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourcePageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourcePageGen.java
@@ -3,42 +3,42 @@ package org.curriki.api.enus.model.resource;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.curriki.api.enus.model.resource.CurrikiResourceGenPage;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourcePage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourcePage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResourcePage.class);
@@ -170,83 +170,44 @@ public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSolrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+				return CurrikiResourceGenPage.staticSearchCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSolrStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+				return CurrikiResourceGenPage.staticSearchStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSolrFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineCurrikiResourcePage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineCurrikiResourcePage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.defineCurrikiResourceGenPage(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestCurrikiResourcePage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof CurrikiResourcePage) {
-			CurrikiResourcePage original = (CurrikiResourcePage)o;
-			super.apiRequestCurrikiResourceGenPage();
+				return CurrikiResourceGenPage.staticSearchFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -260,4 +221,15 @@ public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage
 		return sb.toString();
 	}
 
+
+
+	public static String displayNameForClass(String var) {
+		return CurrikiResourcePage.displayNameCurrikiResourcePage(var);
+	}
+	public static String displayNameCurrikiResourcePage(String var) {
+		switch(var) {
+		default:
+			return CurrikiResourceGenPage.displayNameCurrikiResourceGenPage(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourcePageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/resource/CurrikiResourcePageGen.java
@@ -1,50 +1,44 @@
 package org.curriki.api.enus.model.resource;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.math.RoundingMode;
 import org.curriki.api.enus.model.resource.CurrikiResourceGenPage;
-import org.computate.search.wrap.Wrap;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourcePage">Find the class CurrikiResourcePage in Solr. </a>
- * <br><br>Delete the class CurrikiResourcePage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourcePage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.resource in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.resource&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.resource.CurrikiResourcePage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(CurrikiResourcePage.class);
@@ -176,44 +170,83 @@ public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSearchCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+				return CurrikiResourceGenPage.staticSolrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSearchStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+				return CurrikiResourceGenPage.staticSolrStrCurrikiResourceGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqCurrikiResourcePage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqCurrikiResourcePage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqCurrikiResourcePage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return CurrikiResourceGenPage.staticSearchFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+				return CurrikiResourceGenPage.staticSolrFqCurrikiResourceGenPage(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineCurrikiResourcePage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineCurrikiResourcePage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.defineCurrikiResourceGenPage(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestCurrikiResourcePage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof CurrikiResourcePage) {
+			CurrikiResourcePage original = (CurrikiResourcePage)o;
+			super.apiRequestCurrikiResourceGenPage();
 		}
 	}
 
@@ -227,16 +260,4 @@ public abstract class CurrikiResourcePageGen<DEV> extends CurrikiResourceGenPage
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "CurrikiResourcePage";
-
-
-	public static String displayNameForClass(String var) {
-		return CurrikiResourcePage.displayNameCurrikiResourcePage(var);
-	}
-	public static String displayNameCurrikiResourcePage(String var) {
-		switch(var) {
-		default:
-			return CurrikiResourceGenPage.displayNameCurrikiResourceGenPage(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserGen.java
@@ -2,57 +2,50 @@ package org.curriki.api.enus.model.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
-import org.curriki.api.enus.base.BaseModel;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import java.util.Date;
 import org.slf4j.LoggerFactory;
-import org.apache.commons.lang3.StringUtils;
-import java.lang.Long;
-import java.util.Map;
-import io.vertx.core.json.JsonObject;
-import java.math.RoundingMode;
-import org.curriki.api.enus.model.base.BaseModel;
-import java.math.MathContext;
-import java.util.Set;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import io.vertx.core.Future;
-import java.util.Objects;
-import java.util.List;
-import org.apache.solr.client.solrj.SolrQuery;
-import java.util.Optional;
-import org.apache.solr.client.solrj.util.ClientUtils;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.solr.common.SolrInputDocument;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.request.api.ApiRequest;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
+import org.computate.search.response.solr.SolrResponse;
+import java.lang.Long;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.lang.Boolean;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import io.vertx.core.json.JsonObject;
 import java.lang.String;
+import org.curriki.api.enus.model.base.BaseModel;
+import java.math.RoundingMode;
 import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.commons.text.StringEscapeUtils;
+import java.util.Set;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.apache.solr.client.solrj.SolrClient;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
+import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
-import org.apache.solr.common.SolrDocument;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.curriki.api.enus.java.LocalDateSerializer;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class SiteUserGen<DEV> extends BaseModel {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUser.class);
@@ -84,7 +77,7 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	//////////////
 
 	/**	 The entity userKeys
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<Long>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
@@ -92,11 +85,11 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected List<Long> userKeys = new ArrayList<Long>();
 
-	/**	<br/> The entity userKeys
-	 *  It is constructed before being initialized with the constructor by default List<Long>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKeys">Find the entity userKeys in Solr</a>
-	 * <br/>
-	 * @param userKeys is the entity already constructed. 
+	/**	<br> The entity userKeys
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKeys">Find the entity userKeys in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _userKeys(List<Long> l);
 
@@ -149,16 +142,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Long staticSolrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchUserKeys(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserKeys(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserKeys(siteRequest_, SiteUser.staticSolrUserKeys(siteRequest_, SiteUser.staticSetUserKeys(siteRequest_, o)));
+	public static String staticSearchFqUserKeys(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserKeys(siteRequest_, SiteUser.staticSearchUserKeys(siteRequest_, SiteUser.staticSetUserKeys(siteRequest_, o)));
 	}
 
 	////////////
@@ -172,10 +165,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userId;
 
-	/**	<br/> The entity userId
+	/**	<br> The entity userId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userId(Wrap<String> c);
@@ -198,16 +191,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserId(siteRequest_, SiteUser.staticSolrUserId(siteRequest_, SiteUser.staticSetUserId(siteRequest_, o)));
+	public static String staticSearchFqUserId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserId(siteRequest_, SiteUser.staticSearchUserId(siteRequest_, SiteUser.staticSetUserId(siteRequest_, o)));
+	}
+
+	public String sqlUserId() {
+		return userId;
 	}
 
 	//////////////
@@ -221,10 +218,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br/> The entity userName
+	/**	<br> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> c);
@@ -247,16 +244,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserName(siteRequest_, SiteUser.staticSolrUserName(siteRequest_, SiteUser.staticSetUserName(siteRequest_, o)));
+	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserName(siteRequest_, SiteUser.staticSearchUserName(siteRequest_, SiteUser.staticSetUserName(siteRequest_, o)));
+	}
+
+	public String sqlUserName() {
+		return userName;
 	}
 
 	///////////////
@@ -270,10 +271,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br/> The entity userEmail
+	/**	<br> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> c);
@@ -296,16 +297,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserEmail(siteRequest_, SiteUser.staticSolrUserEmail(siteRequest_, SiteUser.staticSetUserEmail(siteRequest_, o)));
+	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserEmail(siteRequest_, SiteUser.staticSearchUserEmail(siteRequest_, SiteUser.staticSetUserEmail(siteRequest_, o)));
+	}
+
+	public String sqlUserEmail() {
+		return userEmail;
 	}
 
 	///////////////////
@@ -319,10 +324,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFirstName;
 
-	/**	<br/> The entity userFirstName
+	/**	<br> The entity userFirstName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFirstName(Wrap<String> c);
@@ -345,16 +350,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserFirstName(siteRequest_, SiteUser.staticSolrUserFirstName(siteRequest_, SiteUser.staticSetUserFirstName(siteRequest_, o)));
+	public static String staticSearchFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserFirstName(siteRequest_, SiteUser.staticSearchUserFirstName(siteRequest_, SiteUser.staticSetUserFirstName(siteRequest_, o)));
+	}
+
+	public String sqlUserFirstName() {
+		return userFirstName;
 	}
 
 	//////////////////
@@ -368,10 +377,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userLastName;
 
-	/**	<br/> The entity userLastName
+	/**	<br> The entity userLastName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userLastName(Wrap<String> c);
@@ -394,16 +403,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserLastName(siteRequest_, SiteUser.staticSolrUserLastName(siteRequest_, SiteUser.staticSetUserLastName(siteRequest_, o)));
+	public static String staticSearchFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserLastName(siteRequest_, SiteUser.staticSearchUserLastName(siteRequest_, SiteUser.staticSetUserLastName(siteRequest_, o)));
+	}
+
+	public String sqlUserLastName() {
+		return userLastName;
 	}
 
 	//////////////////
@@ -417,10 +430,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br/> The entity userFullName
+	/**	<br> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> c);
@@ -443,16 +456,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrUserFullName(siteRequest_, SiteUser.staticSolrUserFullName(siteRequest_, SiteUser.staticSetUserFullName(siteRequest_, o)));
+	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrUserFullName(siteRequest_, SiteUser.staticSearchUserFullName(siteRequest_, SiteUser.staticSetUserFullName(siteRequest_, o)));
+	}
+
+	public String sqlUserFullName() {
+		return userFullName;
 	}
 
 	/////////////////
@@ -466,10 +483,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean seeArchived;
 
-	/**	<br/> The entity seeArchived
+	/**	<br> The entity seeArchived
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeArchived">Find the entity seeArchived in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeArchived">Find the entity seeArchived in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _seeArchived(Wrap<Boolean> c);
@@ -497,16 +514,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Boolean staticSolrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSearchSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSolrStrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSearchStrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSeeArchived(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrSeeArchived(siteRequest_, SiteUser.staticSolrSeeArchived(siteRequest_, SiteUser.staticSetSeeArchived(siteRequest_, o)));
+	public static String staticSearchFqSeeArchived(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrSeeArchived(siteRequest_, SiteUser.staticSearchSeeArchived(siteRequest_, SiteUser.staticSetSeeArchived(siteRequest_, o)));
+	}
+
+	public Boolean sqlSeeArchived() {
+		return seeArchived;
 	}
 
 	////////////////
@@ -520,10 +541,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean seeDeleted;
 
-	/**	<br/> The entity seeDeleted
+	/**	<br> The entity seeDeleted
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeDeleted">Find the entity seeDeleted in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeDeleted">Find the entity seeDeleted in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _seeDeleted(Wrap<Boolean> c);
@@ -551,16 +572,20 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Boolean staticSolrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSearchSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSolrStrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSearchStrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSeeDeleted(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSolrStrSeeDeleted(siteRequest_, SiteUser.staticSolrSeeDeleted(siteRequest_, SiteUser.staticSetSeeDeleted(siteRequest_, o)));
+	public static String staticSearchFqSeeDeleted(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSearchStrSeeDeleted(siteRequest_, SiteUser.staticSearchSeeDeleted(siteRequest_, SiteUser.staticSetSeeDeleted(siteRequest_, o)));
+	}
+
+	public Boolean sqlSeeDeleted() {
+		return seeDeleted;
 	}
 
 	//////////////
@@ -735,124 +760,168 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrSiteUser(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSolrUserKeys(siteRequest_, (Long)o);
+			return SiteUser.staticSearchUserKeys(siteRequest_, (Long)o);
 		case "userId":
-			return SiteUser.staticSolrUserId(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserId(siteRequest_, (String)o);
 		case "userName":
-			return SiteUser.staticSolrUserName(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteUser.staticSolrUserEmail(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserEmail(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteUser.staticSolrUserFirstName(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserFirstName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteUser.staticSolrUserLastName(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserLastName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteUser.staticSolrUserFullName(siteRequest_, (String)o);
+			return SiteUser.staticSearchUserFullName(siteRequest_, (String)o);
 		case "seeArchived":
-			return SiteUser.staticSolrSeeArchived(siteRequest_, (Boolean)o);
+			return SiteUser.staticSearchSeeArchived(siteRequest_, (Boolean)o);
 		case "seeDeleted":
-			return SiteUser.staticSolrSeeDeleted(siteRequest_, (Boolean)o);
+			return SiteUser.staticSearchSeeDeleted(siteRequest_, (Boolean)o);
 			default:
-				return BaseModel.staticSolrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrSiteUser(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSolrStrUserKeys(siteRequest_, (Long)o);
+			return SiteUser.staticSearchStrUserKeys(siteRequest_, (Long)o);
 		case "userId":
-			return SiteUser.staticSolrStrUserId(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserId(siteRequest_, (String)o);
 		case "userName":
-			return SiteUser.staticSolrStrUserName(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteUser.staticSolrStrUserEmail(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserEmail(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteUser.staticSolrStrUserFirstName(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserFirstName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteUser.staticSolrStrUserLastName(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserLastName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteUser.staticSolrStrUserFullName(siteRequest_, (String)o);
+			return SiteUser.staticSearchStrUserFullName(siteRequest_, (String)o);
 		case "seeArchived":
-			return SiteUser.staticSolrStrSeeArchived(siteRequest_, (Boolean)o);
+			return SiteUser.staticSearchStrSeeArchived(siteRequest_, (Boolean)o);
 		case "seeDeleted":
-			return SiteUser.staticSolrStrSeeDeleted(siteRequest_, (Boolean)o);
+			return SiteUser.staticSearchStrSeeDeleted(siteRequest_, (Boolean)o);
 			default:
-				return BaseModel.staticSolrStrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchStrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqSiteUser(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqSiteUser(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqSiteUser(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSolrFqUserKeys(siteRequest_, o);
+			return SiteUser.staticSearchFqUserKeys(siteRequest_, o);
 		case "userId":
-			return SiteUser.staticSolrFqUserId(siteRequest_, o);
+			return SiteUser.staticSearchFqUserId(siteRequest_, o);
 		case "userName":
-			return SiteUser.staticSolrFqUserName(siteRequest_, o);
+			return SiteUser.staticSearchFqUserName(siteRequest_, o);
 		case "userEmail":
-			return SiteUser.staticSolrFqUserEmail(siteRequest_, o);
+			return SiteUser.staticSearchFqUserEmail(siteRequest_, o);
 		case "userFirstName":
-			return SiteUser.staticSolrFqUserFirstName(siteRequest_, o);
+			return SiteUser.staticSearchFqUserFirstName(siteRequest_, o);
 		case "userLastName":
-			return SiteUser.staticSolrFqUserLastName(siteRequest_, o);
+			return SiteUser.staticSearchFqUserLastName(siteRequest_, o);
 		case "userFullName":
-			return SiteUser.staticSolrFqUserFullName(siteRequest_, o);
+			return SiteUser.staticSearchFqUserFullName(siteRequest_, o);
 		case "seeArchived":
-			return SiteUser.staticSolrFqSeeArchived(siteRequest_, o);
+			return SiteUser.staticSearchFqSeeArchived(siteRequest_, o);
 		case "seeDeleted":
-			return SiteUser.staticSolrFqSeeDeleted(siteRequest_, o);
+			return SiteUser.staticSearchFqSeeDeleted(siteRequest_, o);
 			default:
-				return BaseModel.staticSolrFqBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSearchFqBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	/////////////
-	// define //
+	// persist //
 	/////////////
 
-	@Override public boolean defineForClass(String var, Object val) {
+	@Override public boolean persistForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = defineSiteUser(v, val);
+					o = persistSiteUser(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
+					o = oBaseModel.persistForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object defineSiteUser(String var, Object val) {
+	public Object persistSiteUser(String var, Object val) {
 		switch(var.toLowerCase()) {
+			case "userid":
+				if(val instanceof String)
+					setUserId((String)val);
+				saves.add("userId");
+				return val;
+			case "username":
+				if(val instanceof String)
+					setUserName((String)val);
+				saves.add("userName");
+				return val;
+			case "useremail":
+				if(val instanceof String)
+					setUserEmail((String)val);
+				saves.add("userEmail");
+				return val;
+			case "userfirstname":
+				if(val instanceof String)
+					setUserFirstName((String)val);
+				saves.add("userFirstName");
+				return val;
+			case "userlastname":
+				if(val instanceof String)
+					setUserLastName((String)val);
+				saves.add("userLastName");
+				return val;
+			case "userfullname":
+				if(val instanceof String)
+					setUserFullName((String)val);
+				saves.add("userFullName");
+				return val;
+			case "seearchived":
+				if(val instanceof Boolean)
+					setSeeArchived((Boolean)val);
+				else if(val instanceof String)
+					setSeeArchived((String)val);
+				saves.add("seeArchived");
+				return val;
+			case "seedeleted":
+				if(val instanceof Boolean)
+					setSeeDeleted((Boolean)val);
+				else if(val instanceof String)
+					setSeeDeleted((String)val);
+				saves.add("seeDeleted");
+				return val;
 			default:
-				return super.defineBaseModel(var, val);
+				return super.persistBaseModel(var, val);
 		}
 	}
 
@@ -860,49 +929,51 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	// populate //
 	/////////////
 
-	@Override public void populateForClass(SolrDocument solrDocument) {
-		populateSiteUser(solrDocument);
+	@Override public void populateForClass(SolrResponse.Doc doc) {
+		populateSiteUser(doc);
 	}
-	public void populateSiteUser(SolrDocument solrDocument) {
+	public void populateSiteUser(SolrResponse.Doc doc) {
 		SiteUser oSiteUser = (SiteUser)this;
-		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
+		saves = doc.get("saves_docvalues_strings");
 		if(saves != null) {
 		}
 
-		super.populateBaseModel(solrDocument);
+		super.populateBaseModel(doc);
 	}
 
-	public void indexSiteUser(SolrInputDocument document) {
+	public void indexSiteUser(JsonObject doc) {
 		if(userKeys != null) {
-			for(java.lang.Long o : userKeys) {
-				document.addField("userKeys_docvalues_longs", o);
+			JsonArray l = new JsonArray();
+			doc.put("userKeys_docvalues_longs", l);
+			for(Long o : userKeys) {
+				l.add(o);
 			}
 		}
 		if(userId != null) {
-			document.addField("userId_docvalues_string", userId);
+			doc.put("userId_docvalues_string", userId);
 		}
 		if(userName != null) {
-			document.addField("userName_docvalues_string", userName);
+			doc.put("userName_docvalues_string", userName);
 		}
 		if(userEmail != null) {
-			document.addField("userEmail_docvalues_string", userEmail);
+			doc.put("userEmail_docvalues_string", userEmail);
 		}
 		if(userFirstName != null) {
-			document.addField("userFirstName_docvalues_string", userFirstName);
+			doc.put("userFirstName_docvalues_string", userFirstName);
 		}
 		if(userLastName != null) {
-			document.addField("userLastName_docvalues_string", userLastName);
+			doc.put("userLastName_docvalues_string", userLastName);
 		}
 		if(userFullName != null) {
-			document.addField("userFullName_docvalues_string", userFullName);
+			doc.put("userFullName_docvalues_string", userFullName);
 		}
 		if(seeArchived != null) {
-			document.addField("seeArchived_docvalues_boolean", seeArchived);
+			doc.put("seeArchived_docvalues_boolean", seeArchived);
 		}
 		if(seeDeleted != null) {
-			document.addField("seeDeleted_docvalues_boolean", seeDeleted);
+			doc.put("seeDeleted_docvalues_boolean", seeDeleted);
 		}
-		super.indexBaseModel(document);
+		super.indexBaseModel(doc);
 
 	}
 
@@ -949,25 +1020,25 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	// store //
 	/////////////
 
-	@Override public void storeForClass(SolrDocument solrDocument) {
-		storeSiteUser(solrDocument);
+	@Override public void storeForClass(SolrResponse.Doc doc) {
+		storeSiteUser(doc);
 	}
-	public void storeSiteUser(SolrDocument solrDocument) {
+	public void storeSiteUser(SolrResponse.Doc doc) {
 		SiteUser oSiteUser = (SiteUser)this;
 
-		Optional.ofNullable((List<?>)solrDocument.get("userKeys_docvalues_longs")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		Optional.ofNullable((List<?>)doc.get("userKeys_docvalues_longs")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oSiteUser.addUserKeys(v.toString());
 		});
-		oSiteUser.setUserId(Optional.ofNullable(solrDocument.get("userId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserName(Optional.ofNullable(solrDocument.get("userName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserEmail(Optional.ofNullable(solrDocument.get("userEmail_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserFirstName(Optional.ofNullable(solrDocument.get("userFirstName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserLastName(Optional.ofNullable(solrDocument.get("userLastName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserFullName(Optional.ofNullable(solrDocument.get("userFullName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setSeeArchived(Optional.ofNullable(solrDocument.get("seeArchived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setSeeDeleted(Optional.ofNullable(solrDocument.get("seeDeleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserId(Optional.ofNullable(doc.get("userId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserName(Optional.ofNullable(doc.get("userName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserEmail(Optional.ofNullable(doc.get("userEmail_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserFirstName(Optional.ofNullable(doc.get("userFirstName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserLastName(Optional.ofNullable(doc.get("userLastName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserFullName(Optional.ofNullable(doc.get("userFullName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setSeeArchived(Optional.ofNullable(doc.get("seeArchived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setSeeDeleted(Optional.ofNullable(doc.get("seeDeleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
 
-		super.storeBaseModel(solrDocument);
+		super.storeBaseModel(doc);
 	}
 
 	//////////////////
@@ -975,7 +1046,7 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	//////////////////
 
 	public void apiRequestSiteUser() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof SiteUser) {
 			SiteUser original = (SiteUser)o;
@@ -1029,4 +1100,182 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	public static final String VAR_userFullName = "userFullName";
 	public static final String VAR_seeArchived = "seeArchived";
 	public static final String VAR_seeDeleted = "seeDeleted";
+
+	public static List<String> varsQForClass() {
+		return SiteUser.varsQSiteUser(new ArrayList<String>());
+	}
+	public static List<String> varsQSiteUser(List<String> vars) {
+		BaseModel.varsQBaseModel(vars);
+		return vars;
+	}
+
+	public static List<String> varsFqForClass() {
+		return SiteUser.varsFqSiteUser(new ArrayList<String>());
+	}
+	public static List<String> varsFqSiteUser(List<String> vars) {
+		vars.add(VAR_userKeys);
+		vars.add(VAR_userId);
+		vars.add(VAR_userName);
+		vars.add(VAR_userEmail);
+		vars.add(VAR_userFirstName);
+		vars.add(VAR_userLastName);
+		vars.add(VAR_userFullName);
+		vars.add(VAR_seeArchived);
+		vars.add(VAR_seeDeleted);
+		BaseModel.varsFqBaseModel(vars);
+		return vars;
+	}
+
+	public static List<String> varsRangeForClass() {
+		return SiteUser.varsRangeSiteUser(new ArrayList<String>());
+	}
+	public static List<String> varsRangeSiteUser(List<String> vars) {
+		BaseModel.varsRangeBaseModel(vars);
+		return vars;
+	}
+
+	public static final String DISPLAY_NAME_userKeys = "";
+	public static final String DISPLAY_NAME_userId = "";
+	public static final String DISPLAY_NAME_userName = "";
+	public static final String DISPLAY_NAME_userEmail = "";
+	public static final String DISPLAY_NAME_userFirstName = "";
+	public static final String DISPLAY_NAME_userLastName = "";
+	public static final String DISPLAY_NAME_userFullName = "";
+	public static final String DISPLAY_NAME_seeArchived = "see archived";
+	public static final String DISPLAY_NAME_seeDeleted = "see deleted";
+
+	public static String displayNameForClass(String var) {
+		return SiteUser.displayNameSiteUser(var);
+	}
+	public static String displayNameSiteUser(String var) {
+		switch(var) {
+		case VAR_userKeys:
+			return DISPLAY_NAME_userKeys;
+		case VAR_userId:
+			return DISPLAY_NAME_userId;
+		case VAR_userName:
+			return DISPLAY_NAME_userName;
+		case VAR_userEmail:
+			return DISPLAY_NAME_userEmail;
+		case VAR_userFirstName:
+			return DISPLAY_NAME_userFirstName;
+		case VAR_userLastName:
+			return DISPLAY_NAME_userLastName;
+		case VAR_userFullName:
+			return DISPLAY_NAME_userFullName;
+		case VAR_seeArchived:
+			return DISPLAY_NAME_seeArchived;
+		case VAR_seeDeleted:
+			return DISPLAY_NAME_seeDeleted;
+		default:
+			return BaseModel.displayNameBaseModel(var);
+		}
+	}
+
+	public static String descriptionSiteUser(String var) {
+		switch(var) {
+		case VAR_userKeys:
+			return "User keys that relate to this user";
+		case VAR_userId:
+			return "The unique user ID from the SSO server";
+		case VAR_userName:
+			return "The user's username";
+		case VAR_userEmail:
+			return "The user's email";
+		case VAR_userFirstName:
+			return "The user's first name";
+		case VAR_userLastName:
+			return "The user's last name";
+		case VAR_userFullName:
+			return "The user's full name";
+		case VAR_seeArchived:
+			return "A user field allowing a user to see archived records";
+		case VAR_seeDeleted:
+			return "A user field allowing a user to see deleted records";
+			default:
+				return BaseModel.descriptionBaseModel(var);
+		}
+	}
+
+	public static String classSimpleNameSiteUser(String var) {
+		switch(var) {
+		case VAR_userKeys:
+			return "List";
+		case VAR_userId:
+			return "String";
+		case VAR_userName:
+			return "String";
+		case VAR_userEmail:
+			return "String";
+		case VAR_userFirstName:
+			return "String";
+		case VAR_userLastName:
+			return "String";
+		case VAR_userFullName:
+			return "String";
+		case VAR_seeArchived:
+			return "Boolean";
+		case VAR_seeDeleted:
+			return "Boolean";
+			default:
+				return BaseModel.classSimpleNameBaseModel(var);
+		}
+	}
+
+	public static Integer htmlColumnSiteUser(String var) {
+		switch(var) {
+			default:
+				return BaseModel.htmlColumnBaseModel(var);
+		}
+	}
+
+	public static Integer htmlRowSiteUser(String var) {
+		switch(var) {
+		case VAR_seeArchived:
+			return 3;
+		case VAR_seeDeleted:
+			return 3;
+			default:
+				return BaseModel.htmlRowBaseModel(var);
+		}
+	}
+
+	public static Integer htmlCellSiteUser(String var) {
+		switch(var) {
+		case VAR_seeArchived:
+			return 2;
+		case VAR_seeDeleted:
+			return 3;
+			default:
+				return BaseModel.htmlCellBaseModel(var);
+		}
+	}
+
+	public static Integer lengthMinSiteUser(String var) {
+		switch(var) {
+			default:
+				return BaseModel.lengthMinBaseModel(var);
+		}
+	}
+
+	public static Integer lengthMaxSiteUser(String var) {
+		switch(var) {
+			default:
+				return BaseModel.lengthMaxBaseModel(var);
+		}
+	}
+
+	public static Integer maxSiteUser(String var) {
+		switch(var) {
+			default:
+				return BaseModel.maxBaseModel(var);
+		}
+	}
+
+	public static Integer minSiteUser(String var) {
+		switch(var) {
+			default:
+				return BaseModel.minBaseModel(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserGen.java
@@ -1,57 +1,58 @@
 package org.curriki.api.enus.model.user;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import io.vertx.core.json.JsonObject;
-import java.util.Date;
-import java.util.Set;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import org.curriki.api.enus.base.BaseModel;
+import java.util.Date;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
 import java.lang.Long;
-import java.lang.String;
-import io.vertx.core.json.JsonArray;
-import java.lang.Boolean;
-import org.computate.search.wrap.Wrap;
-import io.vertx.core.Promise;
+import java.util.Map;
+import io.vertx.core.json.JsonObject;
+import java.math.RoundingMode;
+import org.curriki.api.enus.model.base.BaseModel;
+import java.math.MathContext;
+import java.util.Set;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import java.util.Objects;
+import java.util.List;
+import org.apache.solr.client.solrj.SolrQuery;
+import java.util.Optional;
+import org.apache.solr.client.solrj.util.ClientUtils;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.apache.solr.common.SolrInputDocument;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.computate.search.response.solr.SolrResponse;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.request.api.ApiRequest;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.lang.Boolean;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import org.slf4j.Logger;
+import io.vertx.core.Promise;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.curriki.api.enus.config.ConfigKeys;
+import org.apache.solr.client.solrj.SolrClient;
+import io.vertx.core.json.JsonArray;
+import org.apache.solr.common.SolrDocument;
+import org.apache.commons.lang3.math.NumberUtils;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser">Find the class SiteUser in Solr. </a>
- * <br><br>Delete the class SiteUser in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.user in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.user&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class SiteUserGen<DEV> extends BaseModel {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUser.class);
@@ -83,7 +84,7 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	//////////////
 
 	/**	 The entity userKeys
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<Long>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
@@ -91,11 +92,11 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected List<Long> userKeys = new ArrayList<Long>();
 
-	/**	<br> The entity userKeys
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userKeys">Find the entity userKeys in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity userKeys
+	 *  It is constructed before being initialized with the constructor by default List<Long>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKeys">Find the entity userKeys in Solr</a>
+	 * <br/>
+	 * @param userKeys is the entity already constructed. 
 	 **/
 	protected abstract void _userKeys(List<Long> l);
 
@@ -148,16 +149,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Long staticSearchUserKeys(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrUserKeys(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserKeys(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserKeys(siteRequest_, SiteUser.staticSearchUserKeys(siteRequest_, SiteUser.staticSetUserKeys(siteRequest_, o)));
+	public static String staticSolrFqUserKeys(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserKeys(siteRequest_, SiteUser.staticSolrUserKeys(siteRequest_, SiteUser.staticSetUserKeys(siteRequest_, o)));
 	}
 
 	////////////
@@ -171,10 +172,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userId;
 
-	/**	<br> The entity userId
+	/**	<br/> The entity userId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userId(Wrap<String> c);
@@ -197,20 +198,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserId(siteRequest_, SiteUser.staticSearchUserId(siteRequest_, SiteUser.staticSetUserId(siteRequest_, o)));
-	}
-
-	public String sqlUserId() {
-		return userId;
+	public static String staticSolrFqUserId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserId(siteRequest_, SiteUser.staticSolrUserId(siteRequest_, SiteUser.staticSetUserId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -224,10 +221,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br> The entity userName
+	/**	<br/> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> c);
@@ -250,20 +247,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserName(siteRequest_, SiteUser.staticSearchUserName(siteRequest_, SiteUser.staticSetUserName(siteRequest_, o)));
-	}
-
-	public String sqlUserName() {
-		return userName;
+	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserName(siteRequest_, SiteUser.staticSolrUserName(siteRequest_, SiteUser.staticSetUserName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -277,10 +270,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br> The entity userEmail
+	/**	<br/> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> c);
@@ -303,20 +296,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserEmail(siteRequest_, SiteUser.staticSearchUserEmail(siteRequest_, SiteUser.staticSetUserEmail(siteRequest_, o)));
-	}
-
-	public String sqlUserEmail() {
-		return userEmail;
+	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserEmail(siteRequest_, SiteUser.staticSolrUserEmail(siteRequest_, SiteUser.staticSetUserEmail(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -330,10 +319,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFirstName;
 
-	/**	<br> The entity userFirstName
+	/**	<br/> The entity userFirstName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFirstName(Wrap<String> c);
@@ -356,20 +345,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserFirstName(siteRequest_, SiteUser.staticSearchUserFirstName(siteRequest_, SiteUser.staticSetUserFirstName(siteRequest_, o)));
-	}
-
-	public String sqlUserFirstName() {
-		return userFirstName;
+	public static String staticSolrFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserFirstName(siteRequest_, SiteUser.staticSolrUserFirstName(siteRequest_, SiteUser.staticSetUserFirstName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -383,10 +368,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userLastName;
 
-	/**	<br> The entity userLastName
+	/**	<br/> The entity userLastName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userLastName(Wrap<String> c);
@@ -409,20 +394,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserLastName(siteRequest_, SiteUser.staticSearchUserLastName(siteRequest_, SiteUser.staticSetUserLastName(siteRequest_, o)));
-	}
-
-	public String sqlUserLastName() {
-		return userLastName;
+	public static String staticSolrFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserLastName(siteRequest_, SiteUser.staticSolrUserLastName(siteRequest_, SiteUser.staticSetUserLastName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -436,10 +417,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br> The entity userFullName
+	/**	<br/> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> c);
@@ -462,20 +443,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrUserFullName(siteRequest_, SiteUser.staticSearchUserFullName(siteRequest_, SiteUser.staticSetUserFullName(siteRequest_, o)));
-	}
-
-	public String sqlUserFullName() {
-		return userFullName;
+	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrUserFullName(siteRequest_, SiteUser.staticSolrUserFullName(siteRequest_, SiteUser.staticSetUserFullName(siteRequest_, o)));
 	}
 
 	/////////////////
@@ -489,10 +466,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean seeArchived;
 
-	/**	<br> The entity seeArchived
+	/**	<br/> The entity seeArchived
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:seeArchived">Find the entity seeArchived in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeArchived">Find the entity seeArchived in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _seeArchived(Wrap<Boolean> c);
@@ -520,20 +497,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Boolean staticSearchSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSolrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSearchStrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSolrStrSeeArchived(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSeeArchived(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrSeeArchived(siteRequest_, SiteUser.staticSearchSeeArchived(siteRequest_, SiteUser.staticSetSeeArchived(siteRequest_, o)));
-	}
-
-	public Boolean sqlSeeArchived() {
-		return seeArchived;
+	public static String staticSolrFqSeeArchived(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrSeeArchived(siteRequest_, SiteUser.staticSolrSeeArchived(siteRequest_, SiteUser.staticSetSeeArchived(siteRequest_, o)));
 	}
 
 	////////////////
@@ -547,10 +520,10 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	@JsonInclude(Include.NON_NULL)
 	protected Boolean seeDeleted;
 
-	/**	<br> The entity seeDeleted
+	/**	<br/> The entity seeDeleted
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=entiteVar_enUS_indexed_string:seeDeleted">Find the entity seeDeleted in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUser&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:seeDeleted">Find the entity seeDeleted in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _seeDeleted(Wrap<Boolean> c);
@@ -578,20 +551,16 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return (SiteUser)this;
 	}
 
-	public static Boolean staticSearchSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static Boolean staticSolrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o;
 	}
 
-	public static String staticSearchStrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
+	public static String staticSolrStrSeeDeleted(SiteRequestEnUS siteRequest_, Boolean o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSeeDeleted(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUser.staticSearchStrSeeDeleted(siteRequest_, SiteUser.staticSearchSeeDeleted(siteRequest_, SiteUser.staticSetSeeDeleted(siteRequest_, o)));
-	}
-
-	public Boolean sqlSeeDeleted() {
-		return seeDeleted;
+	public static String staticSolrFqSeeDeleted(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUser.staticSolrStrSeeDeleted(siteRequest_, SiteUser.staticSolrSeeDeleted(siteRequest_, SiteUser.staticSetSeeDeleted(siteRequest_, o)));
 	}
 
 	//////////////
@@ -766,168 +735,124 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchSiteUser(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSearchUserKeys(siteRequest_, (Long)o);
+			return SiteUser.staticSolrUserKeys(siteRequest_, (Long)o);
 		case "userId":
-			return SiteUser.staticSearchUserId(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserId(siteRequest_, (String)o);
 		case "userName":
-			return SiteUser.staticSearchUserName(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteUser.staticSearchUserEmail(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserEmail(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteUser.staticSearchUserFirstName(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserFirstName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteUser.staticSearchUserLastName(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserLastName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteUser.staticSearchUserFullName(siteRequest_, (String)o);
+			return SiteUser.staticSolrUserFullName(siteRequest_, (String)o);
 		case "seeArchived":
-			return SiteUser.staticSearchSeeArchived(siteRequest_, (Boolean)o);
+			return SiteUser.staticSolrSeeArchived(siteRequest_, (Boolean)o);
 		case "seeDeleted":
-			return SiteUser.staticSearchSeeDeleted(siteRequest_, (Boolean)o);
+			return SiteUser.staticSolrSeeDeleted(siteRequest_, (Boolean)o);
 			default:
-				return BaseModel.staticSearchBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrSiteUser(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrSiteUser(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSearchStrUserKeys(siteRequest_, (Long)o);
+			return SiteUser.staticSolrStrUserKeys(siteRequest_, (Long)o);
 		case "userId":
-			return SiteUser.staticSearchStrUserId(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserId(siteRequest_, (String)o);
 		case "userName":
-			return SiteUser.staticSearchStrUserName(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteUser.staticSearchStrUserEmail(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserEmail(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteUser.staticSearchStrUserFirstName(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserFirstName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteUser.staticSearchStrUserLastName(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserLastName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteUser.staticSearchStrUserFullName(siteRequest_, (String)o);
+			return SiteUser.staticSolrStrUserFullName(siteRequest_, (String)o);
 		case "seeArchived":
-			return SiteUser.staticSearchStrSeeArchived(siteRequest_, (Boolean)o);
+			return SiteUser.staticSolrStrSeeArchived(siteRequest_, (Boolean)o);
 		case "seeDeleted":
-			return SiteUser.staticSearchStrSeeDeleted(siteRequest_, (Boolean)o);
+			return SiteUser.staticSolrStrSeeDeleted(siteRequest_, (Boolean)o);
 			default:
-				return BaseModel.staticSearchStrBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrStrBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqSiteUser(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqSiteUser(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqSiteUser(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqSiteUser(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "userKeys":
-			return SiteUser.staticSearchFqUserKeys(siteRequest_, o);
+			return SiteUser.staticSolrFqUserKeys(siteRequest_, o);
 		case "userId":
-			return SiteUser.staticSearchFqUserId(siteRequest_, o);
+			return SiteUser.staticSolrFqUserId(siteRequest_, o);
 		case "userName":
-			return SiteUser.staticSearchFqUserName(siteRequest_, o);
+			return SiteUser.staticSolrFqUserName(siteRequest_, o);
 		case "userEmail":
-			return SiteUser.staticSearchFqUserEmail(siteRequest_, o);
+			return SiteUser.staticSolrFqUserEmail(siteRequest_, o);
 		case "userFirstName":
-			return SiteUser.staticSearchFqUserFirstName(siteRequest_, o);
+			return SiteUser.staticSolrFqUserFirstName(siteRequest_, o);
 		case "userLastName":
-			return SiteUser.staticSearchFqUserLastName(siteRequest_, o);
+			return SiteUser.staticSolrFqUserLastName(siteRequest_, o);
 		case "userFullName":
-			return SiteUser.staticSearchFqUserFullName(siteRequest_, o);
+			return SiteUser.staticSolrFqUserFullName(siteRequest_, o);
 		case "seeArchived":
-			return SiteUser.staticSearchFqSeeArchived(siteRequest_, o);
+			return SiteUser.staticSolrFqSeeArchived(siteRequest_, o);
 		case "seeDeleted":
-			return SiteUser.staticSearchFqSeeDeleted(siteRequest_, o);
+			return SiteUser.staticSolrFqSeeDeleted(siteRequest_, o);
 			default:
-				return BaseModel.staticSearchFqBaseModel(entityVar,  siteRequest_, o);
+				return BaseModel.staticSolrFqBaseModel(entityVar,  siteRequest_, o);
 		}
 	}
 
 	/////////////
-	// persist //
+	// define //
 	/////////////
 
-	@Override public boolean persistForClass(String var, Object val) {
+	@Override public boolean defineForClass(String var, Object val) {
 		String[] vars = StringUtils.split(var, ".");
 		Object o = null;
 		if(val != null) {
 			for(String v : vars) {
 				if(o == null)
-					o = persistSiteUser(v, val);
+					o = defineSiteUser(v, val);
 				else if(o instanceof BaseModel) {
 					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.persistForClass(v, val);
+					o = oBaseModel.defineForClass(v, val);
 				}
 			}
 		}
 		return o != null;
 	}
-	public Object persistSiteUser(String var, Object val) {
+	public Object defineSiteUser(String var, Object val) {
 		switch(var.toLowerCase()) {
-			case "userid":
-				if(val instanceof String)
-					setUserId((String)val);
-				saves.add("userId");
-				return val;
-			case "username":
-				if(val instanceof String)
-					setUserName((String)val);
-				saves.add("userName");
-				return val;
-			case "useremail":
-				if(val instanceof String)
-					setUserEmail((String)val);
-				saves.add("userEmail");
-				return val;
-			case "userfirstname":
-				if(val instanceof String)
-					setUserFirstName((String)val);
-				saves.add("userFirstName");
-				return val;
-			case "userlastname":
-				if(val instanceof String)
-					setUserLastName((String)val);
-				saves.add("userLastName");
-				return val;
-			case "userfullname":
-				if(val instanceof String)
-					setUserFullName((String)val);
-				saves.add("userFullName");
-				return val;
-			case "seearchived":
-				if(val instanceof Boolean)
-					setSeeArchived((Boolean)val);
-				else if(val instanceof String)
-					setSeeArchived((String)val);
-				saves.add("seeArchived");
-				return val;
-			case "seedeleted":
-				if(val instanceof Boolean)
-					setSeeDeleted((Boolean)val);
-				else if(val instanceof String)
-					setSeeDeleted((String)val);
-				saves.add("seeDeleted");
-				return val;
 			default:
-				return super.persistBaseModel(var, val);
+				return super.defineBaseModel(var, val);
 		}
 	}
 
@@ -935,77 +860,50 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	// populate //
 	/////////////
 
-	@Override public void populateForClass(SolrResponse.Doc doc) {
-		populateSiteUser(doc);
+	@Override public void populateForClass(SolrDocument solrDocument) {
+		populateSiteUser(solrDocument);
 	}
-	public void populateSiteUser(SolrResponse.Doc doc) {
+	public void populateSiteUser(SolrDocument solrDocument) {
 		SiteUser oSiteUser = (SiteUser)this;
-		saves = doc.get("saves_docvalues_strings");
+		saves = (List<String>)solrDocument.get("saves_docvalues_strings");
 		if(saves != null) {
 		}
 
-		super.populateBaseModel(doc);
+		super.populateBaseModel(solrDocument);
 	}
 
-	public void indexSiteUser(JsonObject doc) {
+	public void indexSiteUser(SolrInputDocument document) {
 		if(userKeys != null) {
-			JsonArray l = new JsonArray();
-			doc.put("userKeys_docvalues_longs", l);
-			for(Long o : userKeys) {
-				l.add(o);
+			for(java.lang.Long o : userKeys) {
+				document.addField("userKeys_docvalues_longs", o);
 			}
 		}
 		if(userId != null) {
-			doc.put("userId_docvalues_string", userId);
+			document.addField("userId_docvalues_string", userId);
 		}
 		if(userName != null) {
-			doc.put("userName_docvalues_string", userName);
+			document.addField("userName_docvalues_string", userName);
 		}
 		if(userEmail != null) {
-			doc.put("userEmail_docvalues_string", userEmail);
+			document.addField("userEmail_docvalues_string", userEmail);
 		}
 		if(userFirstName != null) {
-			doc.put("userFirstName_docvalues_string", userFirstName);
+			document.addField("userFirstName_docvalues_string", userFirstName);
 		}
 		if(userLastName != null) {
-			doc.put("userLastName_docvalues_string", userLastName);
+			document.addField("userLastName_docvalues_string", userLastName);
 		}
 		if(userFullName != null) {
-			doc.put("userFullName_docvalues_string", userFullName);
+			document.addField("userFullName_docvalues_string", userFullName);
 		}
 		if(seeArchived != null) {
-			doc.put("seeArchived_docvalues_boolean", seeArchived);
+			document.addField("seeArchived_docvalues_boolean", seeArchived);
 		}
 		if(seeDeleted != null) {
-			doc.put("seeDeleted_docvalues_boolean", seeDeleted);
+			document.addField("seeDeleted_docvalues_boolean", seeDeleted);
 		}
-		super.indexBaseModel(doc);
+		super.indexBaseModel(document);
 
-	}
-
-	public static String varStoredSiteUser(String entityVar) {
-		switch(entityVar) {
-			case "userKeys":
-				return "userKeys_docvalues_longs";
-			case "userId":
-				return "userId_docvalues_string";
-			case "userName":
-				return "userName_docvalues_string";
-			case "userEmail":
-				return "userEmail_docvalues_string";
-			case "userFirstName":
-				return "userFirstName_docvalues_string";
-			case "userLastName":
-				return "userLastName_docvalues_string";
-			case "userFullName":
-				return "userFullName_docvalues_string";
-			case "seeArchived":
-				return "seeArchived_docvalues_boolean";
-			case "seeDeleted":
-				return "seeDeleted_docvalues_boolean";
-			default:
-				return BaseModel.varStoredBaseModel(entityVar);
-		}
 	}
 
 	public static String varIndexedSiteUser(String entityVar) {
@@ -1051,25 +949,25 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	// store //
 	/////////////
 
-	@Override public void storeForClass(SolrResponse.Doc doc) {
-		storeSiteUser(doc);
+	@Override public void storeForClass(SolrDocument solrDocument) {
+		storeSiteUser(solrDocument);
 	}
-	public void storeSiteUser(SolrResponse.Doc doc) {
+	public void storeSiteUser(SolrDocument solrDocument) {
 		SiteUser oSiteUser = (SiteUser)this;
 
-		Optional.ofNullable((List<?>)doc.get("userKeys_docvalues_longs")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
+		Optional.ofNullable((List<?>)solrDocument.get("userKeys_docvalues_longs")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
 			oSiteUser.addUserKeys(v.toString());
 		});
-		oSiteUser.setUserId(Optional.ofNullable(doc.get("userId_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserName(Optional.ofNullable(doc.get("userName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserEmail(Optional.ofNullable(doc.get("userEmail_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserFirstName(Optional.ofNullable(doc.get("userFirstName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserLastName(Optional.ofNullable(doc.get("userLastName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setUserFullName(Optional.ofNullable(doc.get("userFullName_docvalues_string")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setSeeArchived(Optional.ofNullable(doc.get("seeArchived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
-		oSiteUser.setSeeDeleted(Optional.ofNullable(doc.get("seeDeleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserId(Optional.ofNullable(solrDocument.get("userId_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserName(Optional.ofNullable(solrDocument.get("userName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserEmail(Optional.ofNullable(solrDocument.get("userEmail_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserFirstName(Optional.ofNullable(solrDocument.get("userFirstName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserLastName(Optional.ofNullable(solrDocument.get("userLastName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setUserFullName(Optional.ofNullable(solrDocument.get("userFullName_docvalues_string")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setSeeArchived(Optional.ofNullable(solrDocument.get("seeArchived_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+		oSiteUser.setSeeDeleted(Optional.ofNullable(solrDocument.get("seeDeleted_docvalues_boolean")).map(v -> v.toString()).orElse(null));
 
-		super.storeBaseModel(doc);
+		super.storeBaseModel(solrDocument);
 	}
 
 	//////////////////
@@ -1077,7 +975,7 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	//////////////////
 
 	public void apiRequestSiteUser() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(r -> r.getApiRequest_()).orElse(null);
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
 		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
 		if(o != null && o instanceof SiteUser) {
 			SiteUser original = (SiteUser)o;
@@ -1122,7 +1020,6 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "SiteUser";
 	public static final String VAR_userKeys = "userKeys";
 	public static final String VAR_userId = "userId";
 	public static final String VAR_userName = "userName";
@@ -1132,182 +1029,4 @@ public abstract class SiteUserGen<DEV> extends BaseModel {
 	public static final String VAR_userFullName = "userFullName";
 	public static final String VAR_seeArchived = "seeArchived";
 	public static final String VAR_seeDeleted = "seeDeleted";
-
-	public static List<String> varsQForClass() {
-		return SiteUser.varsQSiteUser(new ArrayList<String>());
-	}
-	public static List<String> varsQSiteUser(List<String> vars) {
-		BaseModel.varsQBaseModel(vars);
-		return vars;
-	}
-
-	public static List<String> varsFqForClass() {
-		return SiteUser.varsFqSiteUser(new ArrayList<String>());
-	}
-	public static List<String> varsFqSiteUser(List<String> vars) {
-		vars.add(VAR_userKeys);
-		vars.add(VAR_userId);
-		vars.add(VAR_userName);
-		vars.add(VAR_userEmail);
-		vars.add(VAR_userFirstName);
-		vars.add(VAR_userLastName);
-		vars.add(VAR_userFullName);
-		vars.add(VAR_seeArchived);
-		vars.add(VAR_seeDeleted);
-		BaseModel.varsFqBaseModel(vars);
-		return vars;
-	}
-
-	public static List<String> varsRangeForClass() {
-		return SiteUser.varsRangeSiteUser(new ArrayList<String>());
-	}
-	public static List<String> varsRangeSiteUser(List<String> vars) {
-		BaseModel.varsRangeBaseModel(vars);
-		return vars;
-	}
-
-	public static final String DISPLAY_NAME_userKeys = "";
-	public static final String DISPLAY_NAME_userId = "";
-	public static final String DISPLAY_NAME_userName = "";
-	public static final String DISPLAY_NAME_userEmail = "";
-	public static final String DISPLAY_NAME_userFirstName = "";
-	public static final String DISPLAY_NAME_userLastName = "";
-	public static final String DISPLAY_NAME_userFullName = "";
-	public static final String DISPLAY_NAME_seeArchived = "see archived";
-	public static final String DISPLAY_NAME_seeDeleted = "see deleted";
-
-	public static String displayNameForClass(String var) {
-		return SiteUser.displayNameSiteUser(var);
-	}
-	public static String displayNameSiteUser(String var) {
-		switch(var) {
-		case VAR_userKeys:
-			return DISPLAY_NAME_userKeys;
-		case VAR_userId:
-			return DISPLAY_NAME_userId;
-		case VAR_userName:
-			return DISPLAY_NAME_userName;
-		case VAR_userEmail:
-			return DISPLAY_NAME_userEmail;
-		case VAR_userFirstName:
-			return DISPLAY_NAME_userFirstName;
-		case VAR_userLastName:
-			return DISPLAY_NAME_userLastName;
-		case VAR_userFullName:
-			return DISPLAY_NAME_userFullName;
-		case VAR_seeArchived:
-			return DISPLAY_NAME_seeArchived;
-		case VAR_seeDeleted:
-			return DISPLAY_NAME_seeDeleted;
-		default:
-			return BaseModel.displayNameBaseModel(var);
-		}
-	}
-
-	public static String descriptionSiteUser(String var) {
-		switch(var) {
-		case VAR_userKeys:
-			return "User keys that relate to this user";
-		case VAR_userId:
-			return "The unique user ID from the SSO server";
-		case VAR_userName:
-			return "The user's username";
-		case VAR_userEmail:
-			return "The user's email";
-		case VAR_userFirstName:
-			return "The user's first name";
-		case VAR_userLastName:
-			return "The user's last name";
-		case VAR_userFullName:
-			return "The user's full name";
-		case VAR_seeArchived:
-			return "A user field allowing a user to see archived records";
-		case VAR_seeDeleted:
-			return "A user field allowing a user to see deleted records";
-			default:
-				return BaseModel.descriptionBaseModel(var);
-		}
-	}
-
-	public static String classSimpleNameSiteUser(String var) {
-		switch(var) {
-		case VAR_userKeys:
-			return "List";
-		case VAR_userId:
-			return "String";
-		case VAR_userName:
-			return "String";
-		case VAR_userEmail:
-			return "String";
-		case VAR_userFirstName:
-			return "String";
-		case VAR_userLastName:
-			return "String";
-		case VAR_userFullName:
-			return "String";
-		case VAR_seeArchived:
-			return "Boolean";
-		case VAR_seeDeleted:
-			return "Boolean";
-			default:
-				return BaseModel.classSimpleNameBaseModel(var);
-		}
-	}
-
-	public static Integer htmlColumnSiteUser(String var) {
-		switch(var) {
-			default:
-				return BaseModel.htmlColumnBaseModel(var);
-		}
-	}
-
-	public static Integer htmlRowSiteUser(String var) {
-		switch(var) {
-		case VAR_seeArchived:
-			return 3;
-		case VAR_seeDeleted:
-			return 3;
-			default:
-				return BaseModel.htmlRowBaseModel(var);
-		}
-	}
-
-	public static Integer htmlCellSiteUser(String var) {
-		switch(var) {
-		case VAR_seeArchived:
-			return 2;
-		case VAR_seeDeleted:
-			return 3;
-			default:
-				return BaseModel.htmlCellBaseModel(var);
-		}
-	}
-
-	public static Integer lengthMinSiteUser(String var) {
-		switch(var) {
-			default:
-				return BaseModel.lengthMinBaseModel(var);
-		}
-	}
-
-	public static Integer lengthMaxSiteUser(String var) {
-		switch(var) {
-			default:
-				return BaseModel.lengthMaxBaseModel(var);
-		}
-	}
-
-	public static Integer maxSiteUser(String var) {
-		switch(var) {
-			default:
-				return BaseModel.maxBaseModel(var);
-		}
-	}
-
-	public static Integer minSiteUser(String var) {
-		switch(var) {
-			default:
-				return BaseModel.minBaseModel(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserGenPageGen.java
@@ -2,48 +2,59 @@ package org.curriki.api.enus.model.user;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
+import java.util.Date;
+import java.time.ZonedDateTime;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
+import org.apache.commons.lang3.StringUtils;
+import org.curriki.api.enus.model.base.BaseModelPage;
+import java.lang.Integer;
+import java.lang.Long;
+import java.util.Locale;
+import java.util.Map;
+import java.time.ZoneOffset;
+import org.curriki.api.enus.model.base.BaseModel;
+import java.math.RoundingMode;
+import java.math.MathContext;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.Instant;
+import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
+import java.time.ZoneId;
+import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
+import org.computate.vertx.search.list.SearchList;
+import java.util.List;
+import java.time.OffsetDateTime;
+import org.computate.search.wrap.Wrap;
+import java.util.Optional;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.model.user.SiteUser;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.computate.search.response.solr.SolrResponse.FacetCounts;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.apache.commons.lang3.StringUtils;
-import java.lang.Integer;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
-import java.lang.Long;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
-import java.math.RoundingMode;
-import org.curriki.api.enus.search.SearchList;
 import org.slf4j.Logger;
-import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.curriki.api.enus.user.SiteUser;
-import io.vertx.core.Future;
-import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import java.time.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
 import org.apache.commons.lang3.math.NumberUtils;
-import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import org.curriki.api.enus.base.BaseModelPage;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUserGenPage.class);
@@ -59,10 +70,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<SiteUser> searchListSiteUser_;
 
-	/**	<br/> The entity searchListSiteUser_
+	/**	<br> The entity searchListSiteUser_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListSiteUser_">Find the entity searchListSiteUser_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListSiteUser_">Find the entity searchListSiteUser_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListSiteUser_(Wrap<SearchList<SiteUser>> w);
@@ -87,20 +98,703 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	}
 
 	//////////////////
+	// pageResponse //
+	//////////////////
+
+	/**	 The entity pageResponse
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String pageResponse;
+
+	/**	<br> The entity pageResponse
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _pageResponse(Wrap<String> w);
+
+	public String getPageResponse() {
+		return pageResponse;
+	}
+	public void setPageResponse(String o) {
+		this.pageResponse = SiteUserGenPage.staticSetPageResponse(siteRequest_, o);
+	}
+	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage pageResponseInit() {
+		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
+		if(pageResponse == null) {
+			_pageResponse(pageResponseWrap);
+			setPageResponse(pageResponseWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrPageResponse(siteRequest_, SiteUserGenPage.staticSearchPageResponse(siteRequest_, SiteUserGenPage.staticSetPageResponse(siteRequest_, o)));
+	}
+
+	///////////////////
+	// defaultZoneId //
+	///////////////////
+
+	/**	 The entity defaultZoneId
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultZoneId;
+
+	/**	<br> The entity defaultZoneId
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultZoneId">Find the entity defaultZoneId in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultZoneId(Wrap<String> w);
+
+	public String getDefaultZoneId() {
+		return defaultZoneId;
+	}
+	public void setDefaultZoneId(String o) {
+		this.defaultZoneId = SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o);
+	}
+	public static String staticSetDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage defaultZoneIdInit() {
+		Wrap<String> defaultZoneIdWrap = new Wrap<String>().var("defaultZoneId");
+		if(defaultZoneId == null) {
+			_defaultZoneId(defaultZoneIdWrap);
+			setDefaultZoneId(defaultZoneIdWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultZoneId(siteRequest_, SiteUserGenPage.staticSearchDefaultZoneId(siteRequest_, SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultTimeZone //
+	/////////////////////
+
+	/**	 The entity defaultTimeZone
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected ZoneId defaultTimeZone;
+
+	/**	<br> The entity defaultTimeZone
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultTimeZone">Find the entity defaultTimeZone in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultTimeZone(Wrap<ZoneId> w);
+
+	public ZoneId getDefaultTimeZone() {
+		return defaultTimeZone;
+	}
+
+	public void setDefaultTimeZone(ZoneId defaultTimeZone) {
+		this.defaultTimeZone = defaultTimeZone;
+	}
+	public static ZoneId staticSetDefaultTimeZone(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected SiteUserGenPage defaultTimeZoneInit() {
+		Wrap<ZoneId> defaultTimeZoneWrap = new Wrap<ZoneId>().var("defaultTimeZone");
+		if(defaultTimeZone == null) {
+			_defaultTimeZone(defaultTimeZoneWrap);
+			setDefaultTimeZone(defaultTimeZoneWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	/////////////////////
+	// defaultLocaleId //
+	/////////////////////
+
+	/**	 The entity defaultLocaleId
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultLocaleId;
+
+	/**	<br> The entity defaultLocaleId
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultLocaleId">Find the entity defaultLocaleId in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultLocaleId(Wrap<String> w);
+
+	public String getDefaultLocaleId() {
+		return defaultLocaleId;
+	}
+	public void setDefaultLocaleId(String o) {
+		this.defaultLocaleId = SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o);
+	}
+	public static String staticSetDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage defaultLocaleIdInit() {
+		Wrap<String> defaultLocaleIdWrap = new Wrap<String>().var("defaultLocaleId");
+		if(defaultLocaleId == null) {
+			_defaultLocaleId(defaultLocaleIdWrap);
+			setDefaultLocaleId(defaultLocaleIdWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultLocaleId(siteRequest_, SiteUserGenPage.staticSearchDefaultLocaleId(siteRequest_, SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o)));
+	}
+
+	///////////////////
+	// defaultLocale //
+	///////////////////
+
+	/**	 The entity defaultLocale
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected Locale defaultLocale;
+
+	/**	<br> The entity defaultLocale
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultLocale">Find the entity defaultLocale in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultLocale(Wrap<Locale> w);
+
+	public Locale getDefaultLocale() {
+		return defaultLocale;
+	}
+
+	public void setDefaultLocale(Locale defaultLocale) {
+		this.defaultLocale = defaultLocale;
+	}
+	public static Locale staticSetDefaultLocale(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected SiteUserGenPage defaultLocaleInit() {
+		Wrap<Locale> defaultLocaleWrap = new Wrap<Locale>().var("defaultLocale");
+		if(defaultLocale == null) {
+			_defaultLocale(defaultLocaleWrap);
+			setDefaultLocale(defaultLocaleWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	/////////////////////
+	// defaultRangeGap //
+	/////////////////////
+
+	/**	 The entity defaultRangeGap
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultRangeGap;
+
+	/**	<br> The entity defaultRangeGap
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeGap">Find the entity defaultRangeGap in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeGap(Wrap<String> w);
+
+	public String getDefaultRangeGap() {
+		return defaultRangeGap;
+	}
+	public void setDefaultRangeGap(String o) {
+		this.defaultRangeGap = SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o);
+	}
+	public static String staticSetDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage defaultRangeGapInit() {
+		Wrap<String> defaultRangeGapWrap = new Wrap<String>().var("defaultRangeGap");
+		if(defaultRangeGap == null) {
+			_defaultRangeGap(defaultRangeGapWrap);
+			setDefaultRangeGap(defaultRangeGapWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultRangeGap(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeGap(siteRequest_, SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultRangeEnd //
+	/////////////////////
+
+	/**	 The entity defaultRangeEnd
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
+	@JsonInclude(Include.NON_NULL)
+	protected ZonedDateTime defaultRangeEnd;
+
+	/**	<br> The entity defaultRangeEnd
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeEnd">Find the entity defaultRangeEnd in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeEnd(Wrap<ZonedDateTime> w);
+
+	public ZonedDateTime getDefaultRangeEnd() {
+		return defaultRangeEnd;
+	}
+
+	public void setDefaultRangeEnd(ZonedDateTime defaultRangeEnd) {
+		this.defaultRangeEnd = defaultRangeEnd;
+	}
+	@JsonIgnore
+	public void setDefaultRangeEnd(Instant o) {
+		this.defaultRangeEnd = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
+	}
+	/** Example: 2011-12-03T10:15:30+01:00 **/
+	@JsonIgnore
+	public void setDefaultRangeEnd(String o) {
+		this.defaultRangeEnd = SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
+	}
+	public static ZonedDateTime staticSetDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
+		if(StringUtils.endsWith(o, "Z"))
+			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+		else
+			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
+	}
+	@JsonIgnore
+	public void setDefaultRangeEnd(Date o) {
+		this.defaultRangeEnd = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+	}
+	protected SiteUserGenPage defaultRangeEndInit() {
+		Wrap<ZonedDateTime> defaultRangeEndWrap = new Wrap<ZonedDateTime>().var("defaultRangeEnd");
+		if(defaultRangeEnd == null) {
+			_defaultRangeEnd(defaultRangeEndWrap);
+			setDefaultRangeEnd(defaultRangeEndWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static Date staticSearchDefaultRangeEnd(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+		return o == null ? null : Date.from(o.toInstant());
+	}
+
+	public static String staticSearchStrDefaultRangeEnd(SiteRequestEnUS siteRequest_, Date o) {
+		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
+	}
+
+	public static String staticSearchFqDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeEnd(siteRequest_, SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o)));
+	}
+
+	///////////////////////
+	// defaultRangeStart //
+	///////////////////////
+
+	/**	 The entity defaultRangeStart
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
+	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
+	@JsonInclude(Include.NON_NULL)
+	protected ZonedDateTime defaultRangeStart;
+
+	/**	<br> The entity defaultRangeStart
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeStart">Find the entity defaultRangeStart in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeStart(Wrap<ZonedDateTime> w);
+
+	public ZonedDateTime getDefaultRangeStart() {
+		return defaultRangeStart;
+	}
+
+	public void setDefaultRangeStart(ZonedDateTime defaultRangeStart) {
+		this.defaultRangeStart = defaultRangeStart;
+	}
+	@JsonIgnore
+	public void setDefaultRangeStart(Instant o) {
+		this.defaultRangeStart = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
+	}
+	/** Example: 2011-12-03T10:15:30+01:00 **/
+	@JsonIgnore
+	public void setDefaultRangeStart(String o) {
+		this.defaultRangeStart = SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o);
+	}
+	public static ZonedDateTime staticSetDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
+		if(StringUtils.endsWith(o, "]"))
+			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
+		if(StringUtils.endsWith(o, "Z"))
+			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+		else
+			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
+	}
+	@JsonIgnore
+	public void setDefaultRangeStart(Date o) {
+		this.defaultRangeStart = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
+	}
+	protected SiteUserGenPage defaultRangeStartInit() {
+		Wrap<ZonedDateTime> defaultRangeStartWrap = new Wrap<ZonedDateTime>().var("defaultRangeStart");
+		if(defaultRangeStart == null) {
+			_defaultRangeStart(defaultRangeStartWrap);
+			setDefaultRangeStart(defaultRangeStartWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static Date staticSearchDefaultRangeStart(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
+		return o == null ? null : Date.from(o.toInstant());
+	}
+
+	public static String staticSearchStrDefaultRangeStart(SiteRequestEnUS siteRequest_, Date o) {
+		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
+	}
+
+	public static String staticSearchFqDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultRangeStart(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeStart(siteRequest_, SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o)));
+	}
+
+	/////////////////////
+	// defaultRangeVar //
+	/////////////////////
+
+	/**	 The entity defaultRangeVar
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultRangeVar;
+
+	/**	<br> The entity defaultRangeVar
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultRangeVar">Find the entity defaultRangeVar in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultRangeVar(Wrap<String> w);
+
+	public String getDefaultRangeVar() {
+		return defaultRangeVar;
+	}
+	public void setDefaultRangeVar(String o) {
+		this.defaultRangeVar = SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o);
+	}
+	public static String staticSetDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage defaultRangeVarInit() {
+		Wrap<String> defaultRangeVarWrap = new Wrap<String>().var("defaultRangeVar");
+		if(defaultRangeVar == null) {
+			_defaultRangeVar(defaultRangeVarWrap);
+			setDefaultRangeVar(defaultRangeVarWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultRangeVar(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeVar(siteRequest_, SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o)));
+	}
+
+	//////////////////////
+	// defaultFacetSort //
+	//////////////////////
+
+	/**	 The entity defaultFacetSort
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String defaultFacetSort;
+
+	/**	<br> The entity defaultFacetSort
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetSort">Find the entity defaultFacetSort in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetSort(Wrap<String> w);
+
+	public String getDefaultFacetSort() {
+		return defaultFacetSort;
+	}
+	public void setDefaultFacetSort(String o) {
+		this.defaultFacetSort = SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o);
+	}
+	public static String staticSetDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage defaultFacetSortInit() {
+		Wrap<String> defaultFacetSortWrap = new Wrap<String>().var("defaultFacetSort");
+		if(defaultFacetSort == null) {
+			_defaultFacetSort(defaultFacetSortWrap);
+			setDefaultFacetSort(defaultFacetSortWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultFacetSort(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetSort(siteRequest_, SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o)));
+	}
+
+	///////////////////////
+	// defaultFacetLimit //
+	///////////////////////
+
+	/**	 The entity defaultFacetLimit
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultFacetLimit;
+
+	/**	<br> The entity defaultFacetLimit
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetLimit">Find the entity defaultFacetLimit in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetLimit(Wrap<Integer> w);
+
+	public Integer getDefaultFacetLimit() {
+		return defaultFacetLimit;
+	}
+
+	public void setDefaultFacetLimit(Integer defaultFacetLimit) {
+		this.defaultFacetLimit = defaultFacetLimit;
+	}
+	@JsonIgnore
+	public void setDefaultFacetLimit(String o) {
+		this.defaultFacetLimit = SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected SiteUserGenPage defaultFacetLimitInit() {
+		Wrap<Integer> defaultFacetLimitWrap = new Wrap<Integer>().var("defaultFacetLimit");
+		if(defaultFacetLimit == null) {
+			_defaultFacetLimit(defaultFacetLimitWrap);
+			setDefaultFacetLimit(defaultFacetLimitWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetLimit(siteRequest_, SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o)));
+	}
+
+	//////////////////////////
+	// defaultFacetMinCount //
+	//////////////////////////
+
+	/**	 The entity defaultFacetMinCount
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultFacetMinCount;
+
+	/**	<br> The entity defaultFacetMinCount
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultFacetMinCount">Find the entity defaultFacetMinCount in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultFacetMinCount(Wrap<Integer> w);
+
+	public Integer getDefaultFacetMinCount() {
+		return defaultFacetMinCount;
+	}
+
+	public void setDefaultFacetMinCount(Integer defaultFacetMinCount) {
+		this.defaultFacetMinCount = defaultFacetMinCount;
+	}
+	@JsonIgnore
+	public void setDefaultFacetMinCount(String o) {
+		this.defaultFacetMinCount = SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected SiteUserGenPage defaultFacetMinCountInit() {
+		Wrap<Integer> defaultFacetMinCountWrap = new Wrap<Integer>().var("defaultFacetMinCount");
+		if(defaultFacetMinCount == null) {
+			_defaultFacetMinCount(defaultFacetMinCountWrap);
+			setDefaultFacetMinCount(defaultFacetMinCountWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetMinCount(siteRequest_, SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o)));
+	}
+
+	//////////////////////////
+	// defaultPivotMinCount //
+	//////////////////////////
+
+	/**	 The entity defaultPivotMinCount
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonSerialize(using = ToStringSerializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected Integer defaultPivotMinCount;
+
+	/**	<br> The entity defaultPivotMinCount
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:defaultPivotMinCount">Find the entity defaultPivotMinCount in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _defaultPivotMinCount(Wrap<Integer> w);
+
+	public Integer getDefaultPivotMinCount() {
+		return defaultPivotMinCount;
+	}
+
+	public void setDefaultPivotMinCount(Integer defaultPivotMinCount) {
+		this.defaultPivotMinCount = defaultPivotMinCount;
+	}
+	@JsonIgnore
+	public void setDefaultPivotMinCount(String o) {
+		this.defaultPivotMinCount = SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
+	}
+	public static Integer staticSetDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
+		if(NumberUtils.isParsable(o))
+			return Integer.parseInt(o);
+		return null;
+	}
+	protected SiteUserGenPage defaultPivotMinCountInit() {
+		Wrap<Integer> defaultPivotMinCountWrap = new Wrap<Integer>().var("defaultPivotMinCount");
+		if(defaultPivotMinCount == null) {
+			_defaultPivotMinCount(defaultPivotMinCountWrap);
+			setDefaultPivotMinCount(defaultPivotMinCountWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static Integer staticSearchDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o;
+	}
+
+	public static String staticSearchStrDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, SiteUserGenPage.staticSearchDefaultPivotMinCount(siteRequest_, SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o)));
+	}
+
+	//////////////////
 	// listSiteUser //
 	//////////////////
 
 	/**	 The entity listSiteUser
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listSiteUser = new JsonArray();
 
-	/**	<br/> The entity listSiteUser
-	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listSiteUser">Find the entity listSiteUser in Solr</a>
-	 * <br/>
-	 * @param listSiteUser is the entity already constructed. 
+	/**	<br> The entity listSiteUser
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listSiteUser">Find the entity listSiteUser in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _listSiteUser(JsonArray l);
 
@@ -119,6 +813,44 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
+	/////////////////
+	// facetCounts //
+	/////////////////
+
+	/**	 The entity facetCounts
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected FacetCounts facetCounts;
+
+	/**	<br> The entity facetCounts
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _facetCounts(Wrap<FacetCounts> w);
+
+	public FacetCounts getFacetCounts() {
+		return facetCounts;
+	}
+
+	public void setFacetCounts(FacetCounts facetCounts) {
+		this.facetCounts = facetCounts;
+	}
+	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
+		return null;
+	}
+	protected SiteUserGenPage facetCountsInit() {
+		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
+		if(facetCounts == null) {
+			_facetCounts(facetCountsWrap);
+			setFacetCounts(facetCountsWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
 	///////////////////
 	// siteUserCount //
 	///////////////////
@@ -131,10 +863,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer siteUserCount;
 
-	/**	<br/> The entity siteUserCount
+	/**	<br> The entity siteUserCount
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUserCount">Find the entity siteUserCount in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUserCount">Find the entity siteUserCount in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUserCount(Wrap<Integer> w);
@@ -164,16 +896,16 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
-	public static Integer staticSolrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSiteUserCount(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSolrStrSiteUserCount(siteRequest_, SiteUserGenPage.staticSolrSiteUserCount(siteRequest_, SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o)));
+	public static String staticSearchFqSiteUserCount(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrSiteUserCount(siteRequest_, SiteUserGenPage.staticSearchSiteUserCount(siteRequest_, SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o)));
 	}
 
 	///////////////
@@ -187,10 +919,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteUser siteUser_;
 
-	/**	<br/> The entity siteUser_
+	/**	<br> The entity siteUser_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUser_(Wrap<SiteUser> w);
@@ -226,10 +958,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br/> The entity pk
+	/**	<br> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -259,16 +991,65 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
-	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSolrStrPk(siteRequest_, SiteUserGenPage.staticSolrPk(siteRequest_, SiteUserGenPage.staticSetPk(siteRequest_, o)));
+	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrPk(siteRequest_, SiteUserGenPage.staticSearchPk(siteRequest_, SiteUserGenPage.staticSetPk(siteRequest_, o)));
+	}
+
+	////////
+	// id //
+	////////
+
+	/**	 The entity id
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String id;
+
+	/**	<br> The entity id
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _id(Wrap<String> w);
+
+	public String getId() {
+		return id;
+	}
+	public void setId(String o) {
+		this.id = SiteUserGenPage.staticSetId(siteRequest_, o);
+	}
+	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteUserGenPage idInit() {
+		Wrap<String> idWrap = new Wrap<String>().var("id");
+		if(id == null) {
+			_id(idWrap);
+			setId(idWrap.o);
+		}
+		return (SiteUserGenPage)this;
+	}
+
+	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSearchStrId(siteRequest_, SiteUserGenPage.staticSearchId(siteRequest_, SiteUserGenPage.staticSetId(siteRequest_, o)));
 	}
 
 	//////////////
@@ -301,10 +1082,25 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListSiteUser_Init();
+				pageResponseInit();
+				defaultZoneIdInit();
+				defaultTimeZoneInit();
+				defaultLocaleIdInit();
+				defaultLocaleInit();
+				defaultRangeGapInit();
+				defaultRangeEndInit();
+				defaultRangeStartInit();
+				defaultRangeVarInit();
+				defaultFacetSortInit();
+				defaultFacetLimitInit();
+				defaultFacetMinCountInit();
+				defaultPivotMinCountInit();
 				listSiteUserInit();
+				facetCountsInit();
 				siteUserCountInit();
 				siteUser_Init();
 				pkInit();
+				idInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -360,14 +1156,44 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		switch(var) {
 			case "searchListSiteUser_":
 				return oSiteUserGenPage.searchListSiteUser_;
+			case "pageResponse":
+				return oSiteUserGenPage.pageResponse;
+			case "defaultZoneId":
+				return oSiteUserGenPage.defaultZoneId;
+			case "defaultTimeZone":
+				return oSiteUserGenPage.defaultTimeZone;
+			case "defaultLocaleId":
+				return oSiteUserGenPage.defaultLocaleId;
+			case "defaultLocale":
+				return oSiteUserGenPage.defaultLocale;
+			case "defaultRangeGap":
+				return oSiteUserGenPage.defaultRangeGap;
+			case "defaultRangeEnd":
+				return oSiteUserGenPage.defaultRangeEnd;
+			case "defaultRangeStart":
+				return oSiteUserGenPage.defaultRangeStart;
+			case "defaultRangeVar":
+				return oSiteUserGenPage.defaultRangeVar;
+			case "defaultFacetSort":
+				return oSiteUserGenPage.defaultFacetSort;
+			case "defaultFacetLimit":
+				return oSiteUserGenPage.defaultFacetLimit;
+			case "defaultFacetMinCount":
+				return oSiteUserGenPage.defaultFacetMinCount;
+			case "defaultPivotMinCount":
+				return oSiteUserGenPage.defaultPivotMinCount;
 			case "listSiteUser":
 				return oSiteUserGenPage.listSiteUser;
+			case "facetCounts":
+				return oSiteUserGenPage.facetCounts;
 			case "siteUserCount":
 				return oSiteUserGenPage.siteUserCount;
 			case "siteUser_":
 				return oSiteUserGenPage.siteUser_;
 			case "pk":
 				return oSiteUserGenPage.pk;
+			case "id":
+				return oSiteUserGenPage.id;
 			default:
 				return super.obtainBaseModelPage(var);
 		}
@@ -407,105 +1233,162 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	}
 	public static Object staticSetSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return SiteUserGenPage.staticSetPageResponse(siteRequest_, o);
+		case "defaultZoneId":
+			return SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o);
+		case "defaultLocaleId":
+			return SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o);
+		case "defaultRangeGap":
+			return SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o);
+		case "defaultRangeEnd":
+			return SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
+		case "defaultRangeStart":
+			return SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o);
+		case "defaultRangeVar":
+			return SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o);
+		case "defaultFacetSort":
+			return SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o);
+		case "defaultFacetLimit":
+			return SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
+		case "defaultFacetMinCount":
+			return SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
+		case "defaultPivotMinCount":
+			return SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
 		case "siteUserCount":
 			return SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o);
 		case "pk":
 			return SiteUserGenPage.staticSetPk(siteRequest_, o);
+		case "id":
+			return SiteUserGenPage.staticSetId(siteRequest_, o);
 			default:
 				return BaseModelPage.staticSetBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return SiteUserGenPage.staticSearchPageResponse(siteRequest_, (String)o);
+		case "defaultZoneId":
+			return SiteUserGenPage.staticSearchDefaultZoneId(siteRequest_, (String)o);
+		case "defaultLocaleId":
+			return SiteUserGenPage.staticSearchDefaultLocaleId(siteRequest_, (String)o);
+		case "defaultRangeGap":
+			return SiteUserGenPage.staticSearchDefaultRangeGap(siteRequest_, (String)o);
+		case "defaultRangeEnd":
+			return SiteUserGenPage.staticSearchDefaultRangeEnd(siteRequest_, (ZonedDateTime)o);
+		case "defaultRangeStart":
+			return SiteUserGenPage.staticSearchDefaultRangeStart(siteRequest_, (ZonedDateTime)o);
+		case "defaultRangeVar":
+			return SiteUserGenPage.staticSearchDefaultRangeVar(siteRequest_, (String)o);
+		case "defaultFacetSort":
+			return SiteUserGenPage.staticSearchDefaultFacetSort(siteRequest_, (String)o);
+		case "defaultFacetLimit":
+			return SiteUserGenPage.staticSearchDefaultFacetLimit(siteRequest_, (Integer)o);
+		case "defaultFacetMinCount":
+			return SiteUserGenPage.staticSearchDefaultFacetMinCount(siteRequest_, (Integer)o);
+		case "defaultPivotMinCount":
+			return SiteUserGenPage.staticSearchDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSolrSiteUserCount(siteRequest_, (Integer)o);
+			return SiteUserGenPage.staticSearchSiteUserCount(siteRequest_, (Integer)o);
 		case "pk":
-			return SiteUserGenPage.staticSolrPk(siteRequest_, (Long)o);
+			return SiteUserGenPage.staticSearchPk(siteRequest_, (Long)o);
+		case "id":
+			return SiteUserGenPage.staticSearchId(siteRequest_, (String)o);
 			default:
-				return BaseModelPage.staticSolrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSearchBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return SiteUserGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
+		case "defaultZoneId":
+			return SiteUserGenPage.staticSearchStrDefaultZoneId(siteRequest_, (String)o);
+		case "defaultLocaleId":
+			return SiteUserGenPage.staticSearchStrDefaultLocaleId(siteRequest_, (String)o);
+		case "defaultRangeGap":
+			return SiteUserGenPage.staticSearchStrDefaultRangeGap(siteRequest_, (String)o);
+		case "defaultRangeEnd":
+			return SiteUserGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, (Date)o);
+		case "defaultRangeStart":
+			return SiteUserGenPage.staticSearchStrDefaultRangeStart(siteRequest_, (Date)o);
+		case "defaultRangeVar":
+			return SiteUserGenPage.staticSearchStrDefaultRangeVar(siteRequest_, (String)o);
+		case "defaultFacetSort":
+			return SiteUserGenPage.staticSearchStrDefaultFacetSort(siteRequest_, (String)o);
+		case "defaultFacetLimit":
+			return SiteUserGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, (Integer)o);
+		case "defaultFacetMinCount":
+			return SiteUserGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, (Integer)o);
+		case "defaultPivotMinCount":
+			return SiteUserGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSolrStrSiteUserCount(siteRequest_, (Integer)o);
+			return SiteUserGenPage.staticSearchStrSiteUserCount(siteRequest_, (Integer)o);
 		case "pk":
-			return SiteUserGenPage.staticSolrStrPk(siteRequest_, (Long)o);
+			return SiteUserGenPage.staticSearchStrPk(siteRequest_, (Long)o);
+		case "id":
+			return SiteUserGenPage.staticSearchStrId(siteRequest_, (String)o);
 			default:
-				return BaseModelPage.staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+		case "pageResponse":
+			return SiteUserGenPage.staticSearchFqPageResponse(siteRequest_, o);
+		case "defaultZoneId":
+			return SiteUserGenPage.staticSearchFqDefaultZoneId(siteRequest_, o);
+		case "defaultLocaleId":
+			return SiteUserGenPage.staticSearchFqDefaultLocaleId(siteRequest_, o);
+		case "defaultRangeGap":
+			return SiteUserGenPage.staticSearchFqDefaultRangeGap(siteRequest_, o);
+		case "defaultRangeEnd":
+			return SiteUserGenPage.staticSearchFqDefaultRangeEnd(siteRequest_, o);
+		case "defaultRangeStart":
+			return SiteUserGenPage.staticSearchFqDefaultRangeStart(siteRequest_, o);
+		case "defaultRangeVar":
+			return SiteUserGenPage.staticSearchFqDefaultRangeVar(siteRequest_, o);
+		case "defaultFacetSort":
+			return SiteUserGenPage.staticSearchFqDefaultFacetSort(siteRequest_, o);
+		case "defaultFacetLimit":
+			return SiteUserGenPage.staticSearchFqDefaultFacetLimit(siteRequest_, o);
+		case "defaultFacetMinCount":
+			return SiteUserGenPage.staticSearchFqDefaultFacetMinCount(siteRequest_, o);
+		case "defaultPivotMinCount":
+			return SiteUserGenPage.staticSearchFqDefaultPivotMinCount(siteRequest_, o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSolrFqSiteUserCount(siteRequest_, o);
+			return SiteUserGenPage.staticSearchFqSiteUserCount(siteRequest_, o);
 		case "pk":
-			return SiteUserGenPage.staticSolrFqPk(siteRequest_, o);
+			return SiteUserGenPage.staticSearchFqPk(siteRequest_, o);
+		case "id":
+			return SiteUserGenPage.staticSearchFqId(siteRequest_, o);
 			default:
-				return BaseModelPage.staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineSiteUserGenPage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineSiteUserGenPage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.defineBaseModelPage(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestSiteUserGenPage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof SiteUserGenPage) {
-			SiteUserGenPage original = (SiteUserGenPage)o;
-			super.apiRequestBaseModelPage();
+				return BaseModelPage.staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -520,8 +1403,94 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	}
 
 	public static final String VAR_searchListSiteUser_ = "searchListSiteUser_";
+	public static final String VAR_pageResponse = "pageResponse";
+	public static final String VAR_defaultZoneId = "defaultZoneId";
+	public static final String VAR_defaultTimeZone = "defaultTimeZone";
+	public static final String VAR_defaultLocaleId = "defaultLocaleId";
+	public static final String VAR_defaultLocale = "defaultLocale";
+	public static final String VAR_defaultRangeGap = "defaultRangeGap";
+	public static final String VAR_defaultRangeEnd = "defaultRangeEnd";
+	public static final String VAR_defaultRangeStart = "defaultRangeStart";
+	public static final String VAR_defaultRangeVar = "defaultRangeVar";
+	public static final String VAR_defaultFacetSort = "defaultFacetSort";
+	public static final String VAR_defaultFacetLimit = "defaultFacetLimit";
+	public static final String VAR_defaultFacetMinCount = "defaultFacetMinCount";
+	public static final String VAR_defaultPivotMinCount = "defaultPivotMinCount";
 	public static final String VAR_listSiteUser = "listSiteUser";
+	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_siteUserCount = "siteUserCount";
 	public static final String VAR_siteUser_ = "siteUser_";
 	public static final String VAR_pk = "pk";
+	public static final String VAR_id = "id";
+
+	public static final String DISPLAY_NAME_searchListSiteUser_ = "";
+	public static final String DISPLAY_NAME_pageResponse = "";
+	public static final String DISPLAY_NAME_defaultZoneId = "";
+	public static final String DISPLAY_NAME_defaultTimeZone = "";
+	public static final String DISPLAY_NAME_defaultLocaleId = "";
+	public static final String DISPLAY_NAME_defaultLocale = "";
+	public static final String DISPLAY_NAME_defaultRangeGap = "";
+	public static final String DISPLAY_NAME_defaultRangeEnd = "";
+	public static final String DISPLAY_NAME_defaultRangeStart = "";
+	public static final String DISPLAY_NAME_defaultRangeVar = "";
+	public static final String DISPLAY_NAME_defaultFacetSort = "";
+	public static final String DISPLAY_NAME_defaultFacetLimit = "";
+	public static final String DISPLAY_NAME_defaultFacetMinCount = "";
+	public static final String DISPLAY_NAME_defaultPivotMinCount = "";
+	public static final String DISPLAY_NAME_listSiteUser = "";
+	public static final String DISPLAY_NAME_facetCounts = "";
+	public static final String DISPLAY_NAME_siteUserCount = "";
+	public static final String DISPLAY_NAME_siteUser_ = "";
+	public static final String DISPLAY_NAME_pk = "";
+	public static final String DISPLAY_NAME_id = "";
+
+	public static String displayNameForClass(String var) {
+		return SiteUserGenPage.displayNameSiteUserGenPage(var);
+	}
+	public static String displayNameSiteUserGenPage(String var) {
+		switch(var) {
+		case VAR_searchListSiteUser_:
+			return DISPLAY_NAME_searchListSiteUser_;
+		case VAR_pageResponse:
+			return DISPLAY_NAME_pageResponse;
+		case VAR_defaultZoneId:
+			return DISPLAY_NAME_defaultZoneId;
+		case VAR_defaultTimeZone:
+			return DISPLAY_NAME_defaultTimeZone;
+		case VAR_defaultLocaleId:
+			return DISPLAY_NAME_defaultLocaleId;
+		case VAR_defaultLocale:
+			return DISPLAY_NAME_defaultLocale;
+		case VAR_defaultRangeGap:
+			return DISPLAY_NAME_defaultRangeGap;
+		case VAR_defaultRangeEnd:
+			return DISPLAY_NAME_defaultRangeEnd;
+		case VAR_defaultRangeStart:
+			return DISPLAY_NAME_defaultRangeStart;
+		case VAR_defaultRangeVar:
+			return DISPLAY_NAME_defaultRangeVar;
+		case VAR_defaultFacetSort:
+			return DISPLAY_NAME_defaultFacetSort;
+		case VAR_defaultFacetLimit:
+			return DISPLAY_NAME_defaultFacetLimit;
+		case VAR_defaultFacetMinCount:
+			return DISPLAY_NAME_defaultFacetMinCount;
+		case VAR_defaultPivotMinCount:
+			return DISPLAY_NAME_defaultPivotMinCount;
+		case VAR_listSiteUser:
+			return DISPLAY_NAME_listSiteUser;
+		case VAR_facetCounts:
+			return DISPLAY_NAME_facetCounts;
+		case VAR_siteUserCount:
+			return DISPLAY_NAME_siteUserCount;
+		case VAR_siteUser_:
+			return DISPLAY_NAME_siteUser_;
+		case VAR_pk:
+			return DISPLAY_NAME_pk;
+		case VAR_id:
+			return DISPLAY_NAME_id;
+		default:
+			return BaseModelPage.displayNameBaseModelPage(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserGenPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserGenPageGen.java
@@ -1,66 +1,49 @@
 package org.curriki.api.enus.model.user;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import org.curriki.api.enus.model.base.BaseModelPage;
-import org.computate.vertx.search.list.SearchList;
-import org.curriki.api.enus.model.user.SiteUser;
-import java.lang.String;
-import java.time.ZoneId;
-import java.util.Locale;
-import java.time.ZonedDateTime;
-import java.time.ZoneOffset;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-import java.time.format.DateTimeFormatter;
-import java.time.Instant;
-import java.time.OffsetDateTime;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
-import io.vertx.core.json.JsonArray;
-import org.computate.search.response.solr.SolrResponse.FacetCounts;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
 import java.lang.Long;
-import org.computate.search.wrap.Wrap;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import java.math.RoundingMode;
+import org.curriki.api.enus.search.SearchList;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
+import org.curriki.api.enus.user.SiteUser;
 import io.vertx.core.Future;
+import java.util.Objects;
+import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import org.curriki.api.enus.base.BaseModelPage;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage">Find the class SiteUserGenPage in Solr. </a>
- * <br><br>Delete the class SiteUserGenPage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.user in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.user&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUserGenPage.class);
@@ -76,10 +59,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SearchList<SiteUser> searchListSiteUser_;
 
-	/**	<br> The entity searchListSiteUser_
+	/**	<br/> The entity searchListSiteUser_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:searchListSiteUser_">Find the entity searchListSiteUser_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:searchListSiteUser_">Find the entity searchListSiteUser_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _searchListSiteUser_(Wrap<SearchList<SiteUser>> w);
@@ -104,703 +87,20 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	}
 
 	//////////////////
-	// pageResponse //
-	//////////////////
-
-	/**	 The entity pageResponse
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String pageResponse;
-
-	/**	<br> The entity pageResponse
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:pageResponse">Find the entity pageResponse in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _pageResponse(Wrap<String> w);
-
-	public String getPageResponse() {
-		return pageResponse;
-	}
-	public void setPageResponse(String o) {
-		this.pageResponse = SiteUserGenPage.staticSetPageResponse(siteRequest_, o);
-	}
-	public static String staticSetPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage pageResponseInit() {
-		Wrap<String> pageResponseWrap = new Wrap<String>().var("pageResponse");
-		if(pageResponse == null) {
-			_pageResponse(pageResponseWrap);
-			setPageResponse(pageResponseWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqPageResponse(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrPageResponse(siteRequest_, SiteUserGenPage.staticSearchPageResponse(siteRequest_, SiteUserGenPage.staticSetPageResponse(siteRequest_, o)));
-	}
-
-	///////////////////
-	// defaultZoneId //
-	///////////////////
-
-	/**	 The entity defaultZoneId
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultZoneId;
-
-	/**	<br> The entity defaultZoneId
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultZoneId">Find the entity defaultZoneId in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultZoneId(Wrap<String> w);
-
-	public String getDefaultZoneId() {
-		return defaultZoneId;
-	}
-	public void setDefaultZoneId(String o) {
-		this.defaultZoneId = SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o);
-	}
-	public static String staticSetDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage defaultZoneIdInit() {
-		Wrap<String> defaultZoneIdWrap = new Wrap<String>().var("defaultZoneId");
-		if(defaultZoneId == null) {
-			_defaultZoneId(defaultZoneIdWrap);
-			setDefaultZoneId(defaultZoneIdWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultZoneId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultZoneId(siteRequest_, SiteUserGenPage.staticSearchDefaultZoneId(siteRequest_, SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultTimeZone //
-	/////////////////////
-
-	/**	 The entity defaultTimeZone
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonIgnore
-	@JsonInclude(Include.NON_NULL)
-	protected ZoneId defaultTimeZone;
-
-	/**	<br> The entity defaultTimeZone
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultTimeZone">Find the entity defaultTimeZone in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultTimeZone(Wrap<ZoneId> w);
-
-	public ZoneId getDefaultTimeZone() {
-		return defaultTimeZone;
-	}
-
-	public void setDefaultTimeZone(ZoneId defaultTimeZone) {
-		this.defaultTimeZone = defaultTimeZone;
-	}
-	public static ZoneId staticSetDefaultTimeZone(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected SiteUserGenPage defaultTimeZoneInit() {
-		Wrap<ZoneId> defaultTimeZoneWrap = new Wrap<ZoneId>().var("defaultTimeZone");
-		if(defaultTimeZone == null) {
-			_defaultTimeZone(defaultTimeZoneWrap);
-			setDefaultTimeZone(defaultTimeZoneWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	/////////////////////
-	// defaultLocaleId //
-	/////////////////////
-
-	/**	 The entity defaultLocaleId
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultLocaleId;
-
-	/**	<br> The entity defaultLocaleId
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultLocaleId">Find the entity defaultLocaleId in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultLocaleId(Wrap<String> w);
-
-	public String getDefaultLocaleId() {
-		return defaultLocaleId;
-	}
-	public void setDefaultLocaleId(String o) {
-		this.defaultLocaleId = SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o);
-	}
-	public static String staticSetDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage defaultLocaleIdInit() {
-		Wrap<String> defaultLocaleIdWrap = new Wrap<String>().var("defaultLocaleId");
-		if(defaultLocaleId == null) {
-			_defaultLocaleId(defaultLocaleIdWrap);
-			setDefaultLocaleId(defaultLocaleIdWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultLocaleId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultLocaleId(siteRequest_, SiteUserGenPage.staticSearchDefaultLocaleId(siteRequest_, SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o)));
-	}
-
-	///////////////////
-	// defaultLocale //
-	///////////////////
-
-	/**	 The entity defaultLocale
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonIgnore
-	@JsonInclude(Include.NON_NULL)
-	protected Locale defaultLocale;
-
-	/**	<br> The entity defaultLocale
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultLocale">Find the entity defaultLocale in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultLocale(Wrap<Locale> w);
-
-	public Locale getDefaultLocale() {
-		return defaultLocale;
-	}
-
-	public void setDefaultLocale(Locale defaultLocale) {
-		this.defaultLocale = defaultLocale;
-	}
-	public static Locale staticSetDefaultLocale(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected SiteUserGenPage defaultLocaleInit() {
-		Wrap<Locale> defaultLocaleWrap = new Wrap<Locale>().var("defaultLocale");
-		if(defaultLocale == null) {
-			_defaultLocale(defaultLocaleWrap);
-			setDefaultLocale(defaultLocaleWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	/////////////////////
-	// defaultRangeGap //
-	/////////////////////
-
-	/**	 The entity defaultRangeGap
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultRangeGap;
-
-	/**	<br> The entity defaultRangeGap
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeGap">Find the entity defaultRangeGap in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeGap(Wrap<String> w);
-
-	public String getDefaultRangeGap() {
-		return defaultRangeGap;
-	}
-	public void setDefaultRangeGap(String o) {
-		this.defaultRangeGap = SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o);
-	}
-	public static String staticSetDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage defaultRangeGapInit() {
-		Wrap<String> defaultRangeGapWrap = new Wrap<String>().var("defaultRangeGap");
-		if(defaultRangeGap == null) {
-			_defaultRangeGap(defaultRangeGapWrap);
-			setDefaultRangeGap(defaultRangeGapWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultRangeGap(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultRangeGap(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeGap(siteRequest_, SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultRangeEnd //
-	/////////////////////
-
-	/**	 The entity defaultRangeEnd
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
-	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
-	@JsonInclude(Include.NON_NULL)
-	protected ZonedDateTime defaultRangeEnd;
-
-	/**	<br> The entity defaultRangeEnd
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeEnd">Find the entity defaultRangeEnd in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeEnd(Wrap<ZonedDateTime> w);
-
-	public ZonedDateTime getDefaultRangeEnd() {
-		return defaultRangeEnd;
-	}
-
-	public void setDefaultRangeEnd(ZonedDateTime defaultRangeEnd) {
-		this.defaultRangeEnd = defaultRangeEnd;
-	}
-	@JsonIgnore
-	public void setDefaultRangeEnd(Instant o) {
-		this.defaultRangeEnd = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
-	}
-	/** Example: 2011-12-03T10:15:30+01:00 **/
-	@JsonIgnore
-	public void setDefaultRangeEnd(String o) {
-		this.defaultRangeEnd = SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
-	}
-	public static ZonedDateTime staticSetDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
-		if(StringUtils.endsWith(o, "Z"))
-			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-		else
-			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
-	}
-	@JsonIgnore
-	public void setDefaultRangeEnd(Date o) {
-		this.defaultRangeEnd = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-	}
-	protected SiteUserGenPage defaultRangeEndInit() {
-		Wrap<ZonedDateTime> defaultRangeEndWrap = new Wrap<ZonedDateTime>().var("defaultRangeEnd");
-		if(defaultRangeEnd == null) {
-			_defaultRangeEnd(defaultRangeEndWrap);
-			setDefaultRangeEnd(defaultRangeEndWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static Date staticSearchDefaultRangeEnd(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
-		return o == null ? null : Date.from(o.toInstant());
-	}
-
-	public static String staticSearchStrDefaultRangeEnd(SiteRequestEnUS siteRequest_, Date o) {
-		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
-	}
-
-	public static String staticSearchFqDefaultRangeEnd(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeEnd(siteRequest_, SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o)));
-	}
-
-	///////////////////////
-	// defaultRangeStart //
-	///////////////////////
-
-	/**	 The entity defaultRangeStart
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonDeserialize(using = ComputateZonedDateTimeDeserializer.class)
-	@JsonSerialize(using = ComputateZonedDateTimeSerializer.class)
-	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd'T'HH:mm:ss.SSSV'['VV']'")
-	@JsonInclude(Include.NON_NULL)
-	protected ZonedDateTime defaultRangeStart;
-
-	/**	<br> The entity defaultRangeStart
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeStart">Find the entity defaultRangeStart in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeStart(Wrap<ZonedDateTime> w);
-
-	public ZonedDateTime getDefaultRangeStart() {
-		return defaultRangeStart;
-	}
-
-	public void setDefaultRangeStart(ZonedDateTime defaultRangeStart) {
-		this.defaultRangeStart = defaultRangeStart;
-	}
-	@JsonIgnore
-	public void setDefaultRangeStart(Instant o) {
-		this.defaultRangeStart = o == null ? null : ZonedDateTime.from(o).truncatedTo(ChronoUnit.MILLIS);
-	}
-	/** Example: 2011-12-03T10:15:30+01:00 **/
-	@JsonIgnore
-	public void setDefaultRangeStart(String o) {
-		this.defaultRangeStart = SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o);
-	}
-	public static ZonedDateTime staticSetDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
-		if(StringUtils.endsWith(o, "]"))
-			return o == null ? null : ZonedDateTime.parse(o, ComputateZonedDateTimeSerializer.ZONED_DATE_TIME_FORMATTER);
-		if(StringUtils.endsWith(o, "Z"))
-			return o == null ? null : Instant.parse(o).atZone(ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-		else
-			return o == null ? null : ZonedDateTime.parse(o, DateTimeFormatter.ISO_DATE_TIME).truncatedTo(ChronoUnit.MILLIS);
-	}
-	@JsonIgnore
-	public void setDefaultRangeStart(Date o) {
-		this.defaultRangeStart = o == null ? null : ZonedDateTime.ofInstant(o.toInstant(), ZoneId.of(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE))).truncatedTo(ChronoUnit.MILLIS);
-	}
-	protected SiteUserGenPage defaultRangeStartInit() {
-		Wrap<ZonedDateTime> defaultRangeStartWrap = new Wrap<ZonedDateTime>().var("defaultRangeStart");
-		if(defaultRangeStart == null) {
-			_defaultRangeStart(defaultRangeStartWrap);
-			setDefaultRangeStart(defaultRangeStartWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static Date staticSearchDefaultRangeStart(SiteRequestEnUS siteRequest_, ZonedDateTime o) {
-		return o == null ? null : Date.from(o.toInstant());
-	}
-
-	public static String staticSearchStrDefaultRangeStart(SiteRequestEnUS siteRequest_, Date o) {
-		return "\"" + DateTimeFormatter.ISO_DATE_TIME.format(o.toInstant().atOffset(ZoneOffset.UTC)) + "\"";
-	}
-
-	public static String staticSearchFqDefaultRangeStart(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultRangeStart(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeStart(siteRequest_, SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o)));
-	}
-
-	/////////////////////
-	// defaultRangeVar //
-	/////////////////////
-
-	/**	 The entity defaultRangeVar
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultRangeVar;
-
-	/**	<br> The entity defaultRangeVar
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultRangeVar">Find the entity defaultRangeVar in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultRangeVar(Wrap<String> w);
-
-	public String getDefaultRangeVar() {
-		return defaultRangeVar;
-	}
-	public void setDefaultRangeVar(String o) {
-		this.defaultRangeVar = SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o);
-	}
-	public static String staticSetDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage defaultRangeVarInit() {
-		Wrap<String> defaultRangeVarWrap = new Wrap<String>().var("defaultRangeVar");
-		if(defaultRangeVar == null) {
-			_defaultRangeVar(defaultRangeVarWrap);
-			setDefaultRangeVar(defaultRangeVarWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultRangeVar(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultRangeVar(siteRequest_, SiteUserGenPage.staticSearchDefaultRangeVar(siteRequest_, SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o)));
-	}
-
-	//////////////////////
-	// defaultFacetSort //
-	//////////////////////
-
-	/**	 The entity defaultFacetSort
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String defaultFacetSort;
-
-	/**	<br> The entity defaultFacetSort
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetSort">Find the entity defaultFacetSort in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetSort(Wrap<String> w);
-
-	public String getDefaultFacetSort() {
-		return defaultFacetSort;
-	}
-	public void setDefaultFacetSort(String o) {
-		this.defaultFacetSort = SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o);
-	}
-	public static String staticSetDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage defaultFacetSortInit() {
-		Wrap<String> defaultFacetSortWrap = new Wrap<String>().var("defaultFacetSort");
-		if(defaultFacetSort == null) {
-			_defaultFacetSort(defaultFacetSortWrap);
-			setDefaultFacetSort(defaultFacetSortWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetSort(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultFacetSort(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetSort(siteRequest_, SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o)));
-	}
-
-	///////////////////////
-	// defaultFacetLimit //
-	///////////////////////
-
-	/**	 The entity defaultFacetLimit
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultFacetLimit;
-
-	/**	<br> The entity defaultFacetLimit
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetLimit">Find the entity defaultFacetLimit in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetLimit(Wrap<Integer> w);
-
-	public Integer getDefaultFacetLimit() {
-		return defaultFacetLimit;
-	}
-
-	public void setDefaultFacetLimit(Integer defaultFacetLimit) {
-		this.defaultFacetLimit = defaultFacetLimit;
-	}
-	@JsonIgnore
-	public void setDefaultFacetLimit(String o) {
-		this.defaultFacetLimit = SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected SiteUserGenPage defaultFacetLimitInit() {
-		Wrap<Integer> defaultFacetLimitWrap = new Wrap<Integer>().var("defaultFacetLimit");
-		if(defaultFacetLimit == null) {
-			_defaultFacetLimit(defaultFacetLimitWrap);
-			setDefaultFacetLimit(defaultFacetLimitWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetLimit(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetLimit(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetLimit(siteRequest_, SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o)));
-	}
-
-	//////////////////////////
-	// defaultFacetMinCount //
-	//////////////////////////
-
-	/**	 The entity defaultFacetMinCount
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultFacetMinCount;
-
-	/**	<br> The entity defaultFacetMinCount
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultFacetMinCount">Find the entity defaultFacetMinCount in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultFacetMinCount(Wrap<Integer> w);
-
-	public Integer getDefaultFacetMinCount() {
-		return defaultFacetMinCount;
-	}
-
-	public void setDefaultFacetMinCount(Integer defaultFacetMinCount) {
-		this.defaultFacetMinCount = defaultFacetMinCount;
-	}
-	@JsonIgnore
-	public void setDefaultFacetMinCount(String o) {
-		this.defaultFacetMinCount = SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected SiteUserGenPage defaultFacetMinCountInit() {
-		Wrap<Integer> defaultFacetMinCountWrap = new Wrap<Integer>().var("defaultFacetMinCount");
-		if(defaultFacetMinCount == null) {
-			_defaultFacetMinCount(defaultFacetMinCountWrap);
-			setDefaultFacetMinCount(defaultFacetMinCountWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultFacetMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultFacetMinCount(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, SiteUserGenPage.staticSearchDefaultFacetMinCount(siteRequest_, SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o)));
-	}
-
-	//////////////////////////
-	// defaultPivotMinCount //
-	//////////////////////////
-
-	/**	 The entity defaultPivotMinCount
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonSerialize(using = ToStringSerializer.class)
-	@JsonInclude(Include.NON_NULL)
-	protected Integer defaultPivotMinCount;
-
-	/**	<br> The entity defaultPivotMinCount
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:defaultPivotMinCount">Find the entity defaultPivotMinCount in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _defaultPivotMinCount(Wrap<Integer> w);
-
-	public Integer getDefaultPivotMinCount() {
-		return defaultPivotMinCount;
-	}
-
-	public void setDefaultPivotMinCount(Integer defaultPivotMinCount) {
-		this.defaultPivotMinCount = defaultPivotMinCount;
-	}
-	@JsonIgnore
-	public void setDefaultPivotMinCount(String o) {
-		this.defaultPivotMinCount = SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
-	}
-	public static Integer staticSetDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
-		if(NumberUtils.isParsable(o))
-			return Integer.parseInt(o);
-		return null;
-	}
-	protected SiteUserGenPage defaultPivotMinCountInit() {
-		Wrap<Integer> defaultPivotMinCountWrap = new Wrap<Integer>().var("defaultPivotMinCount");
-		if(defaultPivotMinCount == null) {
-			_defaultPivotMinCount(defaultPivotMinCountWrap);
-			setDefaultPivotMinCount(defaultPivotMinCountWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static Integer staticSearchDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o;
-	}
-
-	public static String staticSearchStrDefaultPivotMinCount(SiteRequestEnUS siteRequest_, Integer o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqDefaultPivotMinCount(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, SiteUserGenPage.staticSearchDefaultPivotMinCount(siteRequest_, SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o)));
-	}
-
-	//////////////////
 	// listSiteUser //
 	//////////////////
 
 	/**	 The entity listSiteUser
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonArray(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonArray listSiteUser = new JsonArray();
 
-	/**	<br> The entity listSiteUser
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:listSiteUser">Find the entity listSiteUser in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity listSiteUser
+	 *  It is constructed before being initialized with the constructor by default JsonArray(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:listSiteUser">Find the entity listSiteUser in Solr</a>
+	 * <br/>
+	 * @param listSiteUser is the entity already constructed. 
 	 **/
 	protected abstract void _listSiteUser(JsonArray l);
 
@@ -819,44 +119,6 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
-	/////////////////
-	// facetCounts //
-	/////////////////
-
-	/**	 The entity facetCounts
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected FacetCounts facetCounts;
-
-	/**	<br> The entity facetCounts
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:facetCounts">Find the entity facetCounts in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _facetCounts(Wrap<FacetCounts> w);
-
-	public FacetCounts getFacetCounts() {
-		return facetCounts;
-	}
-
-	public void setFacetCounts(FacetCounts facetCounts) {
-		this.facetCounts = facetCounts;
-	}
-	public static FacetCounts staticSetFacetCounts(SiteRequestEnUS siteRequest_, String o) {
-		return null;
-	}
-	protected SiteUserGenPage facetCountsInit() {
-		Wrap<FacetCounts> facetCountsWrap = new Wrap<FacetCounts>().var("facetCounts");
-		if(facetCounts == null) {
-			_facetCounts(facetCountsWrap);
-			setFacetCounts(facetCountsWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
 	///////////////////
 	// siteUserCount //
 	///////////////////
@@ -869,10 +131,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer siteUserCount;
 
-	/**	<br> The entity siteUserCount
+	/**	<br/> The entity siteUserCount
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:siteUserCount">Find the entity siteUserCount in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUserCount">Find the entity siteUserCount in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUserCount(Wrap<Integer> w);
@@ -902,16 +164,16 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
-	public static Integer staticSearchSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrSiteUserCount(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSiteUserCount(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrSiteUserCount(siteRequest_, SiteUserGenPage.staticSearchSiteUserCount(siteRequest_, SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o)));
+	public static String staticSolrFqSiteUserCount(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSolrStrSiteUserCount(siteRequest_, SiteUserGenPage.staticSolrSiteUserCount(siteRequest_, SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o)));
 	}
 
 	///////////////
@@ -925,10 +187,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteUser siteUser_;
 
-	/**	<br> The entity siteUser_
+	/**	<br/> The entity siteUser_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUser_(Wrap<SiteUser> w);
@@ -964,10 +226,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	@JsonInclude(Include.NON_NULL)
 	protected Long pk;
 
-	/**	<br> The entity pk
+	/**	<br/> The entity pk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pk">Find the entity pk in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pk(Wrap<Long> w);
@@ -997,65 +259,16 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return (SiteUserGenPage)this;
 	}
 
-	public static Long staticSearchPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPk(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrPk(siteRequest_, SiteUserGenPage.staticSearchPk(siteRequest_, SiteUserGenPage.staticSetPk(siteRequest_, o)));
-	}
-
-	////////
-	// id //
-	////////
-
-	/**	 The entity id
-	 *	 is defined as null before being initialized. 
-	 */
-	@JsonProperty
-	@JsonInclude(Include.NON_NULL)
-	protected String id;
-
-	/**	<br> The entity id
-	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserGenPage&fq=entiteVar_enUS_indexed_string:id">Find the entity id in Solr</a>
-	 * <br>
-	 * @param w is for wrapping a value to assign to this entity during initialization. 
-	 **/
-	protected abstract void _id(Wrap<String> w);
-
-	public String getId() {
-		return id;
-	}
-	public void setId(String o) {
-		this.id = SiteUserGenPage.staticSetId(siteRequest_, o);
-	}
-	public static String staticSetId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-	protected SiteUserGenPage idInit() {
-		Wrap<String> idWrap = new Wrap<String>().var("id");
-		if(id == null) {
-			_id(idWrap);
-			setId(idWrap.o);
-		}
-		return (SiteUserGenPage)this;
-	}
-
-	public static String staticSearchId(SiteRequestEnUS siteRequest_, String o) {
-		return o;
-	}
-
-	public static String staticSearchStrId(SiteRequestEnUS siteRequest_, String o) {
-		return o == null ? null : o.toString();
-	}
-
-	public static String staticSearchFqId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteUserGenPage.staticSearchStrId(siteRequest_, SiteUserGenPage.staticSearchId(siteRequest_, SiteUserGenPage.staticSetId(siteRequest_, o)));
+	public static String staticSolrFqPk(SiteRequestEnUS siteRequest_, String o) {
+		return SiteUserGenPage.staticSolrStrPk(siteRequest_, SiteUserGenPage.staticSolrPk(siteRequest_, SiteUserGenPage.staticSetPk(siteRequest_, o)));
 	}
 
 	//////////////
@@ -1088,25 +301,10 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 			Promise<Void> promise2 = Promise.promise();
 			try {
 				searchListSiteUser_Init();
-				pageResponseInit();
-				defaultZoneIdInit();
-				defaultTimeZoneInit();
-				defaultLocaleIdInit();
-				defaultLocaleInit();
-				defaultRangeGapInit();
-				defaultRangeEndInit();
-				defaultRangeStartInit();
-				defaultRangeVarInit();
-				defaultFacetSortInit();
-				defaultFacetLimitInit();
-				defaultFacetMinCountInit();
-				defaultPivotMinCountInit();
 				listSiteUserInit();
-				facetCountsInit();
 				siteUserCountInit();
 				siteUser_Init();
 				pkInit();
-				idInit();
 				promise2.complete();
 			} catch(Exception ex) {
 				promise2.fail(ex);
@@ -1162,44 +360,14 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		switch(var) {
 			case "searchListSiteUser_":
 				return oSiteUserGenPage.searchListSiteUser_;
-			case "pageResponse":
-				return oSiteUserGenPage.pageResponse;
-			case "defaultZoneId":
-				return oSiteUserGenPage.defaultZoneId;
-			case "defaultTimeZone":
-				return oSiteUserGenPage.defaultTimeZone;
-			case "defaultLocaleId":
-				return oSiteUserGenPage.defaultLocaleId;
-			case "defaultLocale":
-				return oSiteUserGenPage.defaultLocale;
-			case "defaultRangeGap":
-				return oSiteUserGenPage.defaultRangeGap;
-			case "defaultRangeEnd":
-				return oSiteUserGenPage.defaultRangeEnd;
-			case "defaultRangeStart":
-				return oSiteUserGenPage.defaultRangeStart;
-			case "defaultRangeVar":
-				return oSiteUserGenPage.defaultRangeVar;
-			case "defaultFacetSort":
-				return oSiteUserGenPage.defaultFacetSort;
-			case "defaultFacetLimit":
-				return oSiteUserGenPage.defaultFacetLimit;
-			case "defaultFacetMinCount":
-				return oSiteUserGenPage.defaultFacetMinCount;
-			case "defaultPivotMinCount":
-				return oSiteUserGenPage.defaultPivotMinCount;
 			case "listSiteUser":
 				return oSiteUserGenPage.listSiteUser;
-			case "facetCounts":
-				return oSiteUserGenPage.facetCounts;
 			case "siteUserCount":
 				return oSiteUserGenPage.siteUserCount;
 			case "siteUser_":
 				return oSiteUserGenPage.siteUser_;
 			case "pk":
 				return oSiteUserGenPage.pk;
-			case "id":
-				return oSiteUserGenPage.id;
 			default:
 				return super.obtainBaseModelPage(var);
 		}
@@ -1239,162 +407,105 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 	}
 	public static Object staticSetSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return SiteUserGenPage.staticSetPageResponse(siteRequest_, o);
-		case "defaultZoneId":
-			return SiteUserGenPage.staticSetDefaultZoneId(siteRequest_, o);
-		case "defaultLocaleId":
-			return SiteUserGenPage.staticSetDefaultLocaleId(siteRequest_, o);
-		case "defaultRangeGap":
-			return SiteUserGenPage.staticSetDefaultRangeGap(siteRequest_, o);
-		case "defaultRangeEnd":
-			return SiteUserGenPage.staticSetDefaultRangeEnd(siteRequest_, o);
-		case "defaultRangeStart":
-			return SiteUserGenPage.staticSetDefaultRangeStart(siteRequest_, o);
-		case "defaultRangeVar":
-			return SiteUserGenPage.staticSetDefaultRangeVar(siteRequest_, o);
-		case "defaultFacetSort":
-			return SiteUserGenPage.staticSetDefaultFacetSort(siteRequest_, o);
-		case "defaultFacetLimit":
-			return SiteUserGenPage.staticSetDefaultFacetLimit(siteRequest_, o);
-		case "defaultFacetMinCount":
-			return SiteUserGenPage.staticSetDefaultFacetMinCount(siteRequest_, o);
-		case "defaultPivotMinCount":
-			return SiteUserGenPage.staticSetDefaultPivotMinCount(siteRequest_, o);
 		case "siteUserCount":
 			return SiteUserGenPage.staticSetSiteUserCount(siteRequest_, o);
 		case "pk":
 			return SiteUserGenPage.staticSetPk(siteRequest_, o);
-		case "id":
-			return SiteUserGenPage.staticSetId(siteRequest_, o);
 			default:
 				return BaseModelPage.staticSetBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return SiteUserGenPage.staticSearchPageResponse(siteRequest_, (String)o);
-		case "defaultZoneId":
-			return SiteUserGenPage.staticSearchDefaultZoneId(siteRequest_, (String)o);
-		case "defaultLocaleId":
-			return SiteUserGenPage.staticSearchDefaultLocaleId(siteRequest_, (String)o);
-		case "defaultRangeGap":
-			return SiteUserGenPage.staticSearchDefaultRangeGap(siteRequest_, (String)o);
-		case "defaultRangeEnd":
-			return SiteUserGenPage.staticSearchDefaultRangeEnd(siteRequest_, (ZonedDateTime)o);
-		case "defaultRangeStart":
-			return SiteUserGenPage.staticSearchDefaultRangeStart(siteRequest_, (ZonedDateTime)o);
-		case "defaultRangeVar":
-			return SiteUserGenPage.staticSearchDefaultRangeVar(siteRequest_, (String)o);
-		case "defaultFacetSort":
-			return SiteUserGenPage.staticSearchDefaultFacetSort(siteRequest_, (String)o);
-		case "defaultFacetLimit":
-			return SiteUserGenPage.staticSearchDefaultFacetLimit(siteRequest_, (Integer)o);
-		case "defaultFacetMinCount":
-			return SiteUserGenPage.staticSearchDefaultFacetMinCount(siteRequest_, (Integer)o);
-		case "defaultPivotMinCount":
-			return SiteUserGenPage.staticSearchDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSearchSiteUserCount(siteRequest_, (Integer)o);
+			return SiteUserGenPage.staticSolrSiteUserCount(siteRequest_, (Integer)o);
 		case "pk":
-			return SiteUserGenPage.staticSearchPk(siteRequest_, (Long)o);
-		case "id":
-			return SiteUserGenPage.staticSearchId(siteRequest_, (String)o);
+			return SiteUserGenPage.staticSolrPk(siteRequest_, (Long)o);
 			default:
-				return BaseModelPage.staticSearchBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return SiteUserGenPage.staticSearchStrPageResponse(siteRequest_, (String)o);
-		case "defaultZoneId":
-			return SiteUserGenPage.staticSearchStrDefaultZoneId(siteRequest_, (String)o);
-		case "defaultLocaleId":
-			return SiteUserGenPage.staticSearchStrDefaultLocaleId(siteRequest_, (String)o);
-		case "defaultRangeGap":
-			return SiteUserGenPage.staticSearchStrDefaultRangeGap(siteRequest_, (String)o);
-		case "defaultRangeEnd":
-			return SiteUserGenPage.staticSearchStrDefaultRangeEnd(siteRequest_, (Date)o);
-		case "defaultRangeStart":
-			return SiteUserGenPage.staticSearchStrDefaultRangeStart(siteRequest_, (Date)o);
-		case "defaultRangeVar":
-			return SiteUserGenPage.staticSearchStrDefaultRangeVar(siteRequest_, (String)o);
-		case "defaultFacetSort":
-			return SiteUserGenPage.staticSearchStrDefaultFacetSort(siteRequest_, (String)o);
-		case "defaultFacetLimit":
-			return SiteUserGenPage.staticSearchStrDefaultFacetLimit(siteRequest_, (Integer)o);
-		case "defaultFacetMinCount":
-			return SiteUserGenPage.staticSearchStrDefaultFacetMinCount(siteRequest_, (Integer)o);
-		case "defaultPivotMinCount":
-			return SiteUserGenPage.staticSearchStrDefaultPivotMinCount(siteRequest_, (Integer)o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSearchStrSiteUserCount(siteRequest_, (Integer)o);
+			return SiteUserGenPage.staticSolrStrSiteUserCount(siteRequest_, (Integer)o);
 		case "pk":
-			return SiteUserGenPage.staticSearchStrPk(siteRequest_, (Long)o);
-		case "id":
-			return SiteUserGenPage.staticSearchStrId(siteRequest_, (String)o);
+			return SiteUserGenPage.staticSolrStrPk(siteRequest_, (Long)o);
 			default:
-				return BaseModelPage.staticSearchStrBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrStrBaseModelPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqSiteUserGenPage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqSiteUserGenPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqSiteUserGenPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-		case "pageResponse":
-			return SiteUserGenPage.staticSearchFqPageResponse(siteRequest_, o);
-		case "defaultZoneId":
-			return SiteUserGenPage.staticSearchFqDefaultZoneId(siteRequest_, o);
-		case "defaultLocaleId":
-			return SiteUserGenPage.staticSearchFqDefaultLocaleId(siteRequest_, o);
-		case "defaultRangeGap":
-			return SiteUserGenPage.staticSearchFqDefaultRangeGap(siteRequest_, o);
-		case "defaultRangeEnd":
-			return SiteUserGenPage.staticSearchFqDefaultRangeEnd(siteRequest_, o);
-		case "defaultRangeStart":
-			return SiteUserGenPage.staticSearchFqDefaultRangeStart(siteRequest_, o);
-		case "defaultRangeVar":
-			return SiteUserGenPage.staticSearchFqDefaultRangeVar(siteRequest_, o);
-		case "defaultFacetSort":
-			return SiteUserGenPage.staticSearchFqDefaultFacetSort(siteRequest_, o);
-		case "defaultFacetLimit":
-			return SiteUserGenPage.staticSearchFqDefaultFacetLimit(siteRequest_, o);
-		case "defaultFacetMinCount":
-			return SiteUserGenPage.staticSearchFqDefaultFacetMinCount(siteRequest_, o);
-		case "defaultPivotMinCount":
-			return SiteUserGenPage.staticSearchFqDefaultPivotMinCount(siteRequest_, o);
 		case "siteUserCount":
-			return SiteUserGenPage.staticSearchFqSiteUserCount(siteRequest_, o);
+			return SiteUserGenPage.staticSolrFqSiteUserCount(siteRequest_, o);
 		case "pk":
-			return SiteUserGenPage.staticSearchFqPk(siteRequest_, o);
-		case "id":
-			return SiteUserGenPage.staticSearchFqId(siteRequest_, o);
+			return SiteUserGenPage.staticSolrFqPk(siteRequest_, o);
 			default:
-				return BaseModelPage.staticSearchFqBaseModelPage(entityVar,  siteRequest_, o);
+				return BaseModelPage.staticSolrFqBaseModelPage(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineSiteUserGenPage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineSiteUserGenPage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.defineBaseModelPage(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestSiteUserGenPage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof SiteUserGenPage) {
+			SiteUserGenPage original = (SiteUserGenPage)o;
+			super.apiRequestBaseModelPage();
 		}
 	}
 
@@ -1408,96 +519,9 @@ public abstract class SiteUserGenPageGen<DEV> extends BaseModelPage {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "SiteUserGenPage";
 	public static final String VAR_searchListSiteUser_ = "searchListSiteUser_";
-	public static final String VAR_pageResponse = "pageResponse";
-	public static final String VAR_defaultZoneId = "defaultZoneId";
-	public static final String VAR_defaultTimeZone = "defaultTimeZone";
-	public static final String VAR_defaultLocaleId = "defaultLocaleId";
-	public static final String VAR_defaultLocale = "defaultLocale";
-	public static final String VAR_defaultRangeGap = "defaultRangeGap";
-	public static final String VAR_defaultRangeEnd = "defaultRangeEnd";
-	public static final String VAR_defaultRangeStart = "defaultRangeStart";
-	public static final String VAR_defaultRangeVar = "defaultRangeVar";
-	public static final String VAR_defaultFacetSort = "defaultFacetSort";
-	public static final String VAR_defaultFacetLimit = "defaultFacetLimit";
-	public static final String VAR_defaultFacetMinCount = "defaultFacetMinCount";
-	public static final String VAR_defaultPivotMinCount = "defaultPivotMinCount";
 	public static final String VAR_listSiteUser = "listSiteUser";
-	public static final String VAR_facetCounts = "facetCounts";
 	public static final String VAR_siteUserCount = "siteUserCount";
 	public static final String VAR_siteUser_ = "siteUser_";
 	public static final String VAR_pk = "pk";
-	public static final String VAR_id = "id";
-
-	public static final String DISPLAY_NAME_searchListSiteUser_ = "";
-	public static final String DISPLAY_NAME_pageResponse = "";
-	public static final String DISPLAY_NAME_defaultZoneId = "";
-	public static final String DISPLAY_NAME_defaultTimeZone = "";
-	public static final String DISPLAY_NAME_defaultLocaleId = "";
-	public static final String DISPLAY_NAME_defaultLocale = "";
-	public static final String DISPLAY_NAME_defaultRangeGap = "";
-	public static final String DISPLAY_NAME_defaultRangeEnd = "";
-	public static final String DISPLAY_NAME_defaultRangeStart = "";
-	public static final String DISPLAY_NAME_defaultRangeVar = "";
-	public static final String DISPLAY_NAME_defaultFacetSort = "";
-	public static final String DISPLAY_NAME_defaultFacetLimit = "";
-	public static final String DISPLAY_NAME_defaultFacetMinCount = "";
-	public static final String DISPLAY_NAME_defaultPivotMinCount = "";
-	public static final String DISPLAY_NAME_listSiteUser = "";
-	public static final String DISPLAY_NAME_facetCounts = "";
-	public static final String DISPLAY_NAME_siteUserCount = "";
-	public static final String DISPLAY_NAME_siteUser_ = "";
-	public static final String DISPLAY_NAME_pk = "";
-	public static final String DISPLAY_NAME_id = "";
-
-	public static String displayNameForClass(String var) {
-		return SiteUserGenPage.displayNameSiteUserGenPage(var);
-	}
-	public static String displayNameSiteUserGenPage(String var) {
-		switch(var) {
-		case VAR_searchListSiteUser_:
-			return DISPLAY_NAME_searchListSiteUser_;
-		case VAR_pageResponse:
-			return DISPLAY_NAME_pageResponse;
-		case VAR_defaultZoneId:
-			return DISPLAY_NAME_defaultZoneId;
-		case VAR_defaultTimeZone:
-			return DISPLAY_NAME_defaultTimeZone;
-		case VAR_defaultLocaleId:
-			return DISPLAY_NAME_defaultLocaleId;
-		case VAR_defaultLocale:
-			return DISPLAY_NAME_defaultLocale;
-		case VAR_defaultRangeGap:
-			return DISPLAY_NAME_defaultRangeGap;
-		case VAR_defaultRangeEnd:
-			return DISPLAY_NAME_defaultRangeEnd;
-		case VAR_defaultRangeStart:
-			return DISPLAY_NAME_defaultRangeStart;
-		case VAR_defaultRangeVar:
-			return DISPLAY_NAME_defaultRangeVar;
-		case VAR_defaultFacetSort:
-			return DISPLAY_NAME_defaultFacetSort;
-		case VAR_defaultFacetLimit:
-			return DISPLAY_NAME_defaultFacetLimit;
-		case VAR_defaultFacetMinCount:
-			return DISPLAY_NAME_defaultFacetMinCount;
-		case VAR_defaultPivotMinCount:
-			return DISPLAY_NAME_defaultPivotMinCount;
-		case VAR_listSiteUser:
-			return DISPLAY_NAME_listSiteUser;
-		case VAR_facetCounts:
-			return DISPLAY_NAME_facetCounts;
-		case VAR_siteUserCount:
-			return DISPLAY_NAME_siteUserCount;
-		case VAR_siteUser_:
-			return DISPLAY_NAME_siteUser_;
-		case VAR_pk:
-			return DISPLAY_NAME_pk;
-		case VAR_id:
-			return DISPLAY_NAME_id;
-		default:
-			return BaseModelPage.displayNameBaseModelPage(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserPageGen.java
@@ -3,42 +3,42 @@ package org.curriki.api.enus.model.user;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.curriki.api.enus.model.user.SiteUserGenPage;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUserPage.class);
@@ -170,83 +170,44 @@ public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrSiteUserPage(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSolrSiteUserGenPage(entityVar,  siteRequest_, o);
+				return SiteUserGenPage.staticSearchSiteUserGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrSiteUserPage(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSolrStrSiteUserGenPage(entityVar,  siteRequest_, o);
+				return SiteUserGenPage.staticSearchStrSiteUserGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqSiteUserPage(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSolrFqSiteUserGenPage(entityVar,  siteRequest_, o);
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	@Override public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineSiteUserPage(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineSiteUserPage(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return super.defineSiteUserGenPage(var, val);
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestSiteUserPage() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof SiteUserPage) {
-			SiteUserPage original = (SiteUserPage)o;
-			super.apiRequestSiteUserGenPage();
+				return SiteUserGenPage.staticSearchFqSiteUserGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
@@ -260,4 +221,15 @@ public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 		return sb.toString();
 	}
 
+
+
+	public static String displayNameForClass(String var) {
+		return SiteUserPage.displayNameSiteUserPage(var);
+	}
+	public static String displayNameSiteUserPage(String var) {
+		switch(var) {
+		default:
+			return SiteUserGenPage.displayNameSiteUserGenPage(var);
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/model/user/SiteUserPageGen.java
+++ b/src/gen/java/org/curriki/api/enus/model/user/SiteUserPageGen.java
@@ -1,50 +1,44 @@
 package org.curriki.api.enus.model.user;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.curriki.api.enus.model.user.SiteUserGenPage;
-import org.computate.search.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.math.RoundingMode;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserPage">Find the class SiteUserPage in Solr. </a>
- * <br><br>Delete the class SiteUserPage in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserPage&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.model.user in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.model.user&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.model.user.SiteUserPage&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteUserPage.class);
@@ -176,44 +170,83 @@ public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchSiteUserPage(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSearchSiteUserGenPage(entityVar,  siteRequest_, o);
+				return SiteUserGenPage.staticSolrSiteUserGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrSiteUserPage(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSearchStrSiteUserGenPage(entityVar,  siteRequest_, o);
+				return SiteUserGenPage.staticSolrStrSiteUserGenPage(entityVar,  siteRequest_, o);
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqSiteUserPage(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqSiteUserPage(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqSiteUserPage(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 			default:
-				return SiteUserGenPage.staticSearchFqSiteUserGenPage(entityVar,  siteRequest_, o);
+				return SiteUserGenPage.staticSolrFqSiteUserGenPage(entityVar,  siteRequest_, o);
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	@Override public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineSiteUserPage(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineSiteUserPage(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return super.defineSiteUserGenPage(var, val);
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestSiteUserPage() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof SiteUserPage) {
+			SiteUserPage original = (SiteUserPage)o;
+			super.apiRequestSiteUserGenPage();
 		}
 	}
 
@@ -227,16 +260,4 @@ public abstract class SiteUserPageGen<DEV> extends SiteUserGenPage {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "SiteUserPage";
-
-
-	public static String displayNameForClass(String var) {
-		return SiteUserPage.displayNameSiteUserPage(var);
-	}
-	public static String displayNameSiteUserPage(String var) {
-		switch(var) {
-		default:
-			return SiteUserGenPage.displayNameSiteUserGenPage(var);
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/page/PageLayoutGen.java
+++ b/src/gen/java/org/curriki/api/enus/page/PageLayoutGen.java
@@ -1,56 +1,51 @@
 package org.curriki.api.enus.page;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import java.lang.Object;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.api.service.ServiceRequest;
-import java.lang.String;
-import java.lang.Long;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import java.lang.Long;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.vertx.core.json.JsonObject;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import java.math.RoundingMode;
 import java.lang.Void;
-import io.vertx.core.json.JsonArray;
-import org.computate.search.wrap.Wrap;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import java.util.Objects;
+import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.lang.Object;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout">Find the class PageLayout in Solr. </a>
- * <br><br>Delete the class PageLayout in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.page in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.page&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class PageLayoutGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(PageLayout.class);
@@ -66,10 +61,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br> The entity siteRequest_
+	/**	<br/> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> w);
@@ -104,10 +99,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Map<String, String> requestVars;
 
-	/**	<br> The entity requestVars
+	/**	<br/> The entity requestVars
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestVars(Wrap<Map<String, String>> w);
@@ -142,10 +137,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject config;
 
-	/**	<br> The entity config
+	/**	<br/> The entity config
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _config(Wrap<JsonObject> w);
@@ -180,10 +175,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ServiceRequest serviceRequest;
 
-	/**	<br> The entity serviceRequest
+	/**	<br/> The entity serviceRequest
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _serviceRequest(Wrap<ServiceRequest> w);
@@ -218,10 +213,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String staticBaseUrl;
 
-	/**	<br> The entity staticBaseUrl
+	/**	<br/> The entity staticBaseUrl
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:staticBaseUrl">Find the entity staticBaseUrl in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:staticBaseUrl">Find the entity staticBaseUrl in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _staticBaseUrl(Wrap<String> w);
@@ -244,16 +239,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrStaticBaseUrl(siteRequest_, PageLayout.staticSearchStaticBaseUrl(siteRequest_, PageLayout.staticSetStaticBaseUrl(siteRequest_, o)));
+	public static String staticSolrFqStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrStaticBaseUrl(siteRequest_, PageLayout.staticSolrStaticBaseUrl(siteRequest_, PageLayout.staticSetStaticBaseUrl(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -267,10 +262,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String STATIC_BASE_URL;
 
-	/**	<br> The entity STATIC_BASE_URL
+	/**	<br/> The entity STATIC_BASE_URL
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:STATIC_BASE_URL">Find the entity STATIC_BASE_URL in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:STATIC_BASE_URL">Find the entity STATIC_BASE_URL in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _STATIC_BASE_URL(Wrap<String> w);
@@ -293,16 +288,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSearchSTATIC_BASE_URL(siteRequest_, PageLayout.staticSetSTATIC_BASE_URL(siteRequest_, o)));
+	public static String staticSolrFqSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSolrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSetSTATIC_BASE_URL(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -316,10 +311,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_BASE_URL;
 
-	/**	<br> The entity SITE_BASE_URL
+	/**	<br/> The entity SITE_BASE_URL
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:SITE_BASE_URL">Find the entity SITE_BASE_URL in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_BASE_URL">Find the entity SITE_BASE_URL in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_BASE_URL(Wrap<String> w);
@@ -342,16 +337,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrSITE_BASE_URL(siteRequest_, PageLayout.staticSearchSITE_BASE_URL(siteRequest_, PageLayout.staticSetSITE_BASE_URL(siteRequest_, o)));
+	public static String staticSolrFqSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrSITE_BASE_URL(siteRequest_, PageLayout.staticSolrSITE_BASE_URL(siteRequest_, PageLayout.staticSetSITE_BASE_URL(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -365,10 +360,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_AUTH_URL;
 
-	/**	<br> The entity SITE_AUTH_URL
+	/**	<br/> The entity SITE_AUTH_URL
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:SITE_AUTH_URL">Find the entity SITE_AUTH_URL in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_URL">Find the entity SITE_AUTH_URL in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_AUTH_URL(Wrap<String> w);
@@ -391,16 +386,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrSITE_AUTH_URL(siteRequest_, PageLayout.staticSearchSITE_AUTH_URL(siteRequest_, PageLayout.staticSetSITE_AUTH_URL(siteRequest_, o)));
+	public static String staticSolrFqSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrSITE_AUTH_URL(siteRequest_, PageLayout.staticSolrSITE_AUTH_URL(siteRequest_, PageLayout.staticSetSITE_AUTH_URL(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -414,10 +409,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_AUTH_REALM;
 
-	/**	<br> The entity SITE_AUTH_REALM
+	/**	<br/> The entity SITE_AUTH_REALM
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:SITE_AUTH_REALM">Find the entity SITE_AUTH_REALM in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_REALM">Find the entity SITE_AUTH_REALM in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_AUTH_REALM(Wrap<String> w);
@@ -440,16 +435,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSearchSITE_AUTH_REALM(siteRequest_, PageLayout.staticSetSITE_AUTH_REALM(siteRequest_, o)));
+	public static String staticSolrFqSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSolrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSetSITE_AUTH_REALM(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -463,10 +458,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String FONTAWESOME_KIT;
 
-	/**	<br> The entity FONTAWESOME_KIT
+	/**	<br/> The entity FONTAWESOME_KIT
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:FONTAWESOME_KIT">Find the entity FONTAWESOME_KIT in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:FONTAWESOME_KIT">Find the entity FONTAWESOME_KIT in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _FONTAWESOME_KIT(Wrap<String> w);
@@ -489,16 +484,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSearchFONTAWESOME_KIT(siteRequest_, PageLayout.staticSetFONTAWESOME_KIT(siteRequest_, o)));
+	public static String staticSolrFqFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSolrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSetFONTAWESOME_KIT(siteRequest_, o)));
 	}
 
 	/////////////
@@ -512,10 +507,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUri;
 
-	/**	<br> The entity pageUri
+	/**	<br/> The entity pageUri
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pageUri">Find the entity pageUri in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUri">Find the entity pageUri in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUri(Wrap<String> w);
@@ -538,16 +533,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchPageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageUri(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrPageUri(siteRequest_, PageLayout.staticSearchPageUri(siteRequest_, PageLayout.staticSetPageUri(siteRequest_, o)));
+	public static String staticSolrFqPageUri(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrPageUri(siteRequest_, PageLayout.staticSolrPageUri(siteRequest_, PageLayout.staticSetPageUri(siteRequest_, o)));
 	}
 
 	////////////////
@@ -561,10 +556,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageMethod;
 
-	/**	<br> The entity pageMethod
+	/**	<br/> The entity pageMethod
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pageMethod">Find the entity pageMethod in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageMethod">Find the entity pageMethod in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageMethod(Wrap<String> w);
@@ -587,16 +582,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchPageMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageMethod(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrPageMethod(siteRequest_, PageLayout.staticSearchPageMethod(siteRequest_, PageLayout.staticSetPageMethod(siteRequest_, o)));
+	public static String staticSolrFqPageMethod(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrPageMethod(siteRequest_, PageLayout.staticSolrPageMethod(siteRequest_, PageLayout.staticSetPageMethod(siteRequest_, o)));
 	}
 
 	////////////
@@ -609,10 +604,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject params;
 
-	/**	<br> The entity params
+	/**	<br/> The entity params
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:params">Find the entity params in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:params">Find the entity params in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _params(Wrap<JsonObject> w);
@@ -648,10 +643,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br> The entity userKey
+	/**	<br/> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> w);
@@ -681,16 +676,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrUserKey(siteRequest_, PageLayout.staticSearchUserKey(siteRequest_, PageLayout.staticSetUserKey(siteRequest_, o)));
+	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrUserKey(siteRequest_, PageLayout.staticSolrUserKey(siteRequest_, PageLayout.staticSetUserKey(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -704,10 +699,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br> The entity userFullName
+	/**	<br/> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> w);
@@ -730,16 +725,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrUserFullName(siteRequest_, PageLayout.staticSearchUserFullName(siteRequest_, PageLayout.staticSetUserFullName(siteRequest_, o)));
+	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrUserFullName(siteRequest_, PageLayout.staticSolrUserFullName(siteRequest_, PageLayout.staticSetUserFullName(siteRequest_, o)));
 	}
 
 	//////////////
@@ -753,10 +748,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br> The entity userName
+	/**	<br/> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> w);
@@ -779,16 +774,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrUserName(siteRequest_, PageLayout.staticSearchUserName(siteRequest_, PageLayout.staticSetUserName(siteRequest_, o)));
+	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrUserName(siteRequest_, PageLayout.staticSolrUserName(siteRequest_, PageLayout.staticSetUserName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -802,10 +797,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br> The entity userEmail
+	/**	<br/> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> w);
@@ -828,16 +823,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrUserEmail(siteRequest_, PageLayout.staticSearchUserEmail(siteRequest_, PageLayout.staticSetUserEmail(siteRequest_, o)));
+	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrUserEmail(siteRequest_, PageLayout.staticSolrUserEmail(siteRequest_, PageLayout.staticSetUserEmail(siteRequest_, o)));
 	}
 
 	///////////////
@@ -851,10 +846,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String logoutUrl;
 
-	/**	<br> The entity logoutUrl
+	/**	<br/> The entity logoutUrl
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:logoutUrl">Find the entity logoutUrl in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:logoutUrl">Find the entity logoutUrl in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _logoutUrl(Wrap<String> w);
@@ -877,16 +872,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrLogoutUrl(siteRequest_, PageLayout.staticSearchLogoutUrl(siteRequest_, PageLayout.staticSetLogoutUrl(siteRequest_, o)));
+	public static String staticSolrFqLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrLogoutUrl(siteRequest_, PageLayout.staticSolrLogoutUrl(siteRequest_, PageLayout.staticSetLogoutUrl(siteRequest_, o)));
 	}
 
 	///////////
@@ -901,10 +896,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long long0;
 
-	/**	<br> The entity long0
+	/**	<br/> The entity long0
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:long0">Find the entity long0 in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long0">Find the entity long0 in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _long0(Wrap<Long> w);
@@ -934,16 +929,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSearchLong0(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrLong0(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrLong0(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrLong0(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLong0(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrLong0(siteRequest_, PageLayout.staticSearchLong0(siteRequest_, PageLayout.staticSetLong0(siteRequest_, o)));
+	public static String staticSolrFqLong0(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrLong0(siteRequest_, PageLayout.staticSolrLong0(siteRequest_, PageLayout.staticSetLong0(siteRequest_, o)));
 	}
 
 	///////////
@@ -958,10 +953,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long long1;
 
-	/**	<br> The entity long1
+	/**	<br/> The entity long1
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:long1">Find the entity long1 in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long1">Find the entity long1 in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _long1(Wrap<Long> w);
@@ -991,16 +986,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSearchLong1(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrLong1(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrLong1(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrLong1(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqLong1(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrLong1(siteRequest_, PageLayout.staticSearchLong1(siteRequest_, PageLayout.staticSetLong1(siteRequest_, o)));
+	public static String staticSolrFqLong1(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrLong1(siteRequest_, PageLayout.staticSolrLong1(siteRequest_, PageLayout.staticSetLong1(siteRequest_, o)));
 	}
 
 	//////////
@@ -1015,10 +1010,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer int0;
 
-	/**	<br> The entity int0
+	/**	<br/> The entity int0
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:int0">Find the entity int0 in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int0">Find the entity int0 in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _int0(Wrap<Integer> w);
@@ -1048,16 +1043,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Integer staticSearchInt0(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrInt0(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrInt0(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrInt0(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInt0(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrInt0(siteRequest_, PageLayout.staticSearchInt0(siteRequest_, PageLayout.staticSetInt0(siteRequest_, o)));
+	public static String staticSolrFqInt0(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrInt0(siteRequest_, PageLayout.staticSolrInt0(siteRequest_, PageLayout.staticSetInt0(siteRequest_, o)));
 	}
 
 	//////////
@@ -1072,10 +1067,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer int1;
 
-	/**	<br> The entity int1
+	/**	<br/> The entity int1
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:int1">Find the entity int1 in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int1">Find the entity int1 in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _int1(Wrap<Integer> w);
@@ -1105,16 +1100,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Integer staticSearchInt1(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSolrInt1(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSearchStrInt1(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSolrStrInt1(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqInt1(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrInt1(siteRequest_, PageLayout.staticSearchInt1(siteRequest_, PageLayout.staticSetInt1(siteRequest_, o)));
+	public static String staticSolrFqInt1(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrInt1(siteRequest_, PageLayout.staticSolrInt1(siteRequest_, PageLayout.staticSetInt1(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1128,10 +1123,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Void promiseBefore;
 
-	/**	<br> The entity promiseBefore
+	/**	<br/> The entity promiseBefore
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:promiseBefore">Find the entity promiseBefore in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseBefore">Find the entity promiseBefore in Solr</a>
+	 * <br/>
 	 * @param promise is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _promiseBefore(Promise<Void> promise);
@@ -1170,10 +1165,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classSimpleName;
 
-	/**	<br> The entity classSimpleName
+	/**	<br/> The entity classSimpleName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classSimpleName(Wrap<String> w);
@@ -1196,16 +1191,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrClassSimpleName(siteRequest_, PageLayout.staticSearchClassSimpleName(siteRequest_, PageLayout.staticSetClassSimpleName(siteRequest_, o)));
+	public static String staticSolrFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrClassSimpleName(siteRequest_, PageLayout.staticSolrClassSimpleName(siteRequest_, PageLayout.staticSetClassSimpleName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1219,10 +1214,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageTitle;
 
-	/**	<br> The entity pageTitle
+	/**	<br/> The entity pageTitle
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pageTitle">Find the entity pageTitle in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageTitle">Find the entity pageTitle in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageTitle(Wrap<String> w);
@@ -1245,16 +1240,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchPageTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageTitle(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrPageTitle(siteRequest_, PageLayout.staticSearchPageTitle(siteRequest_, PageLayout.staticSetPageTitle(siteRequest_, o)));
+	public static String staticSolrFqPageTitle(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrPageTitle(siteRequest_, PageLayout.staticSolrPageTitle(siteRequest_, PageLayout.staticSetPageTitle(siteRequest_, o)));
 	}
 
 	///////////
@@ -1262,18 +1257,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity roles
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> roles = new ArrayList<String>();
 
-	/**	<br> The entity roles
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:roles">Find the entity roles in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity roles
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:roles">Find the entity roles in Solr</a>
+	 * <br/>
+	 * @param roles is the entity already constructed. 
 	 **/
 	protected abstract void _roles(List<String> l);
 
@@ -1311,16 +1306,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRoles(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrRoles(siteRequest_, PageLayout.staticSearchRoles(siteRequest_, PageLayout.staticSetRoles(siteRequest_, o)));
+	public static String staticSolrFqRoles(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrRoles(siteRequest_, PageLayout.staticSolrRoles(siteRequest_, PageLayout.staticSetRoles(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1328,18 +1323,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////////////
 
 	/**	 The entity rolesRequired
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> rolesRequired = new ArrayList<String>();
 
-	/**	<br> The entity rolesRequired
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:rolesRequired">Find the entity rolesRequired in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity rolesRequired
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rolesRequired">Find the entity rolesRequired in Solr</a>
+	 * <br/>
+	 * @param rolesRequired is the entity already constructed. 
 	 **/
 	protected abstract void _rolesRequired(List<String> l);
 
@@ -1377,16 +1372,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRolesRequired(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrRolesRequired(siteRequest_, PageLayout.staticSearchRolesRequired(siteRequest_, PageLayout.staticSetRolesRequired(siteRequest_, o)));
+	public static String staticSolrFqRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrRolesRequired(siteRequest_, PageLayout.staticSolrRolesRequired(siteRequest_, PageLayout.staticSetRolesRequired(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -1394,18 +1389,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////////////
 
 	/**	 The entity authRolesAdmin
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> authRolesAdmin = new ArrayList<String>();
 
-	/**	<br> The entity authRolesAdmin
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:authRolesAdmin">Find the entity authRolesAdmin in Solr</a>
-	 * <br>
-	 * @param l is the entity already constructed. 
+	/**	<br/> The entity authRolesAdmin
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:authRolesAdmin">Find the entity authRolesAdmin in Solr</a>
+	 * <br/>
+	 * @param authRolesAdmin is the entity already constructed. 
 	 **/
 	protected abstract void _authRolesAdmin(List<String> l);
 
@@ -1443,16 +1438,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrAuthRolesAdmin(siteRequest_, PageLayout.staticSearchAuthRolesAdmin(siteRequest_, PageLayout.staticSetAuthRolesAdmin(siteRequest_, o)));
+	public static String staticSolrFqAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrAuthRolesAdmin(siteRequest_, PageLayout.staticSolrAuthRolesAdmin(siteRequest_, PageLayout.staticSetAuthRolesAdmin(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1460,15 +1455,15 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////////
 
 	/**	 The entity pagination
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject pagination = new JsonObject();
 
-	/**	<br> The entity pagination
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pagination">Find the entity pagination in Solr</a>
-	 * <br>
+	/**	<br/> The entity pagination
+	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pagination">Find the entity pagination in Solr</a>
+	 * <br/>
 	 * @param pagination is the entity already constructed. 
 	 **/
 	protected abstract void _pagination(JsonObject pagination);
@@ -1493,16 +1488,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity varsQ
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsQ = new JsonObject();
 
-	/**	<br> The entity varsQ
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:varsQ">Find the entity varsQ in Solr</a>
-	 * <br>
-	 * @param vars is the entity already constructed. 
+	/**	<br/> The entity varsQ
+	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsQ">Find the entity varsQ in Solr</a>
+	 * <br/>
+	 * @param varsQ is the entity already constructed. 
 	 **/
 	protected abstract void _varsQ(JsonObject vars);
 
@@ -1526,16 +1521,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////
 
 	/**	 The entity varsFq
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsFq = new JsonObject();
 
-	/**	<br> The entity varsFq
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:varsFq">Find the entity varsFq in Solr</a>
-	 * <br>
-	 * @param vars is the entity already constructed. 
+	/**	<br/> The entity varsFq
+	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsFq">Find the entity varsFq in Solr</a>
+	 * <br/>
+	 * @param varsFq is the entity already constructed. 
 	 **/
 	protected abstract void _varsFq(JsonObject vars);
 
@@ -1559,16 +1554,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////////
 
 	/**	 The entity varsRange
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsRange = new JsonObject();
 
-	/**	<br> The entity varsRange
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:varsRange">Find the entity varsRange in Solr</a>
-	 * <br>
-	 * @param vars is the entity already constructed. 
+	/**	<br/> The entity varsRange
+	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsRange">Find the entity varsRange in Solr</a>
+	 * <br/>
+	 * @param varsRange is the entity already constructed. 
 	 **/
 	protected abstract void _varsRange(JsonObject vars);
 
@@ -1592,15 +1587,15 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity query
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject query = new JsonObject();
 
-	/**	<br> The entity query
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:query">Find the entity query in Solr</a>
-	 * <br>
+	/**	<br/> The entity query
+	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:query">Find the entity query in Solr</a>
+	 * <br/>
 	 * @param query is the entity already constructed. 
 	 **/
 	protected abstract void _query(JsonObject query);
@@ -1631,10 +1626,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Void promiseAfter;
 
-	/**	<br> The entity promiseAfter
+	/**	<br/> The entity promiseAfter
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:promiseAfter">Find the entity promiseAfter in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseAfter">Find the entity promiseAfter in Solr</a>
+	 * <br/>
 	 * @param promise is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _promiseAfter(Promise<Void> promise);
@@ -1673,10 +1668,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageImageUri;
 
-	/**	<br> The entity pageImageUri
+	/**	<br/> The entity pageImageUri
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pageImageUri">Find the entity pageImageUri in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageImageUri">Find the entity pageImageUri in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageImageUri(Wrap<String> w);
@@ -1699,16 +1694,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageImageUri(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrPageImageUri(siteRequest_, PageLayout.staticSearchPageImageUri(siteRequest_, PageLayout.staticSetPageImageUri(siteRequest_, o)));
+	public static String staticSolrFqPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrPageImageUri(siteRequest_, PageLayout.staticSolrPageImageUri(siteRequest_, PageLayout.staticSetPageImageUri(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -1722,10 +1717,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconGroup;
 
-	/**	<br> The entity contextIconGroup
+	/**	<br/> The entity contextIconGroup
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:contextIconGroup">Find the entity contextIconGroup in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconGroup">Find the entity contextIconGroup in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconGroup(Wrap<String> w);
@@ -1748,16 +1743,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrContextIconGroup(siteRequest_, PageLayout.staticSearchContextIconGroup(siteRequest_, PageLayout.staticSetContextIconGroup(siteRequest_, o)));
+	public static String staticSolrFqContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrContextIconGroup(siteRequest_, PageLayout.staticSolrContextIconGroup(siteRequest_, PageLayout.staticSetContextIconGroup(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1771,10 +1766,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconName;
 
-	/**	<br> The entity contextIconName
+	/**	<br/> The entity contextIconName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:contextIconName">Find the entity contextIconName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconName">Find the entity contextIconName in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconName(Wrap<String> w);
@@ -1797,16 +1792,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchContextIconName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrContextIconName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrContextIconName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrContextIconName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContextIconName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrContextIconName(siteRequest_, PageLayout.staticSearchContextIconName(siteRequest_, PageLayout.staticSetContextIconName(siteRequest_, o)));
+	public static String staticSolrFqContextIconName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrContextIconName(siteRequest_, PageLayout.staticSolrContextIconName(siteRequest_, PageLayout.staticSetContextIconName(siteRequest_, o)));
 	}
 
 	///////////////////////////
@@ -1820,10 +1815,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconCssClasses;
 
-	/**	<br> The entity contextIconCssClasses
+	/**	<br/> The entity contextIconCssClasses
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:contextIconCssClasses">Find the entity contextIconCssClasses in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconCssClasses">Find the entity contextIconCssClasses in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconCssClasses(Wrap<String> w);
@@ -1846,16 +1841,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrContextIconCssClasses(siteRequest_, PageLayout.staticSearchContextIconCssClasses(siteRequest_, PageLayout.staticSetContextIconCssClasses(siteRequest_, o)));
+	public static String staticSolrFqContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrContextIconCssClasses(siteRequest_, PageLayout.staticSolrContextIconCssClasses(siteRequest_, PageLayout.staticSetContextIconCssClasses(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1869,10 +1864,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageDescription;
 
-	/**	<br> The entity pageDescription
+	/**	<br/> The entity pageDescription
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=entiteVar_enUS_indexed_string:pageDescription">Find the entity pageDescription in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageDescription">Find the entity pageDescription in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageDescription(Wrap<String> w);
@@ -1895,16 +1890,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSearchPageDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrPageDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrPageDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrPageDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqPageDescription(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSearchStrPageDescription(siteRequest_, PageLayout.staticSearchPageDescription(siteRequest_, PageLayout.staticSetPageDescription(siteRequest_, o)));
+	public static String staticSolrFqPageDescription(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSolrStrPageDescription(siteRequest_, PageLayout.staticSolrPageDescription(siteRequest_, PageLayout.staticSetPageDescription(siteRequest_, o)));
 	}
 
 	//////////////
@@ -2230,206 +2225,244 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchPageLayout(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSearchStaticBaseUrl(siteRequest_, (String)o);
+			return PageLayout.staticSolrStaticBaseUrl(siteRequest_, (String)o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSearchSTATIC_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrSTATIC_BASE_URL(siteRequest_, (String)o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSearchSITE_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrSITE_BASE_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSearchSITE_AUTH_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrSITE_AUTH_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSearchSITE_AUTH_REALM(siteRequest_, (String)o);
+			return PageLayout.staticSolrSITE_AUTH_REALM(siteRequest_, (String)o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSearchFONTAWESOME_KIT(siteRequest_, (String)o);
+			return PageLayout.staticSolrFONTAWESOME_KIT(siteRequest_, (String)o);
 		case "pageUri":
-			return PageLayout.staticSearchPageUri(siteRequest_, (String)o);
+			return PageLayout.staticSolrPageUri(siteRequest_, (String)o);
 		case "pageMethod":
-			return PageLayout.staticSearchPageMethod(siteRequest_, (String)o);
+			return PageLayout.staticSolrPageMethod(siteRequest_, (String)o);
 		case "userKey":
-			return PageLayout.staticSearchUserKey(siteRequest_, (Long)o);
+			return PageLayout.staticSolrUserKey(siteRequest_, (Long)o);
 		case "userFullName":
-			return PageLayout.staticSearchUserFullName(siteRequest_, (String)o);
+			return PageLayout.staticSolrUserFullName(siteRequest_, (String)o);
 		case "userName":
-			return PageLayout.staticSearchUserName(siteRequest_, (String)o);
+			return PageLayout.staticSolrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return PageLayout.staticSearchUserEmail(siteRequest_, (String)o);
+			return PageLayout.staticSolrUserEmail(siteRequest_, (String)o);
 		case "logoutUrl":
-			return PageLayout.staticSearchLogoutUrl(siteRequest_, (String)o);
+			return PageLayout.staticSolrLogoutUrl(siteRequest_, (String)o);
 		case "long0":
-			return PageLayout.staticSearchLong0(siteRequest_, (Long)o);
+			return PageLayout.staticSolrLong0(siteRequest_, (Long)o);
 		case "long1":
-			return PageLayout.staticSearchLong1(siteRequest_, (Long)o);
+			return PageLayout.staticSolrLong1(siteRequest_, (Long)o);
 		case "int0":
-			return PageLayout.staticSearchInt0(siteRequest_, (Integer)o);
+			return PageLayout.staticSolrInt0(siteRequest_, (Integer)o);
 		case "int1":
-			return PageLayout.staticSearchInt1(siteRequest_, (Integer)o);
+			return PageLayout.staticSolrInt1(siteRequest_, (Integer)o);
 		case "classSimpleName":
-			return PageLayout.staticSearchClassSimpleName(siteRequest_, (String)o);
+			return PageLayout.staticSolrClassSimpleName(siteRequest_, (String)o);
 		case "pageTitle":
-			return PageLayout.staticSearchPageTitle(siteRequest_, (String)o);
+			return PageLayout.staticSolrPageTitle(siteRequest_, (String)o);
 		case "roles":
-			return PageLayout.staticSearchRoles(siteRequest_, (String)o);
+			return PageLayout.staticSolrRoles(siteRequest_, (String)o);
 		case "rolesRequired":
-			return PageLayout.staticSearchRolesRequired(siteRequest_, (String)o);
+			return PageLayout.staticSolrRolesRequired(siteRequest_, (String)o);
 		case "authRolesAdmin":
-			return PageLayout.staticSearchAuthRolesAdmin(siteRequest_, (String)o);
+			return PageLayout.staticSolrAuthRolesAdmin(siteRequest_, (String)o);
 		case "pageImageUri":
-			return PageLayout.staticSearchPageImageUri(siteRequest_, (String)o);
+			return PageLayout.staticSolrPageImageUri(siteRequest_, (String)o);
 		case "contextIconGroup":
-			return PageLayout.staticSearchContextIconGroup(siteRequest_, (String)o);
+			return PageLayout.staticSolrContextIconGroup(siteRequest_, (String)o);
 		case "contextIconName":
-			return PageLayout.staticSearchContextIconName(siteRequest_, (String)o);
+			return PageLayout.staticSolrContextIconName(siteRequest_, (String)o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSearchContextIconCssClasses(siteRequest_, (String)o);
+			return PageLayout.staticSolrContextIconCssClasses(siteRequest_, (String)o);
 		case "pageDescription":
-			return PageLayout.staticSearchPageDescription(siteRequest_, (String)o);
+			return PageLayout.staticSolrPageDescription(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrPageLayout(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSearchStrStaticBaseUrl(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrStaticBaseUrl(siteRequest_, (String)o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSearchStrSTATIC_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrSTATIC_BASE_URL(siteRequest_, (String)o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSearchStrSITE_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrSITE_BASE_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSearchStrSITE_AUTH_URL(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrSITE_AUTH_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSearchStrSITE_AUTH_REALM(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrSITE_AUTH_REALM(siteRequest_, (String)o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSearchStrFONTAWESOME_KIT(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrFONTAWESOME_KIT(siteRequest_, (String)o);
 		case "pageUri":
-			return PageLayout.staticSearchStrPageUri(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrPageUri(siteRequest_, (String)o);
 		case "pageMethod":
-			return PageLayout.staticSearchStrPageMethod(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrPageMethod(siteRequest_, (String)o);
 		case "userKey":
-			return PageLayout.staticSearchStrUserKey(siteRequest_, (Long)o);
+			return PageLayout.staticSolrStrUserKey(siteRequest_, (Long)o);
 		case "userFullName":
-			return PageLayout.staticSearchStrUserFullName(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrUserFullName(siteRequest_, (String)o);
 		case "userName":
-			return PageLayout.staticSearchStrUserName(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return PageLayout.staticSearchStrUserEmail(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrUserEmail(siteRequest_, (String)o);
 		case "logoutUrl":
-			return PageLayout.staticSearchStrLogoutUrl(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrLogoutUrl(siteRequest_, (String)o);
 		case "long0":
-			return PageLayout.staticSearchStrLong0(siteRequest_, (Long)o);
+			return PageLayout.staticSolrStrLong0(siteRequest_, (Long)o);
 		case "long1":
-			return PageLayout.staticSearchStrLong1(siteRequest_, (Long)o);
+			return PageLayout.staticSolrStrLong1(siteRequest_, (Long)o);
 		case "int0":
-			return PageLayout.staticSearchStrInt0(siteRequest_, (Integer)o);
+			return PageLayout.staticSolrStrInt0(siteRequest_, (Integer)o);
 		case "int1":
-			return PageLayout.staticSearchStrInt1(siteRequest_, (Integer)o);
+			return PageLayout.staticSolrStrInt1(siteRequest_, (Integer)o);
 		case "classSimpleName":
-			return PageLayout.staticSearchStrClassSimpleName(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrClassSimpleName(siteRequest_, (String)o);
 		case "pageTitle":
-			return PageLayout.staticSearchStrPageTitle(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrPageTitle(siteRequest_, (String)o);
 		case "roles":
-			return PageLayout.staticSearchStrRoles(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrRoles(siteRequest_, (String)o);
 		case "rolesRequired":
-			return PageLayout.staticSearchStrRolesRequired(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrRolesRequired(siteRequest_, (String)o);
 		case "authRolesAdmin":
-			return PageLayout.staticSearchStrAuthRolesAdmin(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrAuthRolesAdmin(siteRequest_, (String)o);
 		case "pageImageUri":
-			return PageLayout.staticSearchStrPageImageUri(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrPageImageUri(siteRequest_, (String)o);
 		case "contextIconGroup":
-			return PageLayout.staticSearchStrContextIconGroup(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrContextIconGroup(siteRequest_, (String)o);
 		case "contextIconName":
-			return PageLayout.staticSearchStrContextIconName(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrContextIconName(siteRequest_, (String)o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSearchStrContextIconCssClasses(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrContextIconCssClasses(siteRequest_, (String)o);
 		case "pageDescription":
-			return PageLayout.staticSearchStrPageDescription(siteRequest_, (String)o);
+			return PageLayout.staticSolrStrPageDescription(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqPageLayout(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqPageLayout(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqPageLayout(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSearchFqStaticBaseUrl(siteRequest_, o);
+			return PageLayout.staticSolrFqStaticBaseUrl(siteRequest_, o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSearchFqSTATIC_BASE_URL(siteRequest_, o);
+			return PageLayout.staticSolrFqSTATIC_BASE_URL(siteRequest_, o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSearchFqSITE_BASE_URL(siteRequest_, o);
+			return PageLayout.staticSolrFqSITE_BASE_URL(siteRequest_, o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSearchFqSITE_AUTH_URL(siteRequest_, o);
+			return PageLayout.staticSolrFqSITE_AUTH_URL(siteRequest_, o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSearchFqSITE_AUTH_REALM(siteRequest_, o);
+			return PageLayout.staticSolrFqSITE_AUTH_REALM(siteRequest_, o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSearchFqFONTAWESOME_KIT(siteRequest_, o);
+			return PageLayout.staticSolrFqFONTAWESOME_KIT(siteRequest_, o);
 		case "pageUri":
-			return PageLayout.staticSearchFqPageUri(siteRequest_, o);
+			return PageLayout.staticSolrFqPageUri(siteRequest_, o);
 		case "pageMethod":
-			return PageLayout.staticSearchFqPageMethod(siteRequest_, o);
+			return PageLayout.staticSolrFqPageMethod(siteRequest_, o);
 		case "userKey":
-			return PageLayout.staticSearchFqUserKey(siteRequest_, o);
+			return PageLayout.staticSolrFqUserKey(siteRequest_, o);
 		case "userFullName":
-			return PageLayout.staticSearchFqUserFullName(siteRequest_, o);
+			return PageLayout.staticSolrFqUserFullName(siteRequest_, o);
 		case "userName":
-			return PageLayout.staticSearchFqUserName(siteRequest_, o);
+			return PageLayout.staticSolrFqUserName(siteRequest_, o);
 		case "userEmail":
-			return PageLayout.staticSearchFqUserEmail(siteRequest_, o);
+			return PageLayout.staticSolrFqUserEmail(siteRequest_, o);
 		case "logoutUrl":
-			return PageLayout.staticSearchFqLogoutUrl(siteRequest_, o);
+			return PageLayout.staticSolrFqLogoutUrl(siteRequest_, o);
 		case "long0":
-			return PageLayout.staticSearchFqLong0(siteRequest_, o);
+			return PageLayout.staticSolrFqLong0(siteRequest_, o);
 		case "long1":
-			return PageLayout.staticSearchFqLong1(siteRequest_, o);
+			return PageLayout.staticSolrFqLong1(siteRequest_, o);
 		case "int0":
-			return PageLayout.staticSearchFqInt0(siteRequest_, o);
+			return PageLayout.staticSolrFqInt0(siteRequest_, o);
 		case "int1":
-			return PageLayout.staticSearchFqInt1(siteRequest_, o);
+			return PageLayout.staticSolrFqInt1(siteRequest_, o);
 		case "classSimpleName":
-			return PageLayout.staticSearchFqClassSimpleName(siteRequest_, o);
+			return PageLayout.staticSolrFqClassSimpleName(siteRequest_, o);
 		case "pageTitle":
-			return PageLayout.staticSearchFqPageTitle(siteRequest_, o);
+			return PageLayout.staticSolrFqPageTitle(siteRequest_, o);
 		case "roles":
-			return PageLayout.staticSearchFqRoles(siteRequest_, o);
+			return PageLayout.staticSolrFqRoles(siteRequest_, o);
 		case "rolesRequired":
-			return PageLayout.staticSearchFqRolesRequired(siteRequest_, o);
+			return PageLayout.staticSolrFqRolesRequired(siteRequest_, o);
 		case "authRolesAdmin":
-			return PageLayout.staticSearchFqAuthRolesAdmin(siteRequest_, o);
+			return PageLayout.staticSolrFqAuthRolesAdmin(siteRequest_, o);
 		case "pageImageUri":
-			return PageLayout.staticSearchFqPageImageUri(siteRequest_, o);
+			return PageLayout.staticSolrFqPageImageUri(siteRequest_, o);
 		case "contextIconGroup":
-			return PageLayout.staticSearchFqContextIconGroup(siteRequest_, o);
+			return PageLayout.staticSolrFqContextIconGroup(siteRequest_, o);
 		case "contextIconName":
-			return PageLayout.staticSearchFqContextIconName(siteRequest_, o);
+			return PageLayout.staticSolrFqContextIconName(siteRequest_, o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSearchFqContextIconCssClasses(siteRequest_, o);
+			return PageLayout.staticSolrFqContextIconCssClasses(siteRequest_, o);
 		case "pageDescription":
-			return PageLayout.staticSearchFqPageDescription(siteRequest_, o);
+			return PageLayout.staticSolrFqPageDescription(siteRequest_, o);
 			default:
 				return null;
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = definePageLayout(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object definePageLayout(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return null;
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestPageLayout() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof PageLayout) {
+			PageLayout original = (PageLayout)o;
 		}
 	}
 
@@ -2442,7 +2475,6 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "PageLayout";
 	public static final String VAR_siteRequest_ = "siteRequest_";
 	public static final String VAR_requestVars = "requestVars";
 	public static final String VAR_config = "config";
@@ -2482,132 +2514,4 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	public static final String VAR_contextIconName = "contextIconName";
 	public static final String VAR_contextIconCssClasses = "contextIconCssClasses";
 	public static final String VAR_pageDescription = "pageDescription";
-
-	public static final String DISPLAY_NAME_siteRequest_ = "";
-	public static final String DISPLAY_NAME_requestVars = "";
-	public static final String DISPLAY_NAME_config = "";
-	public static final String DISPLAY_NAME_serviceRequest = "";
-	public static final String DISPLAY_NAME_staticBaseUrl = "";
-	public static final String DISPLAY_NAME_STATIC_BASE_URL = "";
-	public static final String DISPLAY_NAME_SITE_BASE_URL = "";
-	public static final String DISPLAY_NAME_SITE_AUTH_URL = "";
-	public static final String DISPLAY_NAME_SITE_AUTH_REALM = "";
-	public static final String DISPLAY_NAME_FONTAWESOME_KIT = "";
-	public static final String DISPLAY_NAME_pageUri = "";
-	public static final String DISPLAY_NAME_pageMethod = "";
-	public static final String DISPLAY_NAME_params = "";
-	public static final String DISPLAY_NAME_userKey = "";
-	public static final String DISPLAY_NAME_userFullName = "";
-	public static final String DISPLAY_NAME_userName = "";
-	public static final String DISPLAY_NAME_userEmail = "";
-	public static final String DISPLAY_NAME_logoutUrl = "";
-	public static final String DISPLAY_NAME_long0 = "";
-	public static final String DISPLAY_NAME_long1 = "";
-	public static final String DISPLAY_NAME_int0 = "";
-	public static final String DISPLAY_NAME_int1 = "";
-	public static final String DISPLAY_NAME_promiseBefore = "";
-	public static final String DISPLAY_NAME_classSimpleName = "";
-	public static final String DISPLAY_NAME_pageTitle = "";
-	public static final String DISPLAY_NAME_roles = "";
-	public static final String DISPLAY_NAME_rolesRequired = "";
-	public static final String DISPLAY_NAME_authRolesAdmin = "";
-	public static final String DISPLAY_NAME_pagination = "";
-	public static final String DISPLAY_NAME_varsQ = "";
-	public static final String DISPLAY_NAME_varsFq = "";
-	public static final String DISPLAY_NAME_varsRange = "";
-	public static final String DISPLAY_NAME_query = "";
-	public static final String DISPLAY_NAME_promiseAfter = "";
-	public static final String DISPLAY_NAME_pageImageUri = "";
-	public static final String DISPLAY_NAME_contextIconGroup = "";
-	public static final String DISPLAY_NAME_contextIconName = "";
-	public static final String DISPLAY_NAME_contextIconCssClasses = "";
-	public static final String DISPLAY_NAME_pageDescription = "";
-
-	public static String displayNameForClass(String var) {
-		return PageLayout.displayNamePageLayout(var);
-	}
-	public static String displayNamePageLayout(String var) {
-		switch(var) {
-		case VAR_siteRequest_:
-			return DISPLAY_NAME_siteRequest_;
-		case VAR_requestVars:
-			return DISPLAY_NAME_requestVars;
-		case VAR_config:
-			return DISPLAY_NAME_config;
-		case VAR_serviceRequest:
-			return DISPLAY_NAME_serviceRequest;
-		case VAR_staticBaseUrl:
-			return DISPLAY_NAME_staticBaseUrl;
-		case VAR_STATIC_BASE_URL:
-			return DISPLAY_NAME_STATIC_BASE_URL;
-		case VAR_SITE_BASE_URL:
-			return DISPLAY_NAME_SITE_BASE_URL;
-		case VAR_SITE_AUTH_URL:
-			return DISPLAY_NAME_SITE_AUTH_URL;
-		case VAR_SITE_AUTH_REALM:
-			return DISPLAY_NAME_SITE_AUTH_REALM;
-		case VAR_FONTAWESOME_KIT:
-			return DISPLAY_NAME_FONTAWESOME_KIT;
-		case VAR_pageUri:
-			return DISPLAY_NAME_pageUri;
-		case VAR_pageMethod:
-			return DISPLAY_NAME_pageMethod;
-		case VAR_params:
-			return DISPLAY_NAME_params;
-		case VAR_userKey:
-			return DISPLAY_NAME_userKey;
-		case VAR_userFullName:
-			return DISPLAY_NAME_userFullName;
-		case VAR_userName:
-			return DISPLAY_NAME_userName;
-		case VAR_userEmail:
-			return DISPLAY_NAME_userEmail;
-		case VAR_logoutUrl:
-			return DISPLAY_NAME_logoutUrl;
-		case VAR_long0:
-			return DISPLAY_NAME_long0;
-		case VAR_long1:
-			return DISPLAY_NAME_long1;
-		case VAR_int0:
-			return DISPLAY_NAME_int0;
-		case VAR_int1:
-			return DISPLAY_NAME_int1;
-		case VAR_promiseBefore:
-			return DISPLAY_NAME_promiseBefore;
-		case VAR_classSimpleName:
-			return DISPLAY_NAME_classSimpleName;
-		case VAR_pageTitle:
-			return DISPLAY_NAME_pageTitle;
-		case VAR_roles:
-			return DISPLAY_NAME_roles;
-		case VAR_rolesRequired:
-			return DISPLAY_NAME_rolesRequired;
-		case VAR_authRolesAdmin:
-			return DISPLAY_NAME_authRolesAdmin;
-		case VAR_pagination:
-			return DISPLAY_NAME_pagination;
-		case VAR_varsQ:
-			return DISPLAY_NAME_varsQ;
-		case VAR_varsFq:
-			return DISPLAY_NAME_varsFq;
-		case VAR_varsRange:
-			return DISPLAY_NAME_varsRange;
-		case VAR_query:
-			return DISPLAY_NAME_query;
-		case VAR_promiseAfter:
-			return DISPLAY_NAME_promiseAfter;
-		case VAR_pageImageUri:
-			return DISPLAY_NAME_pageImageUri;
-		case VAR_contextIconGroup:
-			return DISPLAY_NAME_contextIconGroup;
-		case VAR_contextIconName:
-			return DISPLAY_NAME_contextIconName;
-		case VAR_contextIconCssClasses:
-			return DISPLAY_NAME_contextIconCssClasses;
-		case VAR_pageDescription:
-			return DISPLAY_NAME_pageDescription;
-		default:
-			return null;
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/page/PageLayoutGen.java
+++ b/src/gen/java/org/curriki/api/enus/page/PageLayoutGen.java
@@ -3,49 +3,48 @@ package org.curriki.api.enus.page;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.lang.Integer;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import java.lang.Long;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.vertx.core.json.JsonObject;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import java.lang.Void;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
 import java.util.List;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.lang.Object;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class PageLayoutGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(PageLayout.class);
@@ -61,10 +60,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br/> The entity siteRequest_
+	/**	<br> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> w);
@@ -99,10 +98,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Map<String, String> requestVars;
 
-	/**	<br/> The entity requestVars
+	/**	<br> The entity requestVars
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestVars(Wrap<Map<String, String>> w);
@@ -137,10 +136,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject config;
 
-	/**	<br/> The entity config
+	/**	<br> The entity config
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _config(Wrap<JsonObject> w);
@@ -175,10 +174,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ServiceRequest serviceRequest;
 
-	/**	<br/> The entity serviceRequest
+	/**	<br> The entity serviceRequest
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _serviceRequest(Wrap<ServiceRequest> w);
@@ -213,10 +212,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String staticBaseUrl;
 
-	/**	<br/> The entity staticBaseUrl
+	/**	<br> The entity staticBaseUrl
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:staticBaseUrl">Find the entity staticBaseUrl in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:staticBaseUrl">Find the entity staticBaseUrl in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _staticBaseUrl(Wrap<String> w);
@@ -239,16 +238,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrStaticBaseUrl(siteRequest_, PageLayout.staticSolrStaticBaseUrl(siteRequest_, PageLayout.staticSetStaticBaseUrl(siteRequest_, o)));
+	public static String staticSearchFqStaticBaseUrl(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrStaticBaseUrl(siteRequest_, PageLayout.staticSearchStaticBaseUrl(siteRequest_, PageLayout.staticSetStaticBaseUrl(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -262,10 +261,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String STATIC_BASE_URL;
 
-	/**	<br/> The entity STATIC_BASE_URL
+	/**	<br> The entity STATIC_BASE_URL
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:STATIC_BASE_URL">Find the entity STATIC_BASE_URL in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:STATIC_BASE_URL">Find the entity STATIC_BASE_URL in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _STATIC_BASE_URL(Wrap<String> w);
@@ -288,16 +287,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSolrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSetSTATIC_BASE_URL(siteRequest_, o)));
+	public static String staticSearchFqSTATIC_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrSTATIC_BASE_URL(siteRequest_, PageLayout.staticSearchSTATIC_BASE_URL(siteRequest_, PageLayout.staticSetSTATIC_BASE_URL(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -311,10 +310,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_BASE_URL;
 
-	/**	<br/> The entity SITE_BASE_URL
+	/**	<br> The entity SITE_BASE_URL
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_BASE_URL">Find the entity SITE_BASE_URL in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_BASE_URL">Find the entity SITE_BASE_URL in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_BASE_URL(Wrap<String> w);
@@ -337,16 +336,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrSITE_BASE_URL(siteRequest_, PageLayout.staticSolrSITE_BASE_URL(siteRequest_, PageLayout.staticSetSITE_BASE_URL(siteRequest_, o)));
+	public static String staticSearchFqSITE_BASE_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrSITE_BASE_URL(siteRequest_, PageLayout.staticSearchSITE_BASE_URL(siteRequest_, PageLayout.staticSetSITE_BASE_URL(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -360,10 +359,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_AUTH_URL;
 
-	/**	<br/> The entity SITE_AUTH_URL
+	/**	<br> The entity SITE_AUTH_URL
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_URL">Find the entity SITE_AUTH_URL in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_URL">Find the entity SITE_AUTH_URL in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_AUTH_URL(Wrap<String> w);
@@ -386,16 +385,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrSITE_AUTH_URL(siteRequest_, PageLayout.staticSolrSITE_AUTH_URL(siteRequest_, PageLayout.staticSetSITE_AUTH_URL(siteRequest_, o)));
+	public static String staticSearchFqSITE_AUTH_URL(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrSITE_AUTH_URL(siteRequest_, PageLayout.staticSearchSITE_AUTH_URL(siteRequest_, PageLayout.staticSetSITE_AUTH_URL(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -409,10 +408,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String SITE_AUTH_REALM;
 
-	/**	<br/> The entity SITE_AUTH_REALM
+	/**	<br> The entity SITE_AUTH_REALM
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_REALM">Find the entity SITE_AUTH_REALM in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:SITE_AUTH_REALM">Find the entity SITE_AUTH_REALM in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _SITE_AUTH_REALM(Wrap<String> w);
@@ -435,16 +434,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSolrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSetSITE_AUTH_REALM(siteRequest_, o)));
+	public static String staticSearchFqSITE_AUTH_REALM(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrSITE_AUTH_REALM(siteRequest_, PageLayout.staticSearchSITE_AUTH_REALM(siteRequest_, PageLayout.staticSetSITE_AUTH_REALM(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -458,10 +457,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String FONTAWESOME_KIT;
 
-	/**	<br/> The entity FONTAWESOME_KIT
+	/**	<br> The entity FONTAWESOME_KIT
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:FONTAWESOME_KIT">Find the entity FONTAWESOME_KIT in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:FONTAWESOME_KIT">Find the entity FONTAWESOME_KIT in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _FONTAWESOME_KIT(Wrap<String> w);
@@ -484,16 +483,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSolrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSetFONTAWESOME_KIT(siteRequest_, o)));
+	public static String staticSearchFqFONTAWESOME_KIT(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrFONTAWESOME_KIT(siteRequest_, PageLayout.staticSearchFONTAWESOME_KIT(siteRequest_, PageLayout.staticSetFONTAWESOME_KIT(siteRequest_, o)));
 	}
 
 	/////////////
@@ -507,10 +506,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageUri;
 
-	/**	<br/> The entity pageUri
+	/**	<br> The entity pageUri
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUri">Find the entity pageUri in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageUri">Find the entity pageUri in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageUri(Wrap<String> w);
@@ -533,16 +532,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrPageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageUri(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrPageUri(siteRequest_, PageLayout.staticSolrPageUri(siteRequest_, PageLayout.staticSetPageUri(siteRequest_, o)));
+	public static String staticSearchFqPageUri(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrPageUri(siteRequest_, PageLayout.staticSearchPageUri(siteRequest_, PageLayout.staticSetPageUri(siteRequest_, o)));
 	}
 
 	////////////////
@@ -556,10 +555,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageMethod;
 
-	/**	<br/> The entity pageMethod
+	/**	<br> The entity pageMethod
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageMethod">Find the entity pageMethod in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageMethod">Find the entity pageMethod in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageMethod(Wrap<String> w);
@@ -582,16 +581,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrPageMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageMethod(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrPageMethod(siteRequest_, PageLayout.staticSolrPageMethod(siteRequest_, PageLayout.staticSetPageMethod(siteRequest_, o)));
+	public static String staticSearchFqPageMethod(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrPageMethod(siteRequest_, PageLayout.staticSearchPageMethod(siteRequest_, PageLayout.staticSetPageMethod(siteRequest_, o)));
 	}
 
 	////////////
@@ -604,10 +603,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject params;
 
-	/**	<br/> The entity params
+	/**	<br> The entity params
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:params">Find the entity params in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:params">Find the entity params in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _params(Wrap<JsonObject> w);
@@ -643,10 +642,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br/> The entity userKey
+	/**	<br> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> w);
@@ -676,16 +675,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrUserKey(siteRequest_, PageLayout.staticSolrUserKey(siteRequest_, PageLayout.staticSetUserKey(siteRequest_, o)));
+	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrUserKey(siteRequest_, PageLayout.staticSearchUserKey(siteRequest_, PageLayout.staticSetUserKey(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -699,10 +698,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br/> The entity userFullName
+	/**	<br> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> w);
@@ -725,16 +724,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrUserFullName(siteRequest_, PageLayout.staticSolrUserFullName(siteRequest_, PageLayout.staticSetUserFullName(siteRequest_, o)));
+	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrUserFullName(siteRequest_, PageLayout.staticSearchUserFullName(siteRequest_, PageLayout.staticSetUserFullName(siteRequest_, o)));
 	}
 
 	//////////////
@@ -748,10 +747,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br/> The entity userName
+	/**	<br> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> w);
@@ -774,16 +773,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrUserName(siteRequest_, PageLayout.staticSolrUserName(siteRequest_, PageLayout.staticSetUserName(siteRequest_, o)));
+	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrUserName(siteRequest_, PageLayout.staticSearchUserName(siteRequest_, PageLayout.staticSetUserName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -797,10 +796,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br/> The entity userEmail
+	/**	<br> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> w);
@@ -823,16 +822,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrUserEmail(siteRequest_, PageLayout.staticSolrUserEmail(siteRequest_, PageLayout.staticSetUserEmail(siteRequest_, o)));
+	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrUserEmail(siteRequest_, PageLayout.staticSearchUserEmail(siteRequest_, PageLayout.staticSetUserEmail(siteRequest_, o)));
 	}
 
 	///////////////
@@ -846,10 +845,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String logoutUrl;
 
-	/**	<br/> The entity logoutUrl
+	/**	<br> The entity logoutUrl
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:logoutUrl">Find the entity logoutUrl in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:logoutUrl">Find the entity logoutUrl in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _logoutUrl(Wrap<String> w);
@@ -872,16 +871,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrLogoutUrl(siteRequest_, PageLayout.staticSolrLogoutUrl(siteRequest_, PageLayout.staticSetLogoutUrl(siteRequest_, o)));
+	public static String staticSearchFqLogoutUrl(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrLogoutUrl(siteRequest_, PageLayout.staticSearchLogoutUrl(siteRequest_, PageLayout.staticSetLogoutUrl(siteRequest_, o)));
 	}
 
 	///////////
@@ -896,10 +895,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long long0;
 
-	/**	<br/> The entity long0
+	/**	<br> The entity long0
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long0">Find the entity long0 in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long0">Find the entity long0 in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _long0(Wrap<Long> w);
@@ -929,16 +928,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSolrLong0(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchLong0(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrLong0(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrLong0(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLong0(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrLong0(siteRequest_, PageLayout.staticSolrLong0(siteRequest_, PageLayout.staticSetLong0(siteRequest_, o)));
+	public static String staticSearchFqLong0(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrLong0(siteRequest_, PageLayout.staticSearchLong0(siteRequest_, PageLayout.staticSetLong0(siteRequest_, o)));
 	}
 
 	///////////
@@ -953,10 +952,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long long1;
 
-	/**	<br/> The entity long1
+	/**	<br> The entity long1
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long1">Find the entity long1 in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:long1">Find the entity long1 in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _long1(Wrap<Long> w);
@@ -986,16 +985,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Long staticSolrLong1(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchLong1(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrLong1(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrLong1(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqLong1(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrLong1(siteRequest_, PageLayout.staticSolrLong1(siteRequest_, PageLayout.staticSetLong1(siteRequest_, o)));
+	public static String staticSearchFqLong1(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrLong1(siteRequest_, PageLayout.staticSearchLong1(siteRequest_, PageLayout.staticSetLong1(siteRequest_, o)));
 	}
 
 	//////////
@@ -1010,10 +1009,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer int0;
 
-	/**	<br/> The entity int0
+	/**	<br> The entity int0
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int0">Find the entity int0 in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int0">Find the entity int0 in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _int0(Wrap<Integer> w);
@@ -1043,16 +1042,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Integer staticSolrInt0(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchInt0(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrInt0(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrInt0(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInt0(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrInt0(siteRequest_, PageLayout.staticSolrInt0(siteRequest_, PageLayout.staticSetInt0(siteRequest_, o)));
+	public static String staticSearchFqInt0(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrInt0(siteRequest_, PageLayout.staticSearchInt0(siteRequest_, PageLayout.staticSetInt0(siteRequest_, o)));
 	}
 
 	//////////
@@ -1067,10 +1066,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Integer int1;
 
-	/**	<br/> The entity int1
+	/**	<br> The entity int1
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int1">Find the entity int1 in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:int1">Find the entity int1 in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _int1(Wrap<Integer> w);
@@ -1100,16 +1099,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static Integer staticSolrInt1(SiteRequestEnUS siteRequest_, Integer o) {
+	public static Integer staticSearchInt1(SiteRequestEnUS siteRequest_, Integer o) {
 		return o;
 	}
 
-	public static String staticSolrStrInt1(SiteRequestEnUS siteRequest_, Integer o) {
+	public static String staticSearchStrInt1(SiteRequestEnUS siteRequest_, Integer o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqInt1(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrInt1(siteRequest_, PageLayout.staticSolrInt1(siteRequest_, PageLayout.staticSetInt1(siteRequest_, o)));
+	public static String staticSearchFqInt1(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrInt1(siteRequest_, PageLayout.staticSearchInt1(siteRequest_, PageLayout.staticSetInt1(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1123,10 +1122,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Void promiseBefore;
 
-	/**	<br/> The entity promiseBefore
+	/**	<br> The entity promiseBefore
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseBefore">Find the entity promiseBefore in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseBefore">Find the entity promiseBefore in Solr</a>
+	 * <br>
 	 * @param promise is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _promiseBefore(Promise<Void> promise);
@@ -1165,10 +1164,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String classSimpleName;
 
-	/**	<br/> The entity classSimpleName
+	/**	<br> The entity classSimpleName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:classSimpleName">Find the entity classSimpleName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _classSimpleName(Wrap<String> w);
@@ -1191,16 +1190,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrClassSimpleName(siteRequest_, PageLayout.staticSolrClassSimpleName(siteRequest_, PageLayout.staticSetClassSimpleName(siteRequest_, o)));
+	public static String staticSearchFqClassSimpleName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrClassSimpleName(siteRequest_, PageLayout.staticSearchClassSimpleName(siteRequest_, PageLayout.staticSetClassSimpleName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -1214,10 +1213,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageTitle;
 
-	/**	<br/> The entity pageTitle
+	/**	<br> The entity pageTitle
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageTitle">Find the entity pageTitle in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageTitle">Find the entity pageTitle in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageTitle(Wrap<String> w);
@@ -1240,16 +1239,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrPageTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageTitle(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageTitle(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageTitle(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrPageTitle(siteRequest_, PageLayout.staticSolrPageTitle(siteRequest_, PageLayout.staticSetPageTitle(siteRequest_, o)));
+	public static String staticSearchFqPageTitle(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrPageTitle(siteRequest_, PageLayout.staticSearchPageTitle(siteRequest_, PageLayout.staticSetPageTitle(siteRequest_, o)));
 	}
 
 	///////////
@@ -1257,18 +1256,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity roles
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> roles = new ArrayList<String>();
 
-	/**	<br/> The entity roles
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:roles">Find the entity roles in Solr</a>
-	 * <br/>
-	 * @param roles is the entity already constructed. 
+	/**	<br> The entity roles
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:roles">Find the entity roles in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _roles(List<String> l);
 
@@ -1306,16 +1305,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRoles(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrRoles(siteRequest_, PageLayout.staticSolrRoles(siteRequest_, PageLayout.staticSetRoles(siteRequest_, o)));
+	public static String staticSearchFqRoles(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrRoles(siteRequest_, PageLayout.staticSearchRoles(siteRequest_, PageLayout.staticSetRoles(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1323,18 +1322,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////////////
 
 	/**	 The entity rolesRequired
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> rolesRequired = new ArrayList<String>();
 
-	/**	<br/> The entity rolesRequired
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rolesRequired">Find the entity rolesRequired in Solr</a>
-	 * <br/>
-	 * @param rolesRequired is the entity already constructed. 
+	/**	<br> The entity rolesRequired
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:rolesRequired">Find the entity rolesRequired in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _rolesRequired(List<String> l);
 
@@ -1372,16 +1371,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRolesRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRolesRequired(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRolesRequired(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrRolesRequired(siteRequest_, PageLayout.staticSolrRolesRequired(siteRequest_, PageLayout.staticSetRolesRequired(siteRequest_, o)));
+	public static String staticSearchFqRolesRequired(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrRolesRequired(siteRequest_, PageLayout.staticSearchRolesRequired(siteRequest_, PageLayout.staticSetRolesRequired(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -1389,18 +1388,18 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////////////
 
 	/**	 The entity authRolesAdmin
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> authRolesAdmin = new ArrayList<String>();
 
-	/**	<br/> The entity authRolesAdmin
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:authRolesAdmin">Find the entity authRolesAdmin in Solr</a>
-	 * <br/>
-	 * @param authRolesAdmin is the entity already constructed. 
+	/**	<br> The entity authRolesAdmin
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:authRolesAdmin">Find the entity authRolesAdmin in Solr</a>
+	 * <br>
+	 * @param l is the entity already constructed. 
 	 **/
 	protected abstract void _authRolesAdmin(List<String> l);
 
@@ -1438,16 +1437,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrAuthRolesAdmin(siteRequest_, PageLayout.staticSolrAuthRolesAdmin(siteRequest_, PageLayout.staticSetAuthRolesAdmin(siteRequest_, o)));
+	public static String staticSearchFqAuthRolesAdmin(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrAuthRolesAdmin(siteRequest_, PageLayout.staticSearchAuthRolesAdmin(siteRequest_, PageLayout.staticSetAuthRolesAdmin(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1455,15 +1454,15 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////////
 
 	/**	 The entity pagination
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject pagination = new JsonObject();
 
-	/**	<br/> The entity pagination
-	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pagination">Find the entity pagination in Solr</a>
-	 * <br/>
+	/**	<br> The entity pagination
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pagination">Find the entity pagination in Solr</a>
+	 * <br>
 	 * @param pagination is the entity already constructed. 
 	 **/
 	protected abstract void _pagination(JsonObject pagination);
@@ -1488,16 +1487,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity varsQ
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsQ = new JsonObject();
 
-	/**	<br/> The entity varsQ
-	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsQ">Find the entity varsQ in Solr</a>
-	 * <br/>
-	 * @param varsQ is the entity already constructed. 
+	/**	<br> The entity varsQ
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsQ">Find the entity varsQ in Solr</a>
+	 * <br>
+	 * @param vars is the entity already constructed. 
 	 **/
 	protected abstract void _varsQ(JsonObject vars);
 
@@ -1521,16 +1520,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	////////////
 
 	/**	 The entity varsFq
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsFq = new JsonObject();
 
-	/**	<br/> The entity varsFq
-	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsFq">Find the entity varsFq in Solr</a>
-	 * <br/>
-	 * @param varsFq is the entity already constructed. 
+	/**	<br> The entity varsFq
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsFq">Find the entity varsFq in Solr</a>
+	 * <br>
+	 * @param vars is the entity already constructed. 
 	 **/
 	protected abstract void _varsFq(JsonObject vars);
 
@@ -1554,16 +1553,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////////
 
 	/**	 The entity varsRange
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject varsRange = new JsonObject();
 
-	/**	<br/> The entity varsRange
-	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsRange">Find the entity varsRange in Solr</a>
-	 * <br/>
-	 * @param varsRange is the entity already constructed. 
+	/**	<br> The entity varsRange
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:varsRange">Find the entity varsRange in Solr</a>
+	 * <br>
+	 * @param vars is the entity already constructed. 
 	 **/
 	protected abstract void _varsRange(JsonObject vars);
 
@@ -1587,15 +1586,15 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	///////////
 
 	/**	 The entity query
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut JsonObject(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject query = new JsonObject();
 
-	/**	<br/> The entity query
-	 *  It is constructed before being initialized with the constructor by default JsonObject(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:query">Find the entity query in Solr</a>
-	 * <br/>
+	/**	<br> The entity query
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:query">Find the entity query in Solr</a>
+	 * <br>
 	 * @param query is the entity already constructed. 
 	 **/
 	protected abstract void _query(JsonObject query);
@@ -1626,10 +1625,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Void promiseAfter;
 
-	/**	<br/> The entity promiseAfter
+	/**	<br> The entity promiseAfter
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseAfter">Find the entity promiseAfter in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:promiseAfter">Find the entity promiseAfter in Solr</a>
+	 * <br>
 	 * @param promise is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _promiseAfter(Promise<Void> promise);
@@ -1668,10 +1667,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageImageUri;
 
-	/**	<br/> The entity pageImageUri
+	/**	<br> The entity pageImageUri
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageImageUri">Find the entity pageImageUri in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageImageUri">Find the entity pageImageUri in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageImageUri(Wrap<String> w);
@@ -1694,16 +1693,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageImageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageImageUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageImageUri(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrPageImageUri(siteRequest_, PageLayout.staticSolrPageImageUri(siteRequest_, PageLayout.staticSetPageImageUri(siteRequest_, o)));
+	public static String staticSearchFqPageImageUri(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrPageImageUri(siteRequest_, PageLayout.staticSearchPageImageUri(siteRequest_, PageLayout.staticSetPageImageUri(siteRequest_, o)));
 	}
 
 	//////////////////////
@@ -1717,10 +1716,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconGroup;
 
-	/**	<br/> The entity contextIconGroup
+	/**	<br> The entity contextIconGroup
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconGroup">Find the entity contextIconGroup in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconGroup">Find the entity contextIconGroup in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconGroup(Wrap<String> w);
@@ -1743,16 +1742,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrContextIconGroup(siteRequest_, PageLayout.staticSolrContextIconGroup(siteRequest_, PageLayout.staticSetContextIconGroup(siteRequest_, o)));
+	public static String staticSearchFqContextIconGroup(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrContextIconGroup(siteRequest_, PageLayout.staticSearchContextIconGroup(siteRequest_, PageLayout.staticSetContextIconGroup(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1766,10 +1765,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconName;
 
-	/**	<br/> The entity contextIconName
+	/**	<br> The entity contextIconName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconName">Find the entity contextIconName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconName">Find the entity contextIconName in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconName(Wrap<String> w);
@@ -1792,16 +1791,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrContextIconName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchContextIconName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrContextIconName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrContextIconName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContextIconName(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrContextIconName(siteRequest_, PageLayout.staticSolrContextIconName(siteRequest_, PageLayout.staticSetContextIconName(siteRequest_, o)));
+	public static String staticSearchFqContextIconName(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrContextIconName(siteRequest_, PageLayout.staticSearchContextIconName(siteRequest_, PageLayout.staticSetContextIconName(siteRequest_, o)));
 	}
 
 	///////////////////////////
@@ -1815,10 +1814,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String contextIconCssClasses;
 
-	/**	<br/> The entity contextIconCssClasses
+	/**	<br> The entity contextIconCssClasses
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconCssClasses">Find the entity contextIconCssClasses in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:contextIconCssClasses">Find the entity contextIconCssClasses in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _contextIconCssClasses(Wrap<String> w);
@@ -1841,16 +1840,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrContextIconCssClasses(siteRequest_, PageLayout.staticSolrContextIconCssClasses(siteRequest_, PageLayout.staticSetContextIconCssClasses(siteRequest_, o)));
+	public static String staticSearchFqContextIconCssClasses(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrContextIconCssClasses(siteRequest_, PageLayout.staticSearchContextIconCssClasses(siteRequest_, PageLayout.staticSetContextIconCssClasses(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -1864,10 +1863,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String pageDescription;
 
-	/**	<br/> The entity pageDescription
+	/**	<br> The entity pageDescription
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageDescription">Find the entity pageDescription in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.page.PageLayout&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:pageDescription">Find the entity pageDescription in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _pageDescription(Wrap<String> w);
@@ -1890,16 +1889,16 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		return (PageLayout)this;
 	}
 
-	public static String staticSolrPageDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchPageDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrPageDescription(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrPageDescription(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqPageDescription(SiteRequestEnUS siteRequest_, String o) {
-		return PageLayout.staticSolrStrPageDescription(siteRequest_, PageLayout.staticSolrPageDescription(siteRequest_, PageLayout.staticSetPageDescription(siteRequest_, o)));
+	public static String staticSearchFqPageDescription(SiteRequestEnUS siteRequest_, String o) {
+		return PageLayout.staticSearchStrPageDescription(siteRequest_, PageLayout.staticSearchPageDescription(siteRequest_, PageLayout.staticSetPageDescription(siteRequest_, o)));
 	}
 
 	//////////////
@@ -2225,244 +2224,206 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrPageLayout(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSolrStaticBaseUrl(siteRequest_, (String)o);
+			return PageLayout.staticSearchStaticBaseUrl(siteRequest_, (String)o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSolrSTATIC_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchSTATIC_BASE_URL(siteRequest_, (String)o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSolrSITE_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchSITE_BASE_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSolrSITE_AUTH_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchSITE_AUTH_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSolrSITE_AUTH_REALM(siteRequest_, (String)o);
+			return PageLayout.staticSearchSITE_AUTH_REALM(siteRequest_, (String)o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSolrFONTAWESOME_KIT(siteRequest_, (String)o);
+			return PageLayout.staticSearchFONTAWESOME_KIT(siteRequest_, (String)o);
 		case "pageUri":
-			return PageLayout.staticSolrPageUri(siteRequest_, (String)o);
+			return PageLayout.staticSearchPageUri(siteRequest_, (String)o);
 		case "pageMethod":
-			return PageLayout.staticSolrPageMethod(siteRequest_, (String)o);
+			return PageLayout.staticSearchPageMethod(siteRequest_, (String)o);
 		case "userKey":
-			return PageLayout.staticSolrUserKey(siteRequest_, (Long)o);
+			return PageLayout.staticSearchUserKey(siteRequest_, (Long)o);
 		case "userFullName":
-			return PageLayout.staticSolrUserFullName(siteRequest_, (String)o);
+			return PageLayout.staticSearchUserFullName(siteRequest_, (String)o);
 		case "userName":
-			return PageLayout.staticSolrUserName(siteRequest_, (String)o);
+			return PageLayout.staticSearchUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return PageLayout.staticSolrUserEmail(siteRequest_, (String)o);
+			return PageLayout.staticSearchUserEmail(siteRequest_, (String)o);
 		case "logoutUrl":
-			return PageLayout.staticSolrLogoutUrl(siteRequest_, (String)o);
+			return PageLayout.staticSearchLogoutUrl(siteRequest_, (String)o);
 		case "long0":
-			return PageLayout.staticSolrLong0(siteRequest_, (Long)o);
+			return PageLayout.staticSearchLong0(siteRequest_, (Long)o);
 		case "long1":
-			return PageLayout.staticSolrLong1(siteRequest_, (Long)o);
+			return PageLayout.staticSearchLong1(siteRequest_, (Long)o);
 		case "int0":
-			return PageLayout.staticSolrInt0(siteRequest_, (Integer)o);
+			return PageLayout.staticSearchInt0(siteRequest_, (Integer)o);
 		case "int1":
-			return PageLayout.staticSolrInt1(siteRequest_, (Integer)o);
+			return PageLayout.staticSearchInt1(siteRequest_, (Integer)o);
 		case "classSimpleName":
-			return PageLayout.staticSolrClassSimpleName(siteRequest_, (String)o);
+			return PageLayout.staticSearchClassSimpleName(siteRequest_, (String)o);
 		case "pageTitle":
-			return PageLayout.staticSolrPageTitle(siteRequest_, (String)o);
+			return PageLayout.staticSearchPageTitle(siteRequest_, (String)o);
 		case "roles":
-			return PageLayout.staticSolrRoles(siteRequest_, (String)o);
+			return PageLayout.staticSearchRoles(siteRequest_, (String)o);
 		case "rolesRequired":
-			return PageLayout.staticSolrRolesRequired(siteRequest_, (String)o);
+			return PageLayout.staticSearchRolesRequired(siteRequest_, (String)o);
 		case "authRolesAdmin":
-			return PageLayout.staticSolrAuthRolesAdmin(siteRequest_, (String)o);
+			return PageLayout.staticSearchAuthRolesAdmin(siteRequest_, (String)o);
 		case "pageImageUri":
-			return PageLayout.staticSolrPageImageUri(siteRequest_, (String)o);
+			return PageLayout.staticSearchPageImageUri(siteRequest_, (String)o);
 		case "contextIconGroup":
-			return PageLayout.staticSolrContextIconGroup(siteRequest_, (String)o);
+			return PageLayout.staticSearchContextIconGroup(siteRequest_, (String)o);
 		case "contextIconName":
-			return PageLayout.staticSolrContextIconName(siteRequest_, (String)o);
+			return PageLayout.staticSearchContextIconName(siteRequest_, (String)o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSolrContextIconCssClasses(siteRequest_, (String)o);
+			return PageLayout.staticSearchContextIconCssClasses(siteRequest_, (String)o);
 		case "pageDescription":
-			return PageLayout.staticSolrPageDescription(siteRequest_, (String)o);
+			return PageLayout.staticSearchPageDescription(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrPageLayout(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrPageLayout(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSolrStrStaticBaseUrl(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrStaticBaseUrl(siteRequest_, (String)o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSolrStrSTATIC_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrSTATIC_BASE_URL(siteRequest_, (String)o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSolrStrSITE_BASE_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrSITE_BASE_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSolrStrSITE_AUTH_URL(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrSITE_AUTH_URL(siteRequest_, (String)o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSolrStrSITE_AUTH_REALM(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrSITE_AUTH_REALM(siteRequest_, (String)o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSolrStrFONTAWESOME_KIT(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrFONTAWESOME_KIT(siteRequest_, (String)o);
 		case "pageUri":
-			return PageLayout.staticSolrStrPageUri(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrPageUri(siteRequest_, (String)o);
 		case "pageMethod":
-			return PageLayout.staticSolrStrPageMethod(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrPageMethod(siteRequest_, (String)o);
 		case "userKey":
-			return PageLayout.staticSolrStrUserKey(siteRequest_, (Long)o);
+			return PageLayout.staticSearchStrUserKey(siteRequest_, (Long)o);
 		case "userFullName":
-			return PageLayout.staticSolrStrUserFullName(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrUserFullName(siteRequest_, (String)o);
 		case "userName":
-			return PageLayout.staticSolrStrUserName(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrUserName(siteRequest_, (String)o);
 		case "userEmail":
-			return PageLayout.staticSolrStrUserEmail(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrUserEmail(siteRequest_, (String)o);
 		case "logoutUrl":
-			return PageLayout.staticSolrStrLogoutUrl(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrLogoutUrl(siteRequest_, (String)o);
 		case "long0":
-			return PageLayout.staticSolrStrLong0(siteRequest_, (Long)o);
+			return PageLayout.staticSearchStrLong0(siteRequest_, (Long)o);
 		case "long1":
-			return PageLayout.staticSolrStrLong1(siteRequest_, (Long)o);
+			return PageLayout.staticSearchStrLong1(siteRequest_, (Long)o);
 		case "int0":
-			return PageLayout.staticSolrStrInt0(siteRequest_, (Integer)o);
+			return PageLayout.staticSearchStrInt0(siteRequest_, (Integer)o);
 		case "int1":
-			return PageLayout.staticSolrStrInt1(siteRequest_, (Integer)o);
+			return PageLayout.staticSearchStrInt1(siteRequest_, (Integer)o);
 		case "classSimpleName":
-			return PageLayout.staticSolrStrClassSimpleName(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrClassSimpleName(siteRequest_, (String)o);
 		case "pageTitle":
-			return PageLayout.staticSolrStrPageTitle(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrPageTitle(siteRequest_, (String)o);
 		case "roles":
-			return PageLayout.staticSolrStrRoles(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrRoles(siteRequest_, (String)o);
 		case "rolesRequired":
-			return PageLayout.staticSolrStrRolesRequired(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrRolesRequired(siteRequest_, (String)o);
 		case "authRolesAdmin":
-			return PageLayout.staticSolrStrAuthRolesAdmin(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrAuthRolesAdmin(siteRequest_, (String)o);
 		case "pageImageUri":
-			return PageLayout.staticSolrStrPageImageUri(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrPageImageUri(siteRequest_, (String)o);
 		case "contextIconGroup":
-			return PageLayout.staticSolrStrContextIconGroup(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrContextIconGroup(siteRequest_, (String)o);
 		case "contextIconName":
-			return PageLayout.staticSolrStrContextIconName(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrContextIconName(siteRequest_, (String)o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSolrStrContextIconCssClasses(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrContextIconCssClasses(siteRequest_, (String)o);
 		case "pageDescription":
-			return PageLayout.staticSolrStrPageDescription(siteRequest_, (String)o);
+			return PageLayout.staticSearchStrPageDescription(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqPageLayout(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqPageLayout(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqPageLayout(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqPageLayout(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "staticBaseUrl":
-			return PageLayout.staticSolrFqStaticBaseUrl(siteRequest_, o);
+			return PageLayout.staticSearchFqStaticBaseUrl(siteRequest_, o);
 		case "STATIC_BASE_URL":
-			return PageLayout.staticSolrFqSTATIC_BASE_URL(siteRequest_, o);
+			return PageLayout.staticSearchFqSTATIC_BASE_URL(siteRequest_, o);
 		case "SITE_BASE_URL":
-			return PageLayout.staticSolrFqSITE_BASE_URL(siteRequest_, o);
+			return PageLayout.staticSearchFqSITE_BASE_URL(siteRequest_, o);
 		case "SITE_AUTH_URL":
-			return PageLayout.staticSolrFqSITE_AUTH_URL(siteRequest_, o);
+			return PageLayout.staticSearchFqSITE_AUTH_URL(siteRequest_, o);
 		case "SITE_AUTH_REALM":
-			return PageLayout.staticSolrFqSITE_AUTH_REALM(siteRequest_, o);
+			return PageLayout.staticSearchFqSITE_AUTH_REALM(siteRequest_, o);
 		case "FONTAWESOME_KIT":
-			return PageLayout.staticSolrFqFONTAWESOME_KIT(siteRequest_, o);
+			return PageLayout.staticSearchFqFONTAWESOME_KIT(siteRequest_, o);
 		case "pageUri":
-			return PageLayout.staticSolrFqPageUri(siteRequest_, o);
+			return PageLayout.staticSearchFqPageUri(siteRequest_, o);
 		case "pageMethod":
-			return PageLayout.staticSolrFqPageMethod(siteRequest_, o);
+			return PageLayout.staticSearchFqPageMethod(siteRequest_, o);
 		case "userKey":
-			return PageLayout.staticSolrFqUserKey(siteRequest_, o);
+			return PageLayout.staticSearchFqUserKey(siteRequest_, o);
 		case "userFullName":
-			return PageLayout.staticSolrFqUserFullName(siteRequest_, o);
+			return PageLayout.staticSearchFqUserFullName(siteRequest_, o);
 		case "userName":
-			return PageLayout.staticSolrFqUserName(siteRequest_, o);
+			return PageLayout.staticSearchFqUserName(siteRequest_, o);
 		case "userEmail":
-			return PageLayout.staticSolrFqUserEmail(siteRequest_, o);
+			return PageLayout.staticSearchFqUserEmail(siteRequest_, o);
 		case "logoutUrl":
-			return PageLayout.staticSolrFqLogoutUrl(siteRequest_, o);
+			return PageLayout.staticSearchFqLogoutUrl(siteRequest_, o);
 		case "long0":
-			return PageLayout.staticSolrFqLong0(siteRequest_, o);
+			return PageLayout.staticSearchFqLong0(siteRequest_, o);
 		case "long1":
-			return PageLayout.staticSolrFqLong1(siteRequest_, o);
+			return PageLayout.staticSearchFqLong1(siteRequest_, o);
 		case "int0":
-			return PageLayout.staticSolrFqInt0(siteRequest_, o);
+			return PageLayout.staticSearchFqInt0(siteRequest_, o);
 		case "int1":
-			return PageLayout.staticSolrFqInt1(siteRequest_, o);
+			return PageLayout.staticSearchFqInt1(siteRequest_, o);
 		case "classSimpleName":
-			return PageLayout.staticSolrFqClassSimpleName(siteRequest_, o);
+			return PageLayout.staticSearchFqClassSimpleName(siteRequest_, o);
 		case "pageTitle":
-			return PageLayout.staticSolrFqPageTitle(siteRequest_, o);
+			return PageLayout.staticSearchFqPageTitle(siteRequest_, o);
 		case "roles":
-			return PageLayout.staticSolrFqRoles(siteRequest_, o);
+			return PageLayout.staticSearchFqRoles(siteRequest_, o);
 		case "rolesRequired":
-			return PageLayout.staticSolrFqRolesRequired(siteRequest_, o);
+			return PageLayout.staticSearchFqRolesRequired(siteRequest_, o);
 		case "authRolesAdmin":
-			return PageLayout.staticSolrFqAuthRolesAdmin(siteRequest_, o);
+			return PageLayout.staticSearchFqAuthRolesAdmin(siteRequest_, o);
 		case "pageImageUri":
-			return PageLayout.staticSolrFqPageImageUri(siteRequest_, o);
+			return PageLayout.staticSearchFqPageImageUri(siteRequest_, o);
 		case "contextIconGroup":
-			return PageLayout.staticSolrFqContextIconGroup(siteRequest_, o);
+			return PageLayout.staticSearchFqContextIconGroup(siteRequest_, o);
 		case "contextIconName":
-			return PageLayout.staticSolrFqContextIconName(siteRequest_, o);
+			return PageLayout.staticSearchFqContextIconName(siteRequest_, o);
 		case "contextIconCssClasses":
-			return PageLayout.staticSolrFqContextIconCssClasses(siteRequest_, o);
+			return PageLayout.staticSearchFqContextIconCssClasses(siteRequest_, o);
 		case "pageDescription":
-			return PageLayout.staticSolrFqPageDescription(siteRequest_, o);
+			return PageLayout.staticSearchFqPageDescription(siteRequest_, o);
 			default:
 				return null;
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = definePageLayout(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object definePageLayout(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return null;
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestPageLayout() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof PageLayout) {
-			PageLayout original = (PageLayout)o;
 		}
 	}
 
@@ -2514,4 +2475,132 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	public static final String VAR_contextIconName = "contextIconName";
 	public static final String VAR_contextIconCssClasses = "contextIconCssClasses";
 	public static final String VAR_pageDescription = "pageDescription";
+
+	public static final String DISPLAY_NAME_siteRequest_ = "";
+	public static final String DISPLAY_NAME_requestVars = "";
+	public static final String DISPLAY_NAME_config = "";
+	public static final String DISPLAY_NAME_serviceRequest = "";
+	public static final String DISPLAY_NAME_staticBaseUrl = "";
+	public static final String DISPLAY_NAME_STATIC_BASE_URL = "";
+	public static final String DISPLAY_NAME_SITE_BASE_URL = "";
+	public static final String DISPLAY_NAME_SITE_AUTH_URL = "";
+	public static final String DISPLAY_NAME_SITE_AUTH_REALM = "";
+	public static final String DISPLAY_NAME_FONTAWESOME_KIT = "";
+	public static final String DISPLAY_NAME_pageUri = "";
+	public static final String DISPLAY_NAME_pageMethod = "";
+	public static final String DISPLAY_NAME_params = "";
+	public static final String DISPLAY_NAME_userKey = "";
+	public static final String DISPLAY_NAME_userFullName = "";
+	public static final String DISPLAY_NAME_userName = "";
+	public static final String DISPLAY_NAME_userEmail = "";
+	public static final String DISPLAY_NAME_logoutUrl = "";
+	public static final String DISPLAY_NAME_long0 = "";
+	public static final String DISPLAY_NAME_long1 = "";
+	public static final String DISPLAY_NAME_int0 = "";
+	public static final String DISPLAY_NAME_int1 = "";
+	public static final String DISPLAY_NAME_promiseBefore = "";
+	public static final String DISPLAY_NAME_classSimpleName = "";
+	public static final String DISPLAY_NAME_pageTitle = "";
+	public static final String DISPLAY_NAME_roles = "";
+	public static final String DISPLAY_NAME_rolesRequired = "";
+	public static final String DISPLAY_NAME_authRolesAdmin = "";
+	public static final String DISPLAY_NAME_pagination = "";
+	public static final String DISPLAY_NAME_varsQ = "";
+	public static final String DISPLAY_NAME_varsFq = "";
+	public static final String DISPLAY_NAME_varsRange = "";
+	public static final String DISPLAY_NAME_query = "";
+	public static final String DISPLAY_NAME_promiseAfter = "";
+	public static final String DISPLAY_NAME_pageImageUri = "";
+	public static final String DISPLAY_NAME_contextIconGroup = "";
+	public static final String DISPLAY_NAME_contextIconName = "";
+	public static final String DISPLAY_NAME_contextIconCssClasses = "";
+	public static final String DISPLAY_NAME_pageDescription = "";
+
+	public static String displayNameForClass(String var) {
+		return PageLayout.displayNamePageLayout(var);
+	}
+	public static String displayNamePageLayout(String var) {
+		switch(var) {
+		case VAR_siteRequest_:
+			return DISPLAY_NAME_siteRequest_;
+		case VAR_requestVars:
+			return DISPLAY_NAME_requestVars;
+		case VAR_config:
+			return DISPLAY_NAME_config;
+		case VAR_serviceRequest:
+			return DISPLAY_NAME_serviceRequest;
+		case VAR_staticBaseUrl:
+			return DISPLAY_NAME_staticBaseUrl;
+		case VAR_STATIC_BASE_URL:
+			return DISPLAY_NAME_STATIC_BASE_URL;
+		case VAR_SITE_BASE_URL:
+			return DISPLAY_NAME_SITE_BASE_URL;
+		case VAR_SITE_AUTH_URL:
+			return DISPLAY_NAME_SITE_AUTH_URL;
+		case VAR_SITE_AUTH_REALM:
+			return DISPLAY_NAME_SITE_AUTH_REALM;
+		case VAR_FONTAWESOME_KIT:
+			return DISPLAY_NAME_FONTAWESOME_KIT;
+		case VAR_pageUri:
+			return DISPLAY_NAME_pageUri;
+		case VAR_pageMethod:
+			return DISPLAY_NAME_pageMethod;
+		case VAR_params:
+			return DISPLAY_NAME_params;
+		case VAR_userKey:
+			return DISPLAY_NAME_userKey;
+		case VAR_userFullName:
+			return DISPLAY_NAME_userFullName;
+		case VAR_userName:
+			return DISPLAY_NAME_userName;
+		case VAR_userEmail:
+			return DISPLAY_NAME_userEmail;
+		case VAR_logoutUrl:
+			return DISPLAY_NAME_logoutUrl;
+		case VAR_long0:
+			return DISPLAY_NAME_long0;
+		case VAR_long1:
+			return DISPLAY_NAME_long1;
+		case VAR_int0:
+			return DISPLAY_NAME_int0;
+		case VAR_int1:
+			return DISPLAY_NAME_int1;
+		case VAR_promiseBefore:
+			return DISPLAY_NAME_promiseBefore;
+		case VAR_classSimpleName:
+			return DISPLAY_NAME_classSimpleName;
+		case VAR_pageTitle:
+			return DISPLAY_NAME_pageTitle;
+		case VAR_roles:
+			return DISPLAY_NAME_roles;
+		case VAR_rolesRequired:
+			return DISPLAY_NAME_rolesRequired;
+		case VAR_authRolesAdmin:
+			return DISPLAY_NAME_authRolesAdmin;
+		case VAR_pagination:
+			return DISPLAY_NAME_pagination;
+		case VAR_varsQ:
+			return DISPLAY_NAME_varsQ;
+		case VAR_varsFq:
+			return DISPLAY_NAME_varsFq;
+		case VAR_varsRange:
+			return DISPLAY_NAME_varsRange;
+		case VAR_query:
+			return DISPLAY_NAME_query;
+		case VAR_promiseAfter:
+			return DISPLAY_NAME_promiseAfter;
+		case VAR_pageImageUri:
+			return DISPLAY_NAME_pageImageUri;
+		case VAR_contextIconGroup:
+			return DISPLAY_NAME_contextIconGroup;
+		case VAR_contextIconName:
+			return DISPLAY_NAME_contextIconName;
+		case VAR_contextIconCssClasses:
+			return DISPLAY_NAME_contextIconCssClasses;
+		case VAR_pageDescription:
+			return DISPLAY_NAME_pageDescription;
+		default:
+			return null;
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/request/SiteRequestEnUSGen.java
+++ b/src/gen/java/org/curriki/api/enus/request/SiteRequestEnUSGen.java
@@ -4,52 +4,50 @@ import org.curriki.api.enus.model.user.SiteUser;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
 import io.vertx.ext.web.client.WebClient;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
 import io.vertx.core.MultiMap;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
 import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
 import io.vertx.sqlclient.SqlConnection;
-import org.apache.commons.collections.CollectionUtils;
 import java.lang.Long;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.vertx.core.json.JsonObject;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
 import java.lang.String;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
 import java.util.List;
 import io.vertx.ext.auth.User;
+import org.computate.search.wrap.Wrap;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import java.lang.Object;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteRequestEnUS.class);
@@ -64,10 +62,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject config;
 
-	/**	<br/> The entity config
+	/**	<br> The entity config
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _config(Wrap<JsonObject> c);
@@ -102,10 +100,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br/> The entity siteRequest_
+	/**	<br> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> c);
@@ -140,10 +138,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected WebClient webClient;
 
-	/**	<br/> The entity webClient
+	/**	<br> The entity webClient
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:webClient">Find the entity webClient in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:webClient">Find the entity webClient in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _webClient(Wrap<WebClient> c);
@@ -178,10 +176,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ApiRequest apiRequest_;
 
-	/**	<br/> The entity apiRequest_
+	/**	<br> The entity apiRequest_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:apiRequest_">Find the entity apiRequest_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:apiRequest_">Find the entity apiRequest_ in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _apiRequest_(Wrap<ApiRequest> c);
@@ -215,10 +213,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject jsonObject;
 
-	/**	<br/> The entity jsonObject
+	/**	<br> The entity jsonObject
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:jsonObject">Find the entity jsonObject in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:jsonObject">Find the entity jsonObject in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _jsonObject(Wrap<JsonObject> c);
@@ -253,10 +251,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ServiceRequest serviceRequest;
 
-	/**	<br/> The entity serviceRequest
+	/**	<br> The entity serviceRequest
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _serviceRequest(Wrap<ServiceRequest> c);
@@ -291,10 +289,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected User user;
 
-	/**	<br/> The entity user
+	/**	<br> The entity user
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:user">Find the entity user in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:user">Find the entity user in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _user(Wrap<User> c);
@@ -328,10 +326,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject userPrincipal;
 
-	/**	<br/> The entity userPrincipal
+	/**	<br> The entity userPrincipal
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userPrincipal">Find the entity userPrincipal in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userPrincipal">Find the entity userPrincipal in Solr</a>
+	 * <br>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userPrincipal(Wrap<JsonObject> w);
@@ -366,10 +364,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userId;
 
-	/**	<br/> The entity userId
+	/**	<br> The entity userId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userId(Wrap<String> c);
@@ -392,16 +390,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserId(siteRequest_, SiteRequestEnUS.staticSolrUserId(siteRequest_, SiteRequestEnUS.staticSetUserId(siteRequest_, o)));
+	public static String staticSearchFqUserId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserId(siteRequest_, SiteRequestEnUS.staticSearchUserId(siteRequest_, SiteRequestEnUS.staticSetUserId(siteRequest_, o)));
 	}
 
 	/////////////
@@ -416,10 +414,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br/> The entity userKey
+	/**	<br> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> c);
@@ -449,16 +447,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserKey(siteRequest_, SiteRequestEnUS.staticSolrUserKey(siteRequest_, SiteRequestEnUS.staticSetUserKey(siteRequest_, o)));
+	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserKey(siteRequest_, SiteRequestEnUS.staticSearchUserKey(siteRequest_, SiteRequestEnUS.staticSetUserKey(siteRequest_, o)));
 	}
 
 	///////////////
@@ -472,10 +470,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionId;
 
-	/**	<br/> The entity sessionId
+	/**	<br> The entity sessionId
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionId(Wrap<String> c);
@@ -498,16 +496,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSessionId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrSessionId(siteRequest_, SiteRequestEnUS.staticSolrSessionId(siteRequest_, SiteRequestEnUS.staticSetSessionId(siteRequest_, o)));
+	public static String staticSearchFqSessionId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrSessionId(siteRequest_, SiteRequestEnUS.staticSearchSessionId(siteRequest_, SiteRequestEnUS.staticSetSessionId(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -521,10 +519,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionIdBefore;
 
-	/**	<br/> The entity sessionIdBefore
+	/**	<br> The entity sessionIdBefore
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionIdBefore">Find the entity sessionIdBefore in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionIdBefore">Find the entity sessionIdBefore in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionIdBefore(Wrap<String> c);
@@ -547,16 +545,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSolrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSetSessionIdBefore(siteRequest_, o)));
+	public static String staticSearchFqSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSearchSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSetSessionIdBefore(siteRequest_, o)));
 	}
 
 	//////////////
@@ -570,10 +568,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br/> The entity userName
+	/**	<br> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> c);
@@ -596,16 +594,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserName(siteRequest_, SiteRequestEnUS.staticSolrUserName(siteRequest_, SiteRequestEnUS.staticSetUserName(siteRequest_, o)));
+	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserName(siteRequest_, SiteRequestEnUS.staticSearchUserName(siteRequest_, SiteRequestEnUS.staticSetUserName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -619,10 +617,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userLastName;
 
-	/**	<br/> The entity userLastName
+	/**	<br> The entity userLastName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userLastName(Wrap<String> c);
@@ -645,16 +643,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserLastName(siteRequest_, SiteRequestEnUS.staticSolrUserLastName(siteRequest_, SiteRequestEnUS.staticSetUserLastName(siteRequest_, o)));
+	public static String staticSearchFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserLastName(siteRequest_, SiteRequestEnUS.staticSearchUserLastName(siteRequest_, SiteRequestEnUS.staticSetUserLastName(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -668,10 +666,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFirstName;
 
-	/**	<br/> The entity userFirstName
+	/**	<br> The entity userFirstName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFirstName(Wrap<String> c);
@@ -694,16 +692,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserFirstName(siteRequest_, SiteRequestEnUS.staticSolrUserFirstName(siteRequest_, SiteRequestEnUS.staticSetUserFirstName(siteRequest_, o)));
+	public static String staticSearchFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserFirstName(siteRequest_, SiteRequestEnUS.staticSearchUserFirstName(siteRequest_, SiteRequestEnUS.staticSetUserFirstName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -717,10 +715,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br/> The entity userFullName
+	/**	<br> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> c);
@@ -743,16 +741,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserFullName(siteRequest_, SiteRequestEnUS.staticSolrUserFullName(siteRequest_, SiteRequestEnUS.staticSetUserFullName(siteRequest_, o)));
+	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserFullName(siteRequest_, SiteRequestEnUS.staticSearchUserFullName(siteRequest_, SiteRequestEnUS.staticSetUserFullName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -766,10 +764,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br/> The entity userEmail
+	/**	<br> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> c);
@@ -792,16 +790,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserEmail(siteRequest_, SiteRequestEnUS.staticSolrUserEmail(siteRequest_, SiteRequestEnUS.staticSetUserEmail(siteRequest_, o)));
+	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserEmail(siteRequest_, SiteRequestEnUS.staticSearchUserEmail(siteRequest_, SiteRequestEnUS.staticSetUserEmail(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -809,18 +807,18 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	////////////////////
 
 	/**	 The entity userRealmRoles
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> userRealmRoles = new ArrayList<String>();
 
-	/**	<br/> The entity userRealmRoles
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userRealmRoles">Find the entity userRealmRoles in Solr</a>
-	 * <br/>
-	 * @param userRealmRoles is the entity already constructed. 
+	/**	<br> The entity userRealmRoles
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userRealmRoles">Find the entity userRealmRoles in Solr</a>
+	 * <br>
+	 * @param o is the entity already constructed. 
 	 **/
 	protected abstract void _userRealmRoles(List<String> o);
 
@@ -858,16 +856,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSolrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSetUserRealmRoles(siteRequest_, o)));
+	public static String staticSearchFqUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSearchUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSetUserRealmRoles(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -880,10 +878,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject userResource;
 
-	/**	<br/> The entity userResource
+	/**	<br> The entity userResource
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResource">Find the entity userResource in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResource">Find the entity userResource in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userResource(Wrap<JsonObject> c);
@@ -912,18 +910,18 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	///////////////////////
 
 	/**	 The entity userResourceRoles
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> userResourceRoles = new ArrayList<String>();
 
-	/**	<br/> The entity userResourceRoles
-	 *  It is constructed before being initialized with the constructor by default List<String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResourceRoles">Find the entity userResourceRoles in Solr</a>
-	 * <br/>
-	 * @param userResourceRoles is the entity already constructed. 
+	/**	<br> The entity userResourceRoles
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResourceRoles">Find the entity userResourceRoles in Solr</a>
+	 * <br>
+	 * @param o is the entity already constructed. 
 	 **/
 	protected abstract void _userResourceRoles(List<String> o);
 
@@ -961,16 +959,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSolrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSetUserResourceRoles(siteRequest_, o)));
+	public static String staticSearchFqUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSearchUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSetUserResourceRoles(siteRequest_, o)));
 	}
 
 	///////////////
@@ -984,10 +982,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteUser siteUser_;
 
-	/**	<br/> The entity siteUser_
+	/**	<br> The entity siteUser_
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUser_(Wrap<SiteUser> c);
@@ -1011,6 +1009,55 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
+	//////////
+	// lang //
+	//////////
+
+	/**	 The entity lang
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonInclude(Include.NON_NULL)
+	protected String lang;
+
+	/**	<br> The entity lang
+	 *  is defined as null before being initialized. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:lang">Find the entity lang in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _lang(Wrap<String> w);
+
+	public String getLang() {
+		return lang;
+	}
+	public void setLang(String o) {
+		this.lang = SiteRequestEnUS.staticSetLang(siteRequest_, o);
+	}
+	public static String staticSetLang(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+	protected SiteRequestEnUS langInit() {
+		Wrap<String> langWrap = new Wrap<String>().var("lang");
+		if(lang == null) {
+			_lang(langWrap);
+			setLang(langWrap.o);
+		}
+		return (SiteRequestEnUS)this;
+	}
+
+	public static String staticSearchLang(SiteRequestEnUS siteRequest_, String o) {
+		return o;
+	}
+
+	public static String staticSearchStrLang(SiteRequestEnUS siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqLang(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrLang(siteRequest_, SiteRequestEnUS.staticSearchLang(siteRequest_, SiteRequestEnUS.staticSetLang(siteRequest_, o)));
+	}
+
 	///////////////
 	// requestPk //
 	///////////////
@@ -1023,10 +1070,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long requestPk;
 
-	/**	<br/> The entity requestPk
+	/**	<br> The entity requestPk
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestPk">Find the entity requestPk in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestPk">Find the entity requestPk in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestPk(Wrap<Long> c);
@@ -1056,16 +1103,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static Long staticSolrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSearchRequestPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSolrStrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSearchStrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRequestPk(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrRequestPk(siteRequest_, SiteRequestEnUS.staticSolrRequestPk(siteRequest_, SiteRequestEnUS.staticSetRequestPk(siteRequest_, o)));
+	public static String staticSearchFqRequestPk(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrRequestPk(siteRequest_, SiteRequestEnUS.staticSearchRequestPk(siteRequest_, SiteRequestEnUS.staticSetRequestPk(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1079,10 +1126,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String requestUri;
 
-	/**	<br/> The entity requestUri
+	/**	<br> The entity requestUri
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestUri">Find the entity requestUri in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestUri">Find the entity requestUri in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestUri(Wrap<String> c);
@@ -1105,16 +1152,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrRequestUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRequestUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRequestUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRequestUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRequestUri(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrRequestUri(siteRequest_, SiteRequestEnUS.staticSolrRequestUri(siteRequest_, SiteRequestEnUS.staticSetRequestUri(siteRequest_, o)));
+	public static String staticSearchFqRequestUri(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrRequestUri(siteRequest_, SiteRequestEnUS.staticSearchRequestUri(siteRequest_, SiteRequestEnUS.staticSetRequestUri(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1128,10 +1175,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String requestMethod;
 
-	/**	<br/> The entity requestMethod
+	/**	<br> The entity requestMethod
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestMethod">Find the entity requestMethod in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestMethod">Find the entity requestMethod in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestMethod(Wrap<String> c);
@@ -1154,16 +1201,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSolrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchRequestMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSolrStrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchStrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSolrFqRequestMethod(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSolrStrRequestMethod(siteRequest_, SiteRequestEnUS.staticSolrRequestMethod(siteRequest_, SiteRequestEnUS.staticSetRequestMethod(siteRequest_, o)));
+	public static String staticSearchFqRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSearchStrRequestMethod(siteRequest_, SiteRequestEnUS.staticSearchRequestMethod(siteRequest_, SiteRequestEnUS.staticSetRequestMethod(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1177,10 +1224,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SqlConnection sqlConnection;
 
-	/**	<br/> The entity sqlConnection
+	/**	<br> The entity sqlConnection
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sqlConnection">Find the entity sqlConnection in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sqlConnection">Find the entity sqlConnection in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sqlConnection(Wrap<SqlConnection> c);
@@ -1215,10 +1262,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected MultiMap requestHeaders;
 
-	/**	<br/> The entity requestHeaders
+	/**	<br> The entity requestHeaders
 	 *  is defined as null before being initialized. 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestHeaders">Find the entity requestHeaders in Solr</a>
-	 * <br/>
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestHeaders">Find the entity requestHeaders in Solr</a>
+	 * <br>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestHeaders(Wrap<MultiMap> c);
@@ -1247,17 +1294,17 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	/////////////////
 
 	/**	 The entity requestVars
-	 *	Il est construit avant d'être initialisé avec le constructeur par défaut Map<String, String>(). 
+	 *	 It is constructed before being initialized with the constructor by default. 
 	 */
 	@JsonProperty
 	@JsonInclude(Include.NON_NULL)
 	protected Map<String, String> requestVars = new HashMap<String, String>();
 
-	/**	<br/> The entity requestVars
-	 *  It is constructed before being initialized with the constructor by default Map<String, String>(). 
-	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
-	 * <br/>
-	 * @param requestVars is the entity already constructed. 
+	/**	<br> The entity requestVars
+	 *  It is constructed before being initialized with the constructor by default. 
+	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
+	 * <br>
+	 * @param m is the entity already constructed. 
 	 **/
 	protected abstract void _requestVars(Map<String, String> m);
 
@@ -1312,6 +1359,7 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 				userResourceInit();
 				userResourceRolesInit();
 				siteUser_Init();
+				langInit();
 				requestPkInit();
 				requestUriInit();
 				requestMethodInit();
@@ -1401,6 +1449,8 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 				return oSiteRequestEnUS.userResourceRoles;
 			case "siteUser_":
 				return oSiteRequestEnUS.siteUser_;
+			case "lang":
+				return oSiteRequestEnUS.lang;
 			case "requestPk":
 				return oSiteRequestEnUS.requestPk;
 			case "requestUri":
@@ -1474,6 +1524,8 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 			return SiteRequestEnUS.staticSetUserRealmRoles(siteRequest_, o);
 		case "userResourceRoles":
 			return SiteRequestEnUS.staticSetUserResourceRoles(siteRequest_, o);
+		case "lang":
+			return SiteRequestEnUS.staticSetLang(siteRequest_, o);
 		case "requestPk":
 			return SiteRequestEnUS.staticSetRequestPk(siteRequest_, o);
 		case "requestUri":
@@ -1486,166 +1538,134 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSolrUserId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserId(siteRequest_, (String)o);
 		case "userKey":
-			return SiteRequestEnUS.staticSolrUserKey(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSearchUserKey(siteRequest_, (Long)o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSolrSessionId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchSessionId(siteRequest_, (String)o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSolrSessionIdBefore(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchSessionIdBefore(siteRequest_, (String)o);
 		case "userName":
-			return SiteRequestEnUS.staticSolrUserName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSolrUserLastName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserLastName(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSolrUserFirstName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserFirstName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSolrUserFullName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserFullName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSolrUserEmail(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserEmail(siteRequest_, (String)o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSolrUserRealmRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserRealmRoles(siteRequest_, (String)o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSolrUserResourceRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchUserResourceRoles(siteRequest_, (String)o);
+		case "lang":
+			return SiteRequestEnUS.staticSearchLang(siteRequest_, (String)o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSolrRequestPk(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSearchRequestPk(siteRequest_, (Long)o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSolrRequestUri(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchRequestUri(siteRequest_, (String)o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSolrRequestMethod(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchRequestMethod(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSolrStrUserId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserId(siteRequest_, (String)o);
 		case "userKey":
-			return SiteRequestEnUS.staticSolrStrUserKey(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSearchStrUserKey(siteRequest_, (Long)o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSolrStrSessionId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrSessionId(siteRequest_, (String)o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSolrStrSessionIdBefore(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrSessionIdBefore(siteRequest_, (String)o);
 		case "userName":
-			return SiteRequestEnUS.staticSolrStrUserName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSolrStrUserLastName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserLastName(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSolrStrUserFirstName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserFirstName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSolrStrUserFullName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserFullName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSolrStrUserEmail(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserEmail(siteRequest_, (String)o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSolrStrUserRealmRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserRealmRoles(siteRequest_, (String)o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSolrStrUserResourceRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrUserResourceRoles(siteRequest_, (String)o);
+		case "lang":
+			return SiteRequestEnUS.staticSearchStrLang(siteRequest_, (String)o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSolrStrRequestPk(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSearchStrRequestPk(siteRequest_, (Long)o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSolrStrRequestUri(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrRequestUri(siteRequest_, (String)o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSolrStrRequestMethod(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSearchStrRequestMethod(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSolrFqUserId(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserId(siteRequest_, o);
 		case "userKey":
-			return SiteRequestEnUS.staticSolrFqUserKey(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserKey(siteRequest_, o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSolrFqSessionId(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqSessionId(siteRequest_, o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSolrFqSessionIdBefore(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqSessionIdBefore(siteRequest_, o);
 		case "userName":
-			return SiteRequestEnUS.staticSolrFqUserName(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserName(siteRequest_, o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSolrFqUserLastName(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserLastName(siteRequest_, o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSolrFqUserFirstName(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserFirstName(siteRequest_, o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSolrFqUserFullName(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserFullName(siteRequest_, o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSolrFqUserEmail(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserEmail(siteRequest_, o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSolrFqUserRealmRoles(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserRealmRoles(siteRequest_, o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSolrFqUserResourceRoles(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqUserResourceRoles(siteRequest_, o);
+		case "lang":
+			return SiteRequestEnUS.staticSearchFqLang(siteRequest_, o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSolrFqRequestPk(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqRequestPk(siteRequest_, o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSolrFqRequestUri(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqRequestUri(siteRequest_, o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSolrFqRequestMethod(siteRequest_, o);
+			return SiteRequestEnUS.staticSearchFqRequestMethod(siteRequest_, o);
 			default:
 				return null;
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineSiteRequestEnUS(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineSiteRequestEnUS(String var, Object val) {
-		switch(var.toLowerCase()) {
-			default:
-				return null;
-		}
-	}
-
-	//////////////////
-	// apiRequest //
-	//////////////////
-
-	public void apiRequestSiteRequestEnUS() {
-		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
-		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
-		if(o != null && o instanceof SiteRequestEnUS) {
-			SiteRequestEnUS original = (SiteRequestEnUS)o;
 		}
 	}
 
@@ -1679,10 +1699,106 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	public static final String VAR_userResource = "userResource";
 	public static final String VAR_userResourceRoles = "userResourceRoles";
 	public static final String VAR_siteUser_ = "siteUser_";
+	public static final String VAR_lang = "lang";
 	public static final String VAR_requestPk = "requestPk";
 	public static final String VAR_requestUri = "requestUri";
 	public static final String VAR_requestMethod = "requestMethod";
 	public static final String VAR_sqlConnection = "sqlConnection";
 	public static final String VAR_requestHeaders = "requestHeaders";
 	public static final String VAR_requestVars = "requestVars";
+
+	public static final String DISPLAY_NAME_config = "";
+	public static final String DISPLAY_NAME_siteRequest_ = "";
+	public static final String DISPLAY_NAME_webClient = "";
+	public static final String DISPLAY_NAME_apiRequest_ = "";
+	public static final String DISPLAY_NAME_jsonObject = "";
+	public static final String DISPLAY_NAME_serviceRequest = "";
+	public static final String DISPLAY_NAME_user = "";
+	public static final String DISPLAY_NAME_userPrincipal = "";
+	public static final String DISPLAY_NAME_userId = "";
+	public static final String DISPLAY_NAME_userKey = "";
+	public static final String DISPLAY_NAME_sessionId = "";
+	public static final String DISPLAY_NAME_sessionIdBefore = "";
+	public static final String DISPLAY_NAME_userName = "";
+	public static final String DISPLAY_NAME_userLastName = "";
+	public static final String DISPLAY_NAME_userFirstName = "";
+	public static final String DISPLAY_NAME_userFullName = "";
+	public static final String DISPLAY_NAME_userEmail = "";
+	public static final String DISPLAY_NAME_userRealmRoles = "";
+	public static final String DISPLAY_NAME_userResource = "";
+	public static final String DISPLAY_NAME_userResourceRoles = "";
+	public static final String DISPLAY_NAME_siteUser_ = "";
+	public static final String DISPLAY_NAME_lang = "";
+	public static final String DISPLAY_NAME_requestPk = "";
+	public static final String DISPLAY_NAME_requestUri = "";
+	public static final String DISPLAY_NAME_requestMethod = "";
+	public static final String DISPLAY_NAME_sqlConnection = "";
+	public static final String DISPLAY_NAME_requestHeaders = "";
+	public static final String DISPLAY_NAME_requestVars = "";
+
+	public static String displayNameForClass(String var) {
+		return SiteRequestEnUS.displayNameSiteRequestEnUS(var);
+	}
+	public static String displayNameSiteRequestEnUS(String var) {
+		switch(var) {
+		case VAR_config:
+			return DISPLAY_NAME_config;
+		case VAR_siteRequest_:
+			return DISPLAY_NAME_siteRequest_;
+		case VAR_webClient:
+			return DISPLAY_NAME_webClient;
+		case VAR_apiRequest_:
+			return DISPLAY_NAME_apiRequest_;
+		case VAR_jsonObject:
+			return DISPLAY_NAME_jsonObject;
+		case VAR_serviceRequest:
+			return DISPLAY_NAME_serviceRequest;
+		case VAR_user:
+			return DISPLAY_NAME_user;
+		case VAR_userPrincipal:
+			return DISPLAY_NAME_userPrincipal;
+		case VAR_userId:
+			return DISPLAY_NAME_userId;
+		case VAR_userKey:
+			return DISPLAY_NAME_userKey;
+		case VAR_sessionId:
+			return DISPLAY_NAME_sessionId;
+		case VAR_sessionIdBefore:
+			return DISPLAY_NAME_sessionIdBefore;
+		case VAR_userName:
+			return DISPLAY_NAME_userName;
+		case VAR_userLastName:
+			return DISPLAY_NAME_userLastName;
+		case VAR_userFirstName:
+			return DISPLAY_NAME_userFirstName;
+		case VAR_userFullName:
+			return DISPLAY_NAME_userFullName;
+		case VAR_userEmail:
+			return DISPLAY_NAME_userEmail;
+		case VAR_userRealmRoles:
+			return DISPLAY_NAME_userRealmRoles;
+		case VAR_userResource:
+			return DISPLAY_NAME_userResource;
+		case VAR_userResourceRoles:
+			return DISPLAY_NAME_userResourceRoles;
+		case VAR_siteUser_:
+			return DISPLAY_NAME_siteUser_;
+		case VAR_lang:
+			return DISPLAY_NAME_lang;
+		case VAR_requestPk:
+			return DISPLAY_NAME_requestPk;
+		case VAR_requestUri:
+			return DISPLAY_NAME_requestUri;
+		case VAR_requestMethod:
+			return DISPLAY_NAME_requestMethod;
+		case VAR_sqlConnection:
+			return DISPLAY_NAME_sqlConnection;
+		case VAR_requestHeaders:
+			return DISPLAY_NAME_requestHeaders;
+		case VAR_requestVars:
+			return DISPLAY_NAME_requestVars;
+		default:
+			return null;
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/request/SiteRequestEnUSGen.java
+++ b/src/gen/java/org/curriki/api/enus/request/SiteRequestEnUSGen.java
@@ -1,59 +1,55 @@
 package org.curriki.api.enus.request;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
-import java.util.Map;
-import java.lang.Object;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.WebClient;
-import io.vertx.ext.web.api.service.ServiceRequest;
-import io.vertx.ext.auth.User;
-import java.lang.String;
-import java.lang.Long;
-import io.vertx.core.json.JsonArray;
 import org.curriki.api.enus.model.user.SiteUser;
-import io.vertx.sqlclient.SqlConnection;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Arrays;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import io.vertx.ext.web.client.WebClient;
+import org.curriki.api.enus.request.api.ApiRequest;
+import org.slf4j.LoggerFactory;
 import io.vertx.core.MultiMap;
-import org.computate.search.wrap.Wrap;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.computate.vertx.api.ApiRequest;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import io.vertx.sqlclient.SqlConnection;
+import org.apache.commons.collections.CollectionUtils;
+import java.lang.Long;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.vertx.core.json.JsonObject;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.lang.String;
+import java.math.RoundingMode;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import java.util.Objects;
+import io.vertx.core.json.JsonArray;
+import java.util.List;
+import io.vertx.ext.auth.User;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.lang.Object;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS">Find the class SiteRequestEnUS in Solr. </a>
- * <br><br>Delete the class SiteRequestEnUS in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.request in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.request&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(SiteRequestEnUS.class);
@@ -68,10 +64,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject config;
 
-	/**	<br> The entity config
+	/**	<br/> The entity config
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:config">Find the entity config in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _config(Wrap<JsonObject> c);
@@ -106,10 +102,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteRequestEnUS siteRequest_;
 
-	/**	<br> The entity siteRequest_
+	/**	<br/> The entity siteRequest_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteRequest_">Find the entity siteRequest_ in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteRequest_(Wrap<SiteRequestEnUS> c);
@@ -144,10 +140,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected WebClient webClient;
 
-	/**	<br> The entity webClient
+	/**	<br/> The entity webClient
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:webClient">Find the entity webClient in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:webClient">Find the entity webClient in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _webClient(Wrap<WebClient> c);
@@ -182,10 +178,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ApiRequest apiRequest_;
 
-	/**	<br> The entity apiRequest_
+	/**	<br/> The entity apiRequest_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:apiRequest_">Find the entity apiRequest_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:apiRequest_">Find the entity apiRequest_ in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _apiRequest_(Wrap<ApiRequest> c);
@@ -219,10 +215,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject jsonObject;
 
-	/**	<br> The entity jsonObject
+	/**	<br/> The entity jsonObject
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:jsonObject">Find the entity jsonObject in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:jsonObject">Find the entity jsonObject in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _jsonObject(Wrap<JsonObject> c);
@@ -257,10 +253,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected ServiceRequest serviceRequest;
 
-	/**	<br> The entity serviceRequest
+	/**	<br/> The entity serviceRequest
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:serviceRequest">Find the entity serviceRequest in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _serviceRequest(Wrap<ServiceRequest> c);
@@ -295,10 +291,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected User user;
 
-	/**	<br> The entity user
+	/**	<br/> The entity user
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:user">Find the entity user in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:user">Find the entity user in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _user(Wrap<User> c);
@@ -332,10 +328,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject userPrincipal;
 
-	/**	<br> The entity userPrincipal
+	/**	<br/> The entity userPrincipal
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userPrincipal">Find the entity userPrincipal in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userPrincipal">Find the entity userPrincipal in Solr</a>
+	 * <br/>
 	 * @param w is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userPrincipal(Wrap<JsonObject> w);
@@ -370,10 +366,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userId;
 
-	/**	<br> The entity userId
+	/**	<br/> The entity userId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userId">Find the entity userId in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userId(Wrap<String> c);
@@ -396,16 +392,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserId(siteRequest_, SiteRequestEnUS.staticSearchUserId(siteRequest_, SiteRequestEnUS.staticSetUserId(siteRequest_, o)));
+	public static String staticSolrFqUserId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserId(siteRequest_, SiteRequestEnUS.staticSolrUserId(siteRequest_, SiteRequestEnUS.staticSetUserId(siteRequest_, o)));
 	}
 
 	/////////////
@@ -420,10 +416,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long userKey;
 
-	/**	<br> The entity userKey
+	/**	<br/> The entity userKey
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userKey">Find the entity userKey in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userKey(Wrap<Long> c);
@@ -453,16 +449,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static Long staticSearchUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrUserKey(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserKey(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserKey(siteRequest_, SiteRequestEnUS.staticSearchUserKey(siteRequest_, SiteRequestEnUS.staticSetUserKey(siteRequest_, o)));
+	public static String staticSolrFqUserKey(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserKey(siteRequest_, SiteRequestEnUS.staticSolrUserKey(siteRequest_, SiteRequestEnUS.staticSetUserKey(siteRequest_, o)));
 	}
 
 	///////////////
@@ -476,10 +472,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionId;
 
-	/**	<br> The entity sessionId
+	/**	<br/> The entity sessionId
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionId">Find the entity sessionId in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionId(Wrap<String> c);
@@ -502,16 +498,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSessionId(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSessionId(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSessionId(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrSessionId(siteRequest_, SiteRequestEnUS.staticSearchSessionId(siteRequest_, SiteRequestEnUS.staticSetSessionId(siteRequest_, o)));
+	public static String staticSolrFqSessionId(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrSessionId(siteRequest_, SiteRequestEnUS.staticSolrSessionId(siteRequest_, SiteRequestEnUS.staticSetSessionId(siteRequest_, o)));
 	}
 
 	/////////////////////
@@ -525,10 +521,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String sessionIdBefore;
 
-	/**	<br> The entity sessionIdBefore
+	/**	<br/> The entity sessionIdBefore
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:sessionIdBefore">Find the entity sessionIdBefore in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sessionIdBefore">Find the entity sessionIdBefore in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sessionIdBefore(Wrap<String> c);
@@ -551,16 +547,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSearchSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSetSessionIdBefore(siteRequest_, o)));
+	public static String staticSolrFqSessionIdBefore(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSolrSessionIdBefore(siteRequest_, SiteRequestEnUS.staticSetSessionIdBefore(siteRequest_, o)));
 	}
 
 	//////////////
@@ -574,10 +570,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userName;
 
-	/**	<br> The entity userName
+	/**	<br/> The entity userName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userName">Find the entity userName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userName(Wrap<String> c);
@@ -600,16 +596,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserName(siteRequest_, SiteRequestEnUS.staticSearchUserName(siteRequest_, SiteRequestEnUS.staticSetUserName(siteRequest_, o)));
+	public static String staticSolrFqUserName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserName(siteRequest_, SiteRequestEnUS.staticSolrUserName(siteRequest_, SiteRequestEnUS.staticSetUserName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -623,10 +619,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userLastName;
 
-	/**	<br> The entity userLastName
+	/**	<br/> The entity userLastName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userLastName">Find the entity userLastName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userLastName(Wrap<String> c);
@@ -649,16 +645,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserLastName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserLastName(siteRequest_, SiteRequestEnUS.staticSearchUserLastName(siteRequest_, SiteRequestEnUS.staticSetUserLastName(siteRequest_, o)));
+	public static String staticSolrFqUserLastName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserLastName(siteRequest_, SiteRequestEnUS.staticSolrUserLastName(siteRequest_, SiteRequestEnUS.staticSetUserLastName(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -672,10 +668,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFirstName;
 
-	/**	<br> The entity userFirstName
+	/**	<br/> The entity userFirstName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFirstName">Find the entity userFirstName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFirstName(Wrap<String> c);
@@ -698,16 +694,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserFirstName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserFirstName(siteRequest_, SiteRequestEnUS.staticSearchUserFirstName(siteRequest_, SiteRequestEnUS.staticSetUserFirstName(siteRequest_, o)));
+	public static String staticSolrFqUserFirstName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserFirstName(siteRequest_, SiteRequestEnUS.staticSolrUserFirstName(siteRequest_, SiteRequestEnUS.staticSetUserFirstName(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -721,10 +717,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userFullName;
 
-	/**	<br> The entity userFullName
+	/**	<br/> The entity userFullName
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userFullName">Find the entity userFullName in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userFullName(Wrap<String> c);
@@ -747,16 +743,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserFullName(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserFullName(siteRequest_, SiteRequestEnUS.staticSearchUserFullName(siteRequest_, SiteRequestEnUS.staticSetUserFullName(siteRequest_, o)));
+	public static String staticSolrFqUserFullName(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserFullName(siteRequest_, SiteRequestEnUS.staticSolrUserFullName(siteRequest_, SiteRequestEnUS.staticSetUserFullName(siteRequest_, o)));
 	}
 
 	///////////////
@@ -770,10 +766,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String userEmail;
 
-	/**	<br> The entity userEmail
+	/**	<br/> The entity userEmail
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userEmail">Find the entity userEmail in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userEmail(Wrap<String> c);
@@ -796,16 +792,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserEmail(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserEmail(siteRequest_, SiteRequestEnUS.staticSearchUserEmail(siteRequest_, SiteRequestEnUS.staticSetUserEmail(siteRequest_, o)));
+	public static String staticSolrFqUserEmail(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserEmail(siteRequest_, SiteRequestEnUS.staticSolrUserEmail(siteRequest_, SiteRequestEnUS.staticSetUserEmail(siteRequest_, o)));
 	}
 
 	////////////////////
@@ -813,18 +809,18 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	////////////////////
 
 	/**	 The entity userRealmRoles
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> userRealmRoles = new ArrayList<String>();
 
-	/**	<br> The entity userRealmRoles
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userRealmRoles">Find the entity userRealmRoles in Solr</a>
-	 * <br>
-	 * @param o is the entity already constructed. 
+	/**	<br/> The entity userRealmRoles
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userRealmRoles">Find the entity userRealmRoles in Solr</a>
+	 * <br/>
+	 * @param userRealmRoles is the entity already constructed. 
 	 **/
 	protected abstract void _userRealmRoles(List<String> o);
 
@@ -862,16 +858,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSearchUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSetUserRealmRoles(siteRequest_, o)));
+	public static String staticSolrFqUserRealmRoles(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSolrUserRealmRoles(siteRequest_, SiteRequestEnUS.staticSetUserRealmRoles(siteRequest_, o)));
 	}
 
 	//////////////////
@@ -884,10 +880,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected JsonObject userResource;
 
-	/**	<br> The entity userResource
+	/**	<br/> The entity userResource
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userResource">Find the entity userResource in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResource">Find the entity userResource in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _userResource(Wrap<JsonObject> c);
@@ -916,18 +912,18 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	///////////////////////
 
 	/**	 The entity userResourceRoles
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut List<String>(). 
 	 */
 	@JsonProperty
 	@JsonFormat(shape = JsonFormat.Shape.ARRAY)
 	@JsonInclude(Include.NON_NULL)
 	protected List<String> userResourceRoles = new ArrayList<String>();
 
-	/**	<br> The entity userResourceRoles
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:userResourceRoles">Find the entity userResourceRoles in Solr</a>
-	 * <br>
-	 * @param o is the entity already constructed. 
+	/**	<br/> The entity userResourceRoles
+	 *  It is constructed before being initialized with the constructor by default List<String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:userResourceRoles">Find the entity userResourceRoles in Solr</a>
+	 * <br/>
+	 * @param userResourceRoles is the entity already constructed. 
 	 **/
 	protected abstract void _userResourceRoles(List<String> o);
 
@@ -965,16 +961,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSearchUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSetUserResourceRoles(siteRequest_, o)));
+	public static String staticSolrFqUserResourceRoles(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSolrUserResourceRoles(siteRequest_, SiteRequestEnUS.staticSetUserResourceRoles(siteRequest_, o)));
 	}
 
 	///////////////
@@ -988,10 +984,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SiteUser siteUser_;
 
-	/**	<br> The entity siteUser_
+	/**	<br/> The entity siteUser_
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:siteUser_">Find the entity siteUser_ in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _siteUser_(Wrap<SiteUser> c);
@@ -1027,10 +1023,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected Long requestPk;
 
-	/**	<br> The entity requestPk
+	/**	<br/> The entity requestPk
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:requestPk">Find the entity requestPk in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestPk">Find the entity requestPk in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestPk(Wrap<Long> c);
@@ -1060,16 +1056,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static Long staticSearchRequestPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static Long staticSolrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o;
 	}
 
-	public static String staticSearchStrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
+	public static String staticSolrStrRequestPk(SiteRequestEnUS siteRequest_, Long o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRequestPk(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrRequestPk(siteRequest_, SiteRequestEnUS.staticSearchRequestPk(siteRequest_, SiteRequestEnUS.staticSetRequestPk(siteRequest_, o)));
+	public static String staticSolrFqRequestPk(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrRequestPk(siteRequest_, SiteRequestEnUS.staticSolrRequestPk(siteRequest_, SiteRequestEnUS.staticSetRequestPk(siteRequest_, o)));
 	}
 
 	////////////////
@@ -1083,10 +1079,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String requestUri;
 
-	/**	<br> The entity requestUri
+	/**	<br/> The entity requestUri
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:requestUri">Find the entity requestUri in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestUri">Find the entity requestUri in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestUri(Wrap<String> c);
@@ -1109,16 +1105,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchRequestUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRequestUri(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRequestUri(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRequestUri(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRequestUri(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrRequestUri(siteRequest_, SiteRequestEnUS.staticSearchRequestUri(siteRequest_, SiteRequestEnUS.staticSetRequestUri(siteRequest_, o)));
+	public static String staticSolrFqRequestUri(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrRequestUri(siteRequest_, SiteRequestEnUS.staticSolrRequestUri(siteRequest_, SiteRequestEnUS.staticSetRequestUri(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1132,10 +1128,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected String requestMethod;
 
-	/**	<br> The entity requestMethod
+	/**	<br/> The entity requestMethod
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:requestMethod">Find the entity requestMethod in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestMethod">Find the entity requestMethod in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestMethod(Wrap<String> c);
@@ -1158,16 +1154,16 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return (SiteRequestEnUS)this;
 	}
 
-	public static String staticSearchRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o;
 	}
 
-	public static String staticSearchStrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrStrRequestMethod(SiteRequestEnUS siteRequest_, String o) {
 		return o == null ? null : o.toString();
 	}
 
-	public static String staticSearchFqRequestMethod(SiteRequestEnUS siteRequest_, String o) {
-		return SiteRequestEnUS.staticSearchStrRequestMethod(siteRequest_, SiteRequestEnUS.staticSearchRequestMethod(siteRequest_, SiteRequestEnUS.staticSetRequestMethod(siteRequest_, o)));
+	public static String staticSolrFqRequestMethod(SiteRequestEnUS siteRequest_, String o) {
+		return SiteRequestEnUS.staticSolrStrRequestMethod(siteRequest_, SiteRequestEnUS.staticSolrRequestMethod(siteRequest_, SiteRequestEnUS.staticSetRequestMethod(siteRequest_, o)));
 	}
 
 	///////////////////
@@ -1181,10 +1177,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected SqlConnection sqlConnection;
 
-	/**	<br> The entity sqlConnection
+	/**	<br/> The entity sqlConnection
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:sqlConnection">Find the entity sqlConnection in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:sqlConnection">Find the entity sqlConnection in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _sqlConnection(Wrap<SqlConnection> c);
@@ -1219,10 +1215,10 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	@JsonInclude(Include.NON_NULL)
 	protected MultiMap requestHeaders;
 
-	/**	<br> The entity requestHeaders
+	/**	<br/> The entity requestHeaders
 	 *  is defined as null before being initialized. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:requestHeaders">Find the entity requestHeaders in Solr</a>
-	 * <br>
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestHeaders">Find the entity requestHeaders in Solr</a>
+	 * <br/>
 	 * @param c is for wrapping a value to assign to this entity during initialization. 
 	 **/
 	protected abstract void _requestHeaders(Wrap<MultiMap> c);
@@ -1251,17 +1247,17 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	/////////////////
 
 	/**	 The entity requestVars
-	 *	 It is constructed before being initialized with the constructor by default. 
+	 *	Il est construit avant d'être initialisé avec le constructeur par défaut Map<String, String>(). 
 	 */
 	@JsonProperty
 	@JsonInclude(Include.NON_NULL)
 	protected Map<String, String> requestVars = new HashMap<String, String>();
 
-	/**	<br> The entity requestVars
-	 *  It is constructed before being initialized with the constructor by default. 
-	 * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
-	 * <br>
-	 * @param m is the entity already constructed. 
+	/**	<br/> The entity requestVars
+	 *  It is constructed before being initialized with the constructor by default Map<String, String>(). 
+	 * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.request.SiteRequestEnUS&fq=classeEtendGen_indexed_boolean:true&fq=entiteVar_enUS_indexed_string:requestVars">Find the entity requestVars in Solr</a>
+	 * <br/>
+	 * @param requestVars is the entity already constructed. 
 	 **/
 	protected abstract void _requestVars(Map<String, String> m);
 
@@ -1490,128 +1486,166 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSearchUserId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserId(siteRequest_, (String)o);
 		case "userKey":
-			return SiteRequestEnUS.staticSearchUserKey(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSolrUserKey(siteRequest_, (Long)o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSearchSessionId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrSessionId(siteRequest_, (String)o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSearchSessionIdBefore(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrSessionIdBefore(siteRequest_, (String)o);
 		case "userName":
-			return SiteRequestEnUS.staticSearchUserName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSearchUserLastName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserLastName(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSearchUserFirstName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserFirstName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSearchUserFullName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserFullName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSearchUserEmail(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserEmail(siteRequest_, (String)o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSearchUserRealmRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserRealmRoles(siteRequest_, (String)o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSearchUserResourceRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrUserResourceRoles(siteRequest_, (String)o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSearchRequestPk(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSolrRequestPk(siteRequest_, (Long)o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSearchRequestUri(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrRequestUri(siteRequest_, (String)o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSearchRequestMethod(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrRequestMethod(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSearchStrUserId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserId(siteRequest_, (String)o);
 		case "userKey":
-			return SiteRequestEnUS.staticSearchStrUserKey(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSolrStrUserKey(siteRequest_, (Long)o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSearchStrSessionId(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrSessionId(siteRequest_, (String)o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSearchStrSessionIdBefore(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrSessionIdBefore(siteRequest_, (String)o);
 		case "userName":
-			return SiteRequestEnUS.staticSearchStrUserName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserName(siteRequest_, (String)o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSearchStrUserLastName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserLastName(siteRequest_, (String)o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSearchStrUserFirstName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserFirstName(siteRequest_, (String)o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSearchStrUserFullName(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserFullName(siteRequest_, (String)o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSearchStrUserEmail(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserEmail(siteRequest_, (String)o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSearchStrUserRealmRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserRealmRoles(siteRequest_, (String)o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSearchStrUserResourceRoles(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrUserResourceRoles(siteRequest_, (String)o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSearchStrRequestPk(siteRequest_, (Long)o);
+			return SiteRequestEnUS.staticSolrStrRequestPk(siteRequest_, (Long)o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSearchStrRequestUri(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrRequestUri(siteRequest_, (String)o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSearchStrRequestMethod(siteRequest_, (String)o);
+			return SiteRequestEnUS.staticSolrStrRequestMethod(siteRequest_, (String)o);
 			default:
 				return null;
 		}
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqSiteRequestEnUS(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqSiteRequestEnUS(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqSiteRequestEnUS(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
 		case "userId":
-			return SiteRequestEnUS.staticSearchFqUserId(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserId(siteRequest_, o);
 		case "userKey":
-			return SiteRequestEnUS.staticSearchFqUserKey(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserKey(siteRequest_, o);
 		case "sessionId":
-			return SiteRequestEnUS.staticSearchFqSessionId(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqSessionId(siteRequest_, o);
 		case "sessionIdBefore":
-			return SiteRequestEnUS.staticSearchFqSessionIdBefore(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqSessionIdBefore(siteRequest_, o);
 		case "userName":
-			return SiteRequestEnUS.staticSearchFqUserName(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserName(siteRequest_, o);
 		case "userLastName":
-			return SiteRequestEnUS.staticSearchFqUserLastName(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserLastName(siteRequest_, o);
 		case "userFirstName":
-			return SiteRequestEnUS.staticSearchFqUserFirstName(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserFirstName(siteRequest_, o);
 		case "userFullName":
-			return SiteRequestEnUS.staticSearchFqUserFullName(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserFullName(siteRequest_, o);
 		case "userEmail":
-			return SiteRequestEnUS.staticSearchFqUserEmail(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserEmail(siteRequest_, o);
 		case "userRealmRoles":
-			return SiteRequestEnUS.staticSearchFqUserRealmRoles(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserRealmRoles(siteRequest_, o);
 		case "userResourceRoles":
-			return SiteRequestEnUS.staticSearchFqUserResourceRoles(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqUserResourceRoles(siteRequest_, o);
 		case "requestPk":
-			return SiteRequestEnUS.staticSearchFqRequestPk(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqRequestPk(siteRequest_, o);
 		case "requestUri":
-			return SiteRequestEnUS.staticSearchFqRequestUri(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqRequestUri(siteRequest_, o);
 		case "requestMethod":
-			return SiteRequestEnUS.staticSearchFqRequestMethod(siteRequest_, o);
+			return SiteRequestEnUS.staticSolrFqRequestMethod(siteRequest_, o);
 			default:
 				return null;
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineSiteRequestEnUS(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineSiteRequestEnUS(String var, Object val) {
+		switch(var.toLowerCase()) {
+			default:
+				return null;
+		}
+	}
+
+	//////////////////
+	// apiRequest //
+	//////////////////
+
+	public void apiRequestSiteRequestEnUS() {
+		ApiRequest apiRequest = Optional.ofNullable(siteRequest_).map(SiteRequestEnUS::getApiRequest_).orElse(null);
+		Object o = Optional.ofNullable(apiRequest).map(ApiRequest::getOriginal).orElse(null);
+		if(o != null && o instanceof SiteRequestEnUS) {
+			SiteRequestEnUS original = (SiteRequestEnUS)o;
 		}
 	}
 
@@ -1624,7 +1658,6 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 		return sb.toString();
 	}
 
-	public static final String CLASS_SIMPLE_NAME = "SiteRequestEnUS";
 	public static final String VAR_config = "config";
 	public static final String VAR_siteRequest_ = "siteRequest_";
 	public static final String VAR_webClient = "webClient";
@@ -1652,96 +1685,4 @@ public abstract class SiteRequestEnUSGen<DEV> extends Object {
 	public static final String VAR_sqlConnection = "sqlConnection";
 	public static final String VAR_requestHeaders = "requestHeaders";
 	public static final String VAR_requestVars = "requestVars";
-
-	public static final String DISPLAY_NAME_config = "";
-	public static final String DISPLAY_NAME_siteRequest_ = "";
-	public static final String DISPLAY_NAME_webClient = "";
-	public static final String DISPLAY_NAME_apiRequest_ = "";
-	public static final String DISPLAY_NAME_jsonObject = "";
-	public static final String DISPLAY_NAME_serviceRequest = "";
-	public static final String DISPLAY_NAME_user = "";
-	public static final String DISPLAY_NAME_userPrincipal = "";
-	public static final String DISPLAY_NAME_userId = "";
-	public static final String DISPLAY_NAME_userKey = "";
-	public static final String DISPLAY_NAME_sessionId = "";
-	public static final String DISPLAY_NAME_sessionIdBefore = "";
-	public static final String DISPLAY_NAME_userName = "";
-	public static final String DISPLAY_NAME_userLastName = "";
-	public static final String DISPLAY_NAME_userFirstName = "";
-	public static final String DISPLAY_NAME_userFullName = "";
-	public static final String DISPLAY_NAME_userEmail = "";
-	public static final String DISPLAY_NAME_userRealmRoles = "";
-	public static final String DISPLAY_NAME_userResource = "";
-	public static final String DISPLAY_NAME_userResourceRoles = "";
-	public static final String DISPLAY_NAME_siteUser_ = "";
-	public static final String DISPLAY_NAME_requestPk = "";
-	public static final String DISPLAY_NAME_requestUri = "";
-	public static final String DISPLAY_NAME_requestMethod = "";
-	public static final String DISPLAY_NAME_sqlConnection = "";
-	public static final String DISPLAY_NAME_requestHeaders = "";
-	public static final String DISPLAY_NAME_requestVars = "";
-
-	public static String displayNameForClass(String var) {
-		return SiteRequestEnUS.displayNameSiteRequestEnUS(var);
-	}
-	public static String displayNameSiteRequestEnUS(String var) {
-		switch(var) {
-		case VAR_config:
-			return DISPLAY_NAME_config;
-		case VAR_siteRequest_:
-			return DISPLAY_NAME_siteRequest_;
-		case VAR_webClient:
-			return DISPLAY_NAME_webClient;
-		case VAR_apiRequest_:
-			return DISPLAY_NAME_apiRequest_;
-		case VAR_jsonObject:
-			return DISPLAY_NAME_jsonObject;
-		case VAR_serviceRequest:
-			return DISPLAY_NAME_serviceRequest;
-		case VAR_user:
-			return DISPLAY_NAME_user;
-		case VAR_userPrincipal:
-			return DISPLAY_NAME_userPrincipal;
-		case VAR_userId:
-			return DISPLAY_NAME_userId;
-		case VAR_userKey:
-			return DISPLAY_NAME_userKey;
-		case VAR_sessionId:
-			return DISPLAY_NAME_sessionId;
-		case VAR_sessionIdBefore:
-			return DISPLAY_NAME_sessionIdBefore;
-		case VAR_userName:
-			return DISPLAY_NAME_userName;
-		case VAR_userLastName:
-			return DISPLAY_NAME_userLastName;
-		case VAR_userFirstName:
-			return DISPLAY_NAME_userFirstName;
-		case VAR_userFullName:
-			return DISPLAY_NAME_userFullName;
-		case VAR_userEmail:
-			return DISPLAY_NAME_userEmail;
-		case VAR_userRealmRoles:
-			return DISPLAY_NAME_userRealmRoles;
-		case VAR_userResource:
-			return DISPLAY_NAME_userResource;
-		case VAR_userResourceRoles:
-			return DISPLAY_NAME_userResourceRoles;
-		case VAR_siteUser_:
-			return DISPLAY_NAME_siteUser_;
-		case VAR_requestPk:
-			return DISPLAY_NAME_requestPk;
-		case VAR_requestUri:
-			return DISPLAY_NAME_requestUri;
-		case VAR_requestMethod:
-			return DISPLAY_NAME_requestMethod;
-		case VAR_sqlConnection:
-			return DISPLAY_NAME_sqlConnection;
-		case VAR_requestHeaders:
-			return DISPLAY_NAME_requestHeaders;
-		case VAR_requestVars:
-			return DISPLAY_NAME_requestVars;
-		default:
-			return null;
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/vertx/MainVerticleGen.java
+++ b/src/gen/java/org/curriki/api/enus/vertx/MainVerticleGen.java
@@ -1,54 +1,66 @@
 package org.curriki.api.enus.vertx;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
-import io.vertx.core.AbstractVerticle;
-import org.computate.search.wrap.Wrap;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.math.RoundingMode;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.AbstractVerticle;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.MainVerticle">Find the class MainVerticle in Solr. </a>
- * <br><br>Delete the class MainVerticle in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.MainVerticle&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.vertx in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.vertx&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.MainVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class MainVerticleGen<DEV> extends AbstractVerticle {
 
 /*
+CREATE TABLE SiteUser(
+	pk bigserial primary key
+	, inheritPk text
+	, created timestamp with time zone
+	, archived boolean
+	, deleted boolean
+	, sessionId text
+	, userKey bigint
+	);
+CREATE TABLE CurrikiResource(
+	pk bigserial primary key
+	, inheritPk text
+	, created timestamp with time zone
+	, archived boolean
+	, deleted boolean
+	, sessionId text
+	, userKey bigint
+	);
 CREATE TABLE SiteUser(
 	pk bigserial primary key
 	, inheritPk text
@@ -63,99 +75,11 @@ CREATE TABLE SiteUser(
 	, userFirstName text
 	, userLastName text
 	, userFullName text
-	, seeArchived boolean
-	, seeDeleted boolean
-	);
-CREATE TABLE CurrikiResource(
-	pk bigserial primary key
-	, inheritPk text
-	, created timestamp with time zone
-	, archived boolean
-	, deleted boolean
-	, sessionId text
-	, userKey bigint
-	, resourceId text
-	, licenseId text
-	, contributorId bigint
-	, contributionDate timestamp with time zone
-	, description text
-	, title text
-	, keywordsStr text
-	, generatedKeywordsStr text
-	, language text
-	, lastEditorId bigint
-	, lastEditDate timestamp with time zone
-	, currikiLicense text
-	, externalUrl text
-	, resourceChecked text
-	, content text
-	, resourceCheckRequestNote text
-	, resourceCheckDate timestamp with time zone
-	, resourceCheckId bigint
-	, resourceCheckNote text
-	, studentFacing text
-	, source text
-	, reviewStatus text
-	, lastReviewDate timestamp with time zone
-	, reviewByID bigint
-	, reviewRating decimal
-	, technicalCompleteness integer
-	, contentAccuracy integer
-	, pedagogy integer
-	, ratingComment text
-	, standardsAlignment integer
-	, standardsAlignmentComment text
-	, subjectMatter integer
-	, subjectMatterComment text
-	, supportsTeaching integer
-	, supportsTeachingComment text
-	, assessmentsQuality integer
-	, assessmentsQualityComment text
-	, interactivityQuality integer
-	, interactivityQualityComment text
-	, instructionalQuality integer
-	, instructionalQualityComment text
-	, deeperLearning integer
-	, deeperLearningComment text
-	, partner text
-	, createDate timestamp with time zone
-	, type text
-	, featured text
-	, page text
-	, active text
-	, Public text
-	, xwd_id integer
-	, mediaType text
-	, access text
-	, memberRating decimal
-	, aligned text
-	, pageUrl text
-	, indexed text
-	, lastIndexDate timestamp with time zone
-	, indexRequired text
-	, indexRequiredDate timestamp with time zone
-	, rescrape text
-	, goButton text
-	, downloadButton text
-	, topOfSearch text
-	, remove text
-	, spam text
-	, topOfSearchInt integer
-	, partnerInt integer
-	, reviewResource text
-	, oldUrl text
-	, contentDisplayOk text
-	, metadata text
-	, approvalStatus text
-	, approvalStatusDate timestamp with time zone
-	, spamUser text
-	, url text
-	, displaySeqNo integer
-	, fileId integer
 	);
 
 DROP TABLE SiteUser CASCADE;
 DROP TABLE CurrikiResource CASCADE;
+DROP TABLE SiteUser CASCADE;
 */
 
 	protected static final Logger LOG = LoggerFactory.getLogger(MainVerticle.class);
@@ -325,13 +249,13 @@ DROP TABLE CurrikiResource CASCADE;
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchMainVerticle(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -339,13 +263,13 @@ DROP TABLE CurrikiResource CASCADE;
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrMainVerticle(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -353,14 +277,40 @@ DROP TABLE CurrikiResource CASCADE;
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqMainVerticle(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+			default:
+				return null;
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineMainVerticle(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineMainVerticle(String var, Object val) {
+		switch(var.toLowerCase()) {
 			default:
 				return null;
 		}
@@ -377,16 +327,4 @@ DROP TABLE CurrikiResource CASCADE;
 
 	public static final String[] MainVerticleVals = new String[] { configureDataConnectionError1, configureDataConnectionSuccess1, configureDataInitError1, configureDataInitSuccess1, configureOpenApiError1, configureOpenApiSuccess1, configureConfigComplete1, configureConfigFail1, configureSharedWorkerExecutorFail1, configureSharedWorkerExecutorComplete1, configureHealthChecksComplete1, configureHealthChecksFail1, configureHealthChecksErrorDatabase1, configureHealthChecksEmptySolr1, configureHealthChecksErrorSolr1, configureHealthChecksErrorVertx1, configureWebsocketsComplete1, configureWebsocketsFail1, configureEmailComplete1, configureEmailFail1, configureApiFail1, configureApiComplete1, configureUiFail1, configureUiComplete1, configureCamelFail1, configureCamelComplete1, startServerErrorServer1, startServerSuccessServer1, startServerBeforeServer1, startServerSsl1, stopFail1, stopComplete1 };
 
-	public static final String CLASS_SIMPLE_NAME = "MainVerticle";
-
-
-	public static String displayNameForClass(String var) {
-		return MainVerticle.displayNameMainVerticle(var);
-	}
-	public static String displayNameMainVerticle(String var) {
-		switch(var) {
-		default:
-			return null;
-		}
-	}
 }

--- a/src/gen/java/org/curriki/api/enus/vertx/MainVerticleGen.java
+++ b/src/gen/java/org/curriki/api/enus/vertx/MainVerticleGen.java
@@ -3,83 +3,167 @@ package org.curriki.api.enus.vertx;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import io.vertx.core.AbstractVerticle;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.MainVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.MainVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class MainVerticleGen<DEV> extends AbstractVerticle {
 
 /*
 CREATE TABLE SiteUser(
-	pk bigserial primary key
-	, inheritPk text
-	, created timestamp with time zone
-	, archived boolean
-	, deleted boolean
-	, sessionId text
-	, userKey bigint
-	);
-CREATE TABLE CurrikiResource(
-	pk bigserial primary key
-	, inheritPk text
-	, created timestamp with time zone
-	, archived boolean
-	, deleted boolean
-	, sessionId text
-	, userKey bigint
-	);
-CREATE TABLE SiteUser(
-	pk bigserial primary key
-	, inheritPk text
-	, created timestamp with time zone
-	, archived boolean
-	, deleted boolean
-	, sessionId text
-	, userKey bigint
-	, userId text
+	userId text
 	, userName text
 	, userEmail text
 	, userFirstName text
 	, userLastName text
 	, userFullName text
+	, seeArchived boolean
+	, seeDeleted boolean
+	);
+CREATE TABLE CurrikiResource(
+	resourceId text
+	, licenseId text
+	, contributorId bigint
+	, contributionDate timestamp with time zone
+	, description text
+	, title text
+	, keywordsStr text
+	, generatedKeywordsStr text
+	, language text
+	, lastEditorId bigint
+	, lastEditDate timestamp with time zone
+	, currikiLicense text
+	, externalUrl text
+	, resourceChecked text
+	, content text
+	, resourceCheckRequestNote text
+	, resourceCheckDate timestamp with time zone
+	, resourceCheckId bigint
+	, resourceCheckNote text
+	, studentFacing text
+	, source text
+	, reviewStatus text
+	, lastReviewDate timestamp with time zone
+	, reviewByID bigint
+	, reviewRating decimal
+	, technicalCompleteness integer
+	, contentAccuracy integer
+	, pedagogy integer
+	, ratingComment text
+	, standardsAlignment integer
+	, standardsAlignmentComment text
+	, subjectMatter integer
+	, subjectMatterComment text
+	, supportsTeaching integer
+	, supportsTeachingComment text
+	, assessmentsQuality integer
+	, assessmentsQualityComment text
+	, interactivityQuality integer
+	, interactivityQualityComment text
+	, instructionalQuality integer
+	, instructionalQualityComment text
+	, deeperLearning integer
+	, deeperLearningComment text
+	, partner text
+	, createDate timestamp with time zone
+	, type text
+	, featured text
+	, page text
+	, active text
+	, Public text
+	, xwd_id integer
+	, mediaType text
+	, access text
+	, memberRating decimal
+	, aligned text
+	, pageUrl text
+	, indexed text
+	, lastIndexDate timestamp with time zone
+	, indexRequired text
+	, indexRequiredDate timestamp with time zone
+	, rescrape text
+	, goButton text
+	, downloadButton text
+	, topOfSearch text
+	, remove text
+	, spam text
+	, topOfSearchInt integer
+	, partnerInt integer
+	, reviewResource text
+	, oldUrl text
+	, contentDisplayOk text
+	, metadata text
+	, approvalStatus text
+	, approvalStatusDate timestamp with time zone
+	, spamUser text
+	, url text
+	, displaySeqNo integer
+	, fileId integer
+	, fileName text
+	, uploadDate text
+	, sequence integer
+	, uniqueName text
+	, ext text
+	, resourceFilesActive text
+	, tempactive text
+	, s3path text
+	, sdfStatus text
+	, transcoded text
+	, lodestar text
+	, archive text
+	, identifier text
+	, educationLevelDisplayName text
+	, subjectArea text
+	, subjectAreaDisplayName text
+	, instructionTypeDisplayName text
+	, name text
+	);
+CREATE TABLE BaseModel(
+	pk bigserial primary key
+	, inheritPk text
+	, created timestamp with time zone
+	, archived boolean
+	, deleted boolean
+	, sessionId text
+	, userKey bigint
 	);
 
 DROP TABLE SiteUser CASCADE;
 DROP TABLE CurrikiResource CASCADE;
-DROP TABLE SiteUser CASCADE;
+DROP TABLE BaseModel CASCADE;
 */
 
 	protected static final Logger LOG = LoggerFactory.getLogger(MainVerticle.class);
@@ -249,13 +333,13 @@ DROP TABLE SiteUser CASCADE;
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrMainVerticle(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -263,13 +347,13 @@ DROP TABLE SiteUser CASCADE;
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrMainVerticle(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -277,40 +361,14 @@ DROP TABLE SiteUser CASCADE;
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqMainVerticle(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqMainVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqMainVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-			default:
-				return null;
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineMainVerticle(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineMainVerticle(String var, Object val) {
-		switch(var.toLowerCase()) {
 			default:
 				return null;
 		}
@@ -327,4 +385,15 @@ DROP TABLE SiteUser CASCADE;
 
 	public static final String[] MainVerticleVals = new String[] { configureDataConnectionError1, configureDataConnectionSuccess1, configureDataInitError1, configureDataInitSuccess1, configureOpenApiError1, configureOpenApiSuccess1, configureConfigComplete1, configureConfigFail1, configureSharedWorkerExecutorFail1, configureSharedWorkerExecutorComplete1, configureHealthChecksComplete1, configureHealthChecksFail1, configureHealthChecksErrorDatabase1, configureHealthChecksEmptySolr1, configureHealthChecksErrorSolr1, configureHealthChecksErrorVertx1, configureWebsocketsComplete1, configureWebsocketsFail1, configureEmailComplete1, configureEmailFail1, configureApiFail1, configureApiComplete1, configureUiFail1, configureUiComplete1, configureCamelFail1, configureCamelComplete1, startServerErrorServer1, startServerSuccessServer1, startServerBeforeServer1, startServerSsl1, stopFail1, stopComplete1 };
 
+
+
+	public static String displayNameForClass(String var) {
+		return MainVerticle.displayNameMainVerticle(var);
+	}
+	public static String displayNameMainVerticle(String var) {
+		switch(var) {
+		default:
+			return null;
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/vertx/WorkerVerticleGen.java
+++ b/src/gen/java/org/curriki/api/enus/vertx/WorkerVerticleGen.java
@@ -3,42 +3,42 @@ package org.curriki.api.enus.vertx;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Arrays;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import org.curriki.api.enus.base.BaseModel;
-import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
+import org.computate.search.serialize.ComputateLocalDateDeserializer;
 import java.util.HashMap;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import org.apache.commons.lang3.StringUtils;
 import java.text.NumberFormat;
 import java.util.ArrayList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
-import org.apache.commons.collections.CollectionUtils;
+import org.computate.vertx.api.ApiRequest;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import org.curriki.api.enus.model.base.BaseModel;
 import java.math.RoundingMode;
 import org.slf4j.Logger;
 import java.math.MathContext;
 import io.vertx.core.Promise;
-import org.apache.commons.text.StringEscapeUtils;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import org.curriki.api.enus.config.ConfigKeys;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.vertx.core.Future;
+import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
 import java.util.Objects;
+import org.computate.search.serialize.ComputateLocalDateSerializer;
 import io.vertx.core.json.JsonArray;
+import java.util.List;
+import org.computate.search.wrap.Wrap;
 import io.vertx.core.AbstractVerticle;
 import org.apache.commons.lang3.math.NumberUtils;
 import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.WorkerVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
- * <br/>
+ * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.WorkerVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br>
  **/
 public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	protected static final Logger LOG = LoggerFactory.getLogger(WorkerVerticle.class);
@@ -204,13 +204,13 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	////////////////
-	// staticSolr //
+	// staticSearch //
 	////////////////
 
-	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrWorkerVerticle(entityVar,  siteRequest_, o);
+	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSolrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSearchWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -218,13 +218,13 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	///////////////////
-	// staticSolrStr //
+	// staticSearchStr //
 	///////////////////
 
-	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSolrStrWorkerVerticle(entityVar,  siteRequest_, o);
+	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSearchStrWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrStrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSearchStrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -232,40 +232,14 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	//////////////////
-	// staticSolrFq //
+	// staticSearchFq //
 	//////////////////
 
-	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSolrFqWorkerVerticle(entityVar,  siteRequest_, o);
+	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSearchFqWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSolrFqWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSearchFqWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
-			default:
-				return null;
-		}
-	}
-
-	/////////////
-	// define //
-	/////////////
-
-	public boolean defineForClass(String var, Object val) {
-		String[] vars = StringUtils.split(var, ".");
-		Object o = null;
-		if(val != null) {
-			for(String v : vars) {
-				if(o == null)
-					o = defineWorkerVerticle(v, val);
-				else if(o instanceof BaseModel) {
-					BaseModel oBaseModel = (BaseModel)o;
-					o = oBaseModel.defineForClass(v, val);
-				}
-			}
-		}
-		return o != null;
-	}
-	public Object defineWorkerVerticle(String var, Object val) {
-		switch(var.toLowerCase()) {
 			default:
 				return null;
 		}
@@ -282,4 +256,15 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 
 	public static final String[] WorkerVerticleVals = new String[] { configureDataConnectionError1, configureDataConnectionSuccess1, configureDataInitError1, configureDataInitSuccess1, configureSharedWorkerExecutorFail1, configureSharedWorkerExecutorComplete1, configureEmailComplete1, configureEmailFail1, configureMoonshotsDataComplete1, configureMoonshotsDataFail1, importTimerScheduling1, importTimerSkip1, importDataClassComplete1, importDataClassFail1, importDataSkip1, importDataCurrikiResourceComplete1, importDataCurrikiResourceFail1, importDataCurrikiResourceSkip1, importDataCurrikiResourceRowFail1, processRowCurrikiResourceComplete1, processRowCurrikiResourceFail1, refreshAllDataComplete1, refreshAllDataStarted1, refreshAllDataFail1, refreshAllDataSkip1, refreshDataComplete1, refreshDataStarted1, refreshDataSkip1, refreshDataFail1, refreshDataCounterResetFail1 };
 
+
+
+	public static String displayNameForClass(String var) {
+		return WorkerVerticle.displayNameWorkerVerticle(var);
+	}
+	public static String displayNameWorkerVerticle(String var) {
+		switch(var) {
+		default:
+			return null;
+		}
+	}
 }

--- a/src/gen/java/org/curriki/api/enus/vertx/WorkerVerticleGen.java
+++ b/src/gen/java/org/curriki/api/enus/vertx/WorkerVerticleGen.java
@@ -1,50 +1,44 @@
 package org.curriki.api.enus.vertx;
 
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.base.BaseModel;
-import org.computate.vertx.api.ApiRequest;
-import org.curriki.api.enus.config.ConfigKeys;
-import java.util.Optional;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
-import java.util.Objects;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.computate.search.serialize.ComputateLocalDateSerializer;
-import org.computate.search.serialize.ComputateLocalDateDeserializer;
-import org.computate.search.serialize.ComputateZonedDateTimeSerializer;
-import org.computate.search.serialize.ComputateZonedDateTimeDeserializer;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
-import java.math.MathContext;
-import org.apache.commons.lang3.math.NumberUtils;
-import java.text.NumberFormat;
 import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.HashMap;
-import org.slf4j.Logger;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.curriki.api.enus.base.BaseModel;
+import org.curriki.api.enus.request.api.ApiRequest;
 import org.slf4j.LoggerFactory;
-import java.math.RoundingMode;
+import java.util.HashMap;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.apache.commons.lang3.StringUtils;
+import java.text.NumberFormat;
+import java.util.ArrayList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.java.ZonedDateTimeDeserializer;
+import org.apache.commons.collections.CollectionUtils;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
-import io.vertx.core.AbstractVerticle;
-import org.computate.search.wrap.Wrap;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.curriki.api.enus.java.ZonedDateTimeSerializer;
+import java.math.RoundingMode;
+import org.slf4j.Logger;
+import java.math.MathContext;
 import io.vertx.core.Promise;
+import org.apache.commons.text.StringEscapeUtils;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.curriki.api.enus.config.ConfigKeys;
 import io.vertx.core.Future;
+import java.util.Objects;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.AbstractVerticle;
+import org.apache.commons.lang3.math.NumberUtils;
+import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.curriki.api.enus.java.LocalDateSerializer;
 
 /**	
- * <br><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.WorkerVerticle">Find the class WorkerVerticle in Solr. </a>
- * <br><br>Delete the class WorkerVerticle in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.WorkerVerticle&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the package org.curriki.api.enus.vertx in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;classeNomEnsemble_enUS_indexed_string:org.curriki.api.enus.vertx&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>Delete  the project ActiveLearningStudio-API in Solr. 
- * <br><pre>curl 'http://localhost:8983/solr/computate/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data-raw '&lt;add&gt;&lt;delete&gt;&lt;query&gt;siteNom_indexed_string:ActiveLearningStudio\-API&lt;/query&gt;&lt;/delete&gt;&lt;/add&gt;'</pre>
- * <br>
+ * <br/><a href="http://localhost:8983/solr/computate/select?q=*:*&fq=partEstClasse_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.curriki.api.enus.vertx.WorkerVerticle&fq=classeEtendGen_indexed_boolean:true">Find the class  in Solr. </a>
+ * <br/>
  **/
 public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	protected static final Logger LOG = LoggerFactory.getLogger(WorkerVerticle.class);
@@ -210,13 +204,13 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	////////////////
-	// staticSearch //
+	// staticSolr //
 	////////////////
 
-	public static Object staticSearchForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchWorkerVerticle(entityVar,  siteRequest_, o);
+	public static Object staticSolrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static Object staticSearchWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static Object staticSolrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -224,13 +218,13 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	///////////////////
-	// staticSearchStr //
+	// staticSolrStr //
 	///////////////////
 
-	public static String staticSearchStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
-		return staticSearchStrWorkerVerticle(entityVar,  siteRequest_, o);
+	public static String staticSolrStrForClass(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+		return staticSolrStrWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchStrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
+	public static String staticSolrStrWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, Object o) {
 		switch(entityVar) {
 			default:
 				return null;
@@ -238,14 +232,40 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 	}
 
 	//////////////////
-	// staticSearchFq //
+	// staticSolrFq //
 	//////////////////
 
-	public static String staticSearchFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
-		return staticSearchFqWorkerVerticle(entityVar,  siteRequest_, o);
+	public static String staticSolrFqForClass(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+		return staticSolrFqWorkerVerticle(entityVar,  siteRequest_, o);
 	}
-	public static String staticSearchFqWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
+	public static String staticSolrFqWorkerVerticle(String entityVar, SiteRequestEnUS siteRequest_, String o) {
 		switch(entityVar) {
+			default:
+				return null;
+		}
+	}
+
+	/////////////
+	// define //
+	/////////////
+
+	public boolean defineForClass(String var, Object val) {
+		String[] vars = StringUtils.split(var, ".");
+		Object o = null;
+		if(val != null) {
+			for(String v : vars) {
+				if(o == null)
+					o = defineWorkerVerticle(v, val);
+				else if(o instanceof BaseModel) {
+					BaseModel oBaseModel = (BaseModel)o;
+					o = oBaseModel.defineForClass(v, val);
+				}
+			}
+		}
+		return o != null;
+	}
+	public Object defineWorkerVerticle(String var, Object val) {
+		switch(var.toLowerCase()) {
 			default:
 				return null;
 		}
@@ -262,16 +282,4 @@ public abstract class WorkerVerticleGen<DEV> extends AbstractVerticle {
 
 	public static final String[] WorkerVerticleVals = new String[] { configureDataConnectionError1, configureDataConnectionSuccess1, configureDataInitError1, configureDataInitSuccess1, configureSharedWorkerExecutorFail1, configureSharedWorkerExecutorComplete1, configureEmailComplete1, configureEmailFail1, configureMoonshotsDataComplete1, configureMoonshotsDataFail1, importTimerScheduling1, importTimerSkip1, importDataClassComplete1, importDataClassFail1, importDataSkip1, importDataCurrikiResourceComplete1, importDataCurrikiResourceFail1, importDataCurrikiResourceSkip1, importDataCurrikiResourceRowFail1, processRowCurrikiResourceComplete1, processRowCurrikiResourceFail1, refreshAllDataComplete1, refreshAllDataStarted1, refreshAllDataFail1, refreshAllDataSkip1, refreshDataComplete1, refreshDataStarted1, refreshDataSkip1, refreshDataFail1, refreshDataCounterResetFail1 };
 
-	public static final String CLASS_SIMPLE_NAME = "WorkerVerticle";
-
-
-	public static String displayNameForClass(String var) {
-		return WorkerVerticle.displayNameWorkerVerticle(var);
-	}
-	public static String displayNameWorkerVerticle(String var) {
-		switch(var) {
-		default:
-			return null;
-		}
-	}
 }

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModel.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModel.java
@@ -14,6 +14,7 @@ import org.curriki.api.enus.request.SiteRequestEnUS;
 
 /**
  * Indexed: true
+ * Model: true
  * Page: true
  * SuperPage: PageLayout
  * Keyword: classSimpleNameBaseModel
@@ -39,6 +40,7 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateVertxBas
 	 * HtmlCell: 1
 	 * DisplayName.enUS: primary key
 	 * Description: The primary key of this object in the database
+	 * Facet: true
 	 */
 	protected void _pk(Wrap<Long> w) {}
 
@@ -59,10 +61,11 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateVertxBas
 	 * VarCreated: true
 	 * HtmlRow: 1
 	 * HtmlCell: 2
-	 * HtmlColumn: 2
+	 * HtmlColumn: 1
 	 * DisplayName.enUS: created
 	 * FormatHtm: MMM d, yyyy h:mm:ss a
 	 * Description: A created timestamp for this record in the database
+	 * Facet: true
 	 */
 	protected void _created(Wrap<ZonedDateTime> w) {}
 
@@ -219,8 +222,7 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateVertxBas
 			Class<?> cl = getClass();
 
 			try {
-				String o = toId(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase((String)FieldUtils.getField(cl, cl.getSimpleName() + "_NameVar").get(this)), "-"));
-				w.o(o);
+				w.o(toId(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase((String)FieldUtils.getField(cl, String.format("%s_NameVar_%s", cl.getSimpleName(), siteRequest_.getLang())).get(this)), "-")));
 			} catch (Exception e) {
 				ExceptionUtils.rethrow(e);
 			}
@@ -297,6 +299,7 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateVertxBas
 	/**
 	 * {@inheritDoc}
 	 * DocValues: true
+	 * VarUrlApi: true
 	 * Description: The link to this object in the API
 	 */
 	protected void _pageUrlApi(Wrap<String> w) {

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModel.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModel.java
@@ -222,7 +222,7 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateVertxBas
 			Class<?> cl = getClass();
 
 			try {
-				w.o(toId(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase((String)FieldUtils.getField(cl, String.format("%s_NameVar_%s", cl.getSimpleName(), siteRequest_.getLang())).get(this)), "-")));
+				w.o(toId(StringUtils.join(StringUtils.splitByCharacterTypeCamelCase((String)FieldUtils.getField(cl, String.format("%s_NameVar", cl.getSimpleName())).get(this)), "-")));
 			} catch (Exception e) {
 				ExceptionUtils.rethrow(e);
 			}

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSApiServiceImpl.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSApiServiceImpl.java
@@ -1,0 +1,20 @@
+package org.curriki.api.enus.model.base;
+
+import io.vertx.ext.auth.authorization.AuthorizationProvider;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.json.JsonObject;
+import io.vertx.pgclient.PgPool;
+import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
+
+/**
+ * Translate: false
+ **/
+public class BaseModelEnUSApiServiceImpl extends BaseModelEnUSGenApiServiceImpl {
+
+	public BaseModelEnUSApiServiceImpl(EventBus eventBus, JsonObject config, WorkerExecutor workerExecutor, PgPool pgPool, WebClient webClient, OAuth2Auth oauth2AuthenticationProvider, AuthorizationProvider authorizationProvider, HandlebarsTemplateEngine templateEngine) {
+		super(eventBus, config, workerExecutor, pgPool, webClient, oauth2AuthenticationProvider, authorizationProvider, templateEngine);
+	}
+}

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSGenApiService.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSGenApiService.java
@@ -1,0 +1,32 @@
+package org.curriki.api.enus.model.base;
+
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.serviceproxy.ServiceBinder;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.web.api.service.WebApiServiceGen;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.pgclient.PgPool;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import io.vertx.ext.auth.authorization.AuthorizationProvider;
+
+/**
+ * Translate: false
+ * Gen: false
+ **/
+@WebApiServiceGen
+@ProxyGen
+public interface BaseModelEnUSGenApiService {
+	static void registerService(EventBus eventBus, JsonObject config, WorkerExecutor workerExecutor, PgPool pgPool, WebClient webClient, OAuth2Auth oauth2AuthenticationProvider, AuthorizationProvider authorizationProvider, HandlebarsTemplateEngine templateEngine, Vertx vertx) {
+		new ServiceBinder(vertx).setAddress("ActiveLearningStudio-API-enUS-BaseModel").register(BaseModelEnUSGenApiService.class, new BaseModelEnUSApiServiceImpl(eventBus, config, workerExecutor, pgPool, webClient, oauth2AuthenticationProvider, authorizationProvider, templateEngine));
+	}
+
+}

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModelEnUSGenApiServiceImpl.java
@@ -1,0 +1,432 @@
+package org.curriki.api.enus.model.base;
+
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.curriki.api.enus.model.user.SiteUser;
+import org.computate.vertx.api.ApiRequest;
+import org.computate.vertx.search.list.SearchResult;
+import org.computate.vertx.verticle.EmailVerticle;
+import org.curriki.api.enus.config.ConfigKeys;
+import org.computate.vertx.api.BaseApiServiceImpl;
+import io.vertx.ext.web.client.WebClient;
+import java.util.Objects;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.pgclient.PgPool;
+import io.vertx.core.json.impl.JsonUtil;
+import io.vertx.ext.auth.authorization.AuthorizationProvider;
+import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
+import io.vertx.core.eventbus.DeliveryOptions;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.time.Instant;
+import java.util.stream.Collectors;
+import io.vertx.core.json.Json;
+import org.apache.commons.lang3.StringUtils;
+import java.security.Principal;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Date;
+import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.HashSet;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+import org.apache.commons.lang3.math.NumberUtils;
+import io.vertx.ext.web.Router;
+import io.vertx.core.Vertx;
+import io.vertx.ext.reactivestreams.ReactiveReadStream;
+import io.vertx.ext.reactivestreams.ReactiveWriteStream;
+import io.vertx.core.MultiMap;
+import io.vertx.ext.auth.oauth2.OAuth2Auth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import io.vertx.sqlclient.Transaction;
+import io.vertx.sqlclient.SqlConnection;
+import io.vertx.sqlclient.Tuple;
+import io.vertx.sqlclient.Row;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.sql.Timestamp;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.AsyncResult;
+import java.net.URLEncoder;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.http.HttpHeaders;
+import java.nio.charset.Charset;
+import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.api.service.ServiceResponse;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import java.util.HashMap;
+import io.vertx.ext.auth.User;
+import java.util.Optional;
+import java.util.stream.Stream;
+import java.net.URLDecoder;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.Map.Entry;
+import java.util.Iterator;
+import org.computate.search.tool.SearchTool;
+import org.computate.search.response.solr.SolrResponse;
+import java.util.Base64;
+import java.time.ZonedDateTime;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.BooleanUtils;
+import org.curriki.api.enus.model.user.SiteUserEnUSApiServiceImpl;
+import org.computate.vertx.search.list.SearchList;
+
+
+/**
+ * Translate: false
+ **/
+public class BaseModelEnUSGenApiServiceImpl extends BaseApiServiceImpl implements BaseModelEnUSGenApiService {
+
+	protected static final Logger LOG = LoggerFactory.getLogger(BaseModelEnUSGenApiServiceImpl.class);
+
+	public BaseModelEnUSGenApiServiceImpl(EventBus eventBus, JsonObject config, WorkerExecutor workerExecutor, PgPool pgPool, WebClient webClient, OAuth2Auth oauth2AuthenticationProvider, AuthorizationProvider authorizationProvider, HandlebarsTemplateEngine templateEngine) {
+		super(eventBus, config, workerExecutor, pgPool, webClient, oauth2AuthenticationProvider, authorizationProvider, templateEngine);
+	}
+
+	// General //
+
+	public void searchBaseModelQ(SearchList<BaseModel> searchList, String entityVar, String valueIndexed, String varIndexed) {
+		searchList.q(varIndexed + ":" + ("*".equals(valueIndexed) ? valueIndexed : SearchTool.escapeQueryChars(valueIndexed)));
+		if(!"*".equals(entityVar)) {
+		}
+	}
+
+	public String searchBaseModelFq(SearchList<BaseModel> searchList, String entityVar, String valueIndexed, String varIndexed) {
+		if(varIndexed == null)
+			throw new RuntimeException(String.format("\"%s\" is not an indexed entity. ", entityVar));
+		if(StringUtils.startsWith(valueIndexed, "[")) {
+			String[] fqs = StringUtils.substringBefore(StringUtils.substringAfter(valueIndexed, "["), "]").split(" TO ");
+			if(fqs.length != 2)
+				throw new RuntimeException(String.format("\"%s\" invalid range query. ", valueIndexed));
+			String fq1 = fqs[0].equals("*") ? fqs[0] : BaseModel.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[0]);
+			String fq2 = fqs[1].equals("*") ? fqs[1] : BaseModel.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[1]);
+			 return varIndexed + ":[" + fq1 + " TO " + fq2 + "]";
+		} else {
+			return varIndexed + ":" + SearchTool.escapeQueryChars(BaseModel.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), valueIndexed)).replace("\\", "\\\\");
+		}
+	}
+
+	public void searchBaseModelSort(SearchList<BaseModel> searchList, String entityVar, String valueIndexed, String varIndexed) {
+		if(varIndexed == null)
+			throw new RuntimeException(String.format("\"%s\" is not an indexed entity. ", entityVar));
+		searchList.sort(varIndexed, valueIndexed);
+	}
+
+	public void searchBaseModelRows(SearchList<BaseModel> searchList, Long valueRows) {
+			searchList.rows(valueRows != null ? valueRows : 10L);
+	}
+
+	public void searchBaseModelStart(SearchList<BaseModel> searchList, Long valueStart) {
+		searchList.start(valueStart);
+	}
+
+	public void searchBaseModelVar(SearchList<BaseModel> searchList, String var, String value) {
+		searchList.getSiteRequest_(SiteRequestEnUS.class).getRequestVars().put(var, value);
+	}
+
+	public void searchBaseModelUri(SearchList<BaseModel> searchList) {
+	}
+
+	public Future<ServiceResponse> varsBaseModel(SiteRequestEnUS siteRequest) {
+		Promise<ServiceResponse> promise = Promise.promise();
+		try {
+			ServiceRequest serviceRequest = siteRequest.getServiceRequest();
+
+			serviceRequest.getParams().getJsonObject("query").stream().filter(paramRequest -> "var".equals(paramRequest.getKey()) && paramRequest.getValue() != null).findFirst().ifPresent(paramRequest -> {
+				String entityVar = null;
+				String valueIndexed = null;
+				Object paramValuesObject = paramRequest.getValue();
+				JsonArray paramObjects = paramValuesObject instanceof JsonArray ? (JsonArray)paramValuesObject : new JsonArray().add(paramValuesObject);
+
+				try {
+					for(Object paramObject : paramObjects) {
+						entityVar = StringUtils.trim(StringUtils.substringBefore((String)paramObject, ":"));
+						valueIndexed = URLDecoder.decode(StringUtils.trim(StringUtils.substringAfter((String)paramObject, ":")), "UTF-8");
+						siteRequest.getRequestVars().put(entityVar, valueIndexed);
+					}
+				} catch(Exception ex) {
+					LOG.error(String.format("searchBaseModel failed. "), ex);
+					promise.fail(ex);
+				}
+			});
+			promise.complete();
+		} catch(Exception ex) {
+			LOG.error(String.format("searchBaseModel failed. "), ex);
+			promise.fail(ex);
+		}
+		return promise.future();
+	}
+
+	public Future<SearchList<BaseModel>> searchBaseModelList(SiteRequestEnUS siteRequest, Boolean populate, Boolean store, Boolean modify) {
+		Promise<SearchList<BaseModel>> promise = Promise.promise();
+		try {
+			ServiceRequest serviceRequest = siteRequest.getServiceRequest();
+			String entityListStr = siteRequest.getServiceRequest().getParams().getJsonObject("query").getString("fl");
+			String[] entityList = entityListStr == null ? null : entityListStr.split(",\\s*");
+			SearchList<BaseModel> searchList = new SearchList<BaseModel>();
+			searchList.setPopulate(populate);
+			searchList.setStore(store);
+			searchList.q("*:*");
+			searchList.setC(BaseModel.class);
+			searchList.setSiteRequest_(siteRequest);
+			if(entityList != null) {
+				for(String v : entityList) {
+					searchList.fl(BaseModel.varIndexedBaseModel(v));
+				}
+			}
+
+			String id = serviceRequest.getParams().getJsonObject("path").getString("id");
+			if(id != null && NumberUtils.isCreatable(id)) {
+				searchList.fq("(pk_docvalues_long:" + SearchTool.escapeQueryChars(id) + " OR objectId_docvalues_string:" + SearchTool.escapeQueryChars(id) + ")");
+			} else if(id != null) {
+				searchList.fq("objectId_docvalues_string:" + SearchTool.escapeQueryChars(id));
+			}
+
+			serviceRequest.getParams().getJsonObject("query").forEach(paramRequest -> {
+				String entityVar = null;
+				String valueIndexed = null;
+				String varIndexed = null;
+				String valueSort = null;
+				Long valueStart = null;
+				Long valueRows = null;
+				String valueCursorMark = null;
+				String paramName = paramRequest.getKey();
+				Object paramValuesObject = paramRequest.getValue();
+				JsonArray paramObjects = paramValuesObject instanceof JsonArray ? (JsonArray)paramValuesObject : new JsonArray().add(paramValuesObject);
+
+				try {
+					if(paramValuesObject != null && "facet.pivot".equals(paramName)) {
+						Matcher mFacetPivot = Pattern.compile("(?:(\\{![^\\}]+\\}))?(.*)").matcher(StringUtils.join(paramObjects.getList().toArray(), ","));
+						boolean foundFacetPivot = mFacetPivot.find();
+						if(foundFacetPivot) {
+							String solrLocalParams = mFacetPivot.group(1);
+							String[] entityVars = mFacetPivot.group(2).trim().split(",");
+							String[] varsIndexed = new String[entityVars.length];
+							for(Integer i = 0; i < entityVars.length; i++) {
+								entityVar = entityVars[i];
+								varsIndexed[i] = BaseModel.varIndexedBaseModel(entityVar);
+							}
+							searchList.facetPivot((solrLocalParams == null ? "" : solrLocalParams) + StringUtils.join(varsIndexed, ","));
+						}
+					} else if(paramValuesObject != null) {
+						for(Object paramObject : paramObjects) {
+							switch(paramName) {
+								case "q":
+									Matcher mQ = Pattern.compile("(\\w+):(.+?(?=(\\)|\\s+OR\\s+|\\s+AND\\s+|\\^|$)))").matcher((String)paramObject);
+									boolean foundQ = mQ.find();
+									if(foundQ) {
+										StringBuffer sb = new StringBuffer();
+										while(foundQ) {
+											entityVar = mQ.group(1).trim();
+											valueIndexed = mQ.group(2).trim();
+											varIndexed = BaseModel.varIndexedBaseModel(entityVar);
+											String entityQ = searchBaseModelFq(searchList, entityVar, valueIndexed, varIndexed);
+											mQ.appendReplacement(sb, entityQ);
+											foundQ = mQ.find();
+										}
+										mQ.appendTail(sb);
+										searchList.q(sb.toString());
+									}
+									break;
+								case "fq":
+									Matcher mFq = Pattern.compile("(\\w+):(.+?(?=(\\)|\\s+OR\\s+|\\s+AND\\s+|$)))").matcher((String)paramObject);
+									boolean foundFq = mFq.find();
+									if(foundFq) {
+										StringBuffer sb = new StringBuffer();
+										while(foundFq) {
+											entityVar = mFq.group(1).trim();
+											valueIndexed = mFq.group(2).trim();
+											varIndexed = BaseModel.varIndexedBaseModel(entityVar);
+											String entityFq = searchBaseModelFq(searchList, entityVar, valueIndexed, varIndexed);
+											mFq.appendReplacement(sb, entityFq);
+											foundFq = mFq.find();
+										}
+										mFq.appendTail(sb);
+										searchList.fq(sb.toString());
+									}
+									break;
+								case "sort":
+									entityVar = StringUtils.trim(StringUtils.substringBefore((String)paramObject, " "));
+									valueIndexed = StringUtils.trim(StringUtils.substringAfter((String)paramObject, " "));
+									varIndexed = BaseModel.varIndexedBaseModel(entityVar);
+									searchBaseModelSort(searchList, entityVar, valueIndexed, varIndexed);
+									break;
+								case "start":
+									valueStart = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									searchBaseModelStart(searchList, valueStart);
+									break;
+								case "rows":
+									valueRows = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									searchBaseModelRows(searchList, valueRows);
+									break;
+								case "facet":
+									searchList.facet((Boolean)paramObject);
+									break;
+								case "facet.range.start":
+									String startMathStr = (String)paramObject;
+									Date start = SearchTool.parseMath(startMathStr);
+									searchList.facetRangeStart(start.toInstant().toString());
+									break;
+								case "facet.range.end":
+									String endMathStr = (String)paramObject;
+									Date end = SearchTool.parseMath(endMathStr);
+									searchList.facetRangeEnd(end.toInstant().toString());
+									break;
+								case "facet.range.gap":
+									String gap = (String)paramObject;
+									searchList.facetRangeGap(gap);
+									break;
+								case "facet.range":
+									Matcher mFacetRange = Pattern.compile("(?:(\\{![^\\}]+\\}))?(.*)").matcher((String)paramObject);
+									boolean foundFacetRange = mFacetRange.find();
+									if(foundFacetRange) {
+										String solrLocalParams = mFacetRange.group(1);
+										entityVar = mFacetRange.group(2).trim();
+										varIndexed = BaseModel.varIndexedBaseModel(entityVar);
+										searchList.facetRange((solrLocalParams == null ? "" : solrLocalParams) + varIndexed);
+									}
+									break;
+								case "facet.field":
+									entityVar = (String)paramObject;
+									varIndexed = BaseModel.varIndexedBaseModel(entityVar);
+									if(varIndexed != null)
+										searchList.facetField(varIndexed);
+									break;
+								case "var":
+									entityVar = StringUtils.trim(StringUtils.substringBefore((String)paramObject, ":"));
+									valueIndexed = URLDecoder.decode(StringUtils.trim(StringUtils.substringAfter((String)paramObject, ":")), "UTF-8");
+									searchBaseModelVar(searchList, entityVar, valueIndexed);
+									break;
+								case "cursorMark":
+									valueCursorMark = (String)paramObject;
+									searchList.cursorMark((String)paramObject);
+									break;
+							}
+						}
+						searchBaseModelUri(searchList);
+					}
+				} catch(Exception e) {
+					ExceptionUtils.rethrow(e);
+				}
+			});
+			if("*:*".equals(searchList.getQuery()) && searchList.getSorts().size() == 0) {
+				searchList.sort("created_docvalues_date", "desc");
+			}
+			searchBaseModel2(siteRequest, populate, store, modify, searchList);
+			searchList.promiseDeepForClass(siteRequest).onSuccess(a -> {
+				promise.complete(searchList);
+			}).onFailure(ex -> {
+				LOG.error(String.format("searchBaseModel failed. "), ex);
+				promise.fail(ex);
+			});
+		} catch(Exception ex) {
+			LOG.error(String.format("searchBaseModel failed. "), ex);
+			promise.fail(ex);
+		}
+		return promise.future();
+	}
+	public void searchBaseModel2(SiteRequestEnUS siteRequest, Boolean populate, Boolean store, Boolean modify, SearchList<BaseModel> searchList) {
+	}
+
+	public Future<Void> persistBaseModel(BaseModel o) {
+		Promise<Void> promise = Promise.promise();
+		try {
+			SiteRequestEnUS siteRequest = o.getSiteRequest_();
+			SqlConnection sqlConnection = siteRequest.getSqlConnection();
+			Long pk = o.getPk();
+			sqlConnection.preparedQuery("SELECT * FROM BaseModel WHERE pk=$1")
+					.collecting(Collectors.toList())
+					.execute(Tuple.of(pk)
+					).onSuccess(result -> {
+				try {
+					for(Row definition : result.value()) {
+						for(Integer i = 0; i < definition.size(); i++) {
+							String columnName = definition.getColumnName(i);
+							Object columnValue = definition.getValue(i);
+							if(!"pk".equals(columnName)) {
+								try {
+									o.persistForClass(columnName, columnValue);
+								} catch(Exception e) {
+									LOG.error(String.format("persistBaseModel failed. "), e);
+								}
+							}
+						}
+					}
+					promise.complete();
+				} catch(Exception ex) {
+					LOG.error(String.format("persistBaseModel failed. "), ex);
+					promise.fail(ex);
+				}
+			}).onFailure(ex -> {
+				RuntimeException ex2 = new RuntimeException(ex);
+				LOG.error(String.format("persistBaseModel failed. "), ex2);
+				promise.fail(ex2);
+			});
+		} catch(Exception ex) {
+			LOG.error(String.format("persistBaseModel failed. "), ex);
+			promise.fail(ex);
+		}
+		return promise.future();
+	}
+
+	public Future<Void> relateBaseModel(BaseModel o) {
+		Promise<Void> promise = Promise.promise();
+			promise.complete();
+		return promise.future();
+	}
+
+	public Future<Void> indexBaseModel(BaseModel o) {
+		Promise<Void> promise = Promise.promise();
+		try {
+			SiteRequestEnUS siteRequest = o.getSiteRequest_();
+			ApiRequest apiRequest = siteRequest.getApiRequest_();
+			o.promiseDeepForClass(siteRequest).onSuccess(a -> {
+				JsonObject json = new JsonObject();
+				JsonObject add = new JsonObject();
+				json.put("add", add);
+				JsonObject doc = new JsonObject();
+				add.put("doc", doc);
+				o.indexBaseModel(doc);
+				String solrHostName = siteRequest.getConfig().getString(ConfigKeys.SOLR_HOST_NAME);
+				Integer solrPort = siteRequest.getConfig().getInteger(ConfigKeys.SOLR_PORT);
+				String solrCollection = siteRequest.getConfig().getString(ConfigKeys.SOLR_COLLECTION);
+				Boolean softCommit = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getBoolean("softCommit")).orElse(null);
+				Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
+					if(softCommit == null && commitWithin == null)
+						softCommit = true;
+					else if(softCommit == null)
+						softCommit = false;
+				String solrRequestUri = String.format("/solr/%s/update%s%s%s", solrCollection, "?overwrite=true&wt=json", softCommit ? "&softCommit=true" : "", commitWithin != null ? ("&commitWithin=" + commitWithin) : "");
+				webClient.post(solrPort, solrHostName, solrRequestUri).putHeader("Content-Type", "application/json").expect(ResponsePredicate.SC_OK).sendBuffer(json.toBuffer()).onSuccess(b -> {
+					promise.complete();
+				}).onFailure(ex -> {
+					LOG.error(String.format("indexBaseModel failed. "), new RuntimeException(ex));
+					promise.fail(ex);
+				});
+			}).onFailure(ex -> {
+				LOG.error(String.format("indexBaseModel failed. "), ex);
+				promise.fail(ex);
+			});
+		} catch(Exception ex) {
+			LOG.error(String.format("indexBaseModel failed. "), ex);
+			promise.fail(ex);
+		}
+		return promise.future();
+	}
+}

--- a/src/main/java/org/curriki/api/enus/model/base/BaseModelGenPage.java
+++ b/src/main/java/org/curriki/api/enus/model/base/BaseModelGenPage.java
@@ -1,5 +1,6 @@
 package org.curriki.api.enus.model.base;
 
+import org.curriki.api.enus.model.base.BaseModel;
 import org.curriki.api.enus.request.SiteRequestEnUS;
 import java.lang.Long;
 import java.lang.String;
@@ -9,12 +10,12 @@ import java.util.Locale;
 import java.lang.Boolean;
 import java.util.List;
 import org.curriki.api.enus.page.PageLayout;
-import org.curriki.api.enus.user.SiteUser;
+import org.curriki.api.enus.model.user.SiteUser;
 import java.io.IOException;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import org.curriki.api.enus.search.SearchList;
-import org.curriki.api.enus.wrap.Wrap;
+import org.computate.vertx.search.list.SearchList;
+import org.computate.search.wrap.Wrap;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.LocalDate;
@@ -27,18 +28,19 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.apache.solr.common.util.SimpleOrderedMap;
 import java.util.stream.Collectors;
 import java.util.Arrays;
-import org.apache.solr.client.solrj.response.QueryResponse;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.math.MathContext;
 import org.apache.commons.collections.CollectionUtils;
 import java.util.Objects;
-import org.apache.solr.client.solrj.SolrQuery.SortClause;
 import io.vertx.core.Promise;
 import org.curriki.api.enus.config.ConfigKeys;
+import org.computate.search.response.solr.SolrResponse;
+import java.util.HashMap;
+import org.computate.search.tool.TimeTool;
+import java.time.ZoneId;
 
 
 /**
@@ -53,11 +55,36 @@ public class BaseModelGenPage extends BaseModelGenPageGen<PageLayout> {
 	protected void _searchListBaseModel_(Wrap<SearchList<BaseModel>> w) {
 	}
 
+	protected void _pageResponse(Wrap<String> w) {
+		if(searchListBaseModel_ != null)
+			w.o(JsonObject.mapFrom(searchListBaseModel_.getQueryResponse()).toString());
+	}
+
+	protected void _defaultPivotVars(List<String> l) {
+		Optional.ofNullable(searchListBaseModel_.getFacetPivots()).orElse(Arrays.asList()).forEach(facetPivot -> {
+			String facetPivot2 = facetPivot;
+			if(StringUtils.contains(facetPivot2, "}"))
+				facetPivot2 = StringUtils.substringAfterLast(facetPivot2, "}");
+			String[] parts = facetPivot2.split(",");
+			for(String part : parts) {
+				if(StringUtils.isNotBlank(part)) {
+					String var = StringUtils.substringBefore(part, "_");
+					if(StringUtils.isNotBlank(var))
+						l.add(var);
+				}
+			}
+		});
+	}
+
 	/**
 	 * {@inheritDoc}
 	 **/
 	protected void _listBaseModel(JsonArray l) {
 		Optional.ofNullable(searchListBaseModel_).map(o -> o.getList()).orElse(Arrays.asList()).stream().map(o -> JsonObject.mapFrom(o)).forEach(o -> l.add(o));
+	}
+
+	protected void _facetCounts(Wrap<SolrResponse.FacetCounts> w) {
+		w.o(searchListBaseModel_.getQueryResponse().getFacetCounts());
 	}
 
 	protected void _baseModelCount(Wrap<Integer> w) {
@@ -72,6 +99,11 @@ public class BaseModelGenPage extends BaseModelGenPageGen<PageLayout> {
 	protected void _pk(Wrap<Long> w) {
 		if(baseModelCount == 1)
 			w.o(baseModel_.getPk());
+	}
+
+	protected void _id(Wrap<String> w) {
+		if(baseModelCount == 1)
+			w.o(baseModel_.getId());
 	}
 
 	@Override
@@ -111,7 +143,7 @@ public class BaseModelGenPage extends BaseModelGenPageGen<PageLayout> {
 		JsonArray pages = new JsonArray();
 		Long start = searchListBaseModel_.getStart().longValue();
 		Long rows = searchListBaseModel_.getRows().longValue();
-		Long foundNum = searchListBaseModel_.getQueryResponse().getResults().getNumFound();
+		Long foundNum = searchListBaseModel_.getQueryResponse().getResponse().getNumFound().longValue();
 		Long startNum = start + 1L;
 		Long endNum = start + rows;
 		Long floorMod = Math.floorMod(foundNum, rows);
@@ -152,12 +184,64 @@ public class BaseModelGenPage extends BaseModelGenPageGen<PageLayout> {
 	}
 
 	@Override
+	protected void _varsQ(JsonObject vars) {
+		BaseModel.varsQForClass().forEach(var -> {
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(BaseModel.displayNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(BaseModel.classSimpleNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", Optional.ofNullable(searchListBaseModel_.getRequest().getQuery()).filter(fq -> fq.startsWith(BaseModel.varIndexedBaseModel(var) + ":")).map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsFq(JsonObject vars) {
+		Map<String, SolrResponse.FacetField> facetFields = Optional.ofNullable(facetCounts).map(c -> c.getFacetFields()).map(f -> f.getFacets()).orElse(new HashMap<String,SolrResponse.FacetField>());
+		BaseModel.varsFqForClass().forEach(var -> {
+			String varIndexed = BaseModel.varIndexedBaseModel(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(BaseModel.displayNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(BaseModel.classSimpleNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListBaseModel_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(BaseModel.varIndexedBaseModel(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			Optional.ofNullable(facetFields.get(varIndexed)).ifPresent(facetField -> {
+				JsonObject facetJson = new JsonObject();
+				JsonObject counts = new JsonObject();
+				facetJson.put("var", var);
+				facetField.getCounts().forEach((val, count) -> {
+					counts.put(val, count);
+				});
+				facetJson.put("counts", counts);
+				json.put("facetField", facetJson);
+			});
+			if(defaultPivotVars.contains(var)) {
+				json.put("pivot", true);
+			}
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsRange(JsonObject vars) {
+		BaseModel.varsRangeForClass().forEach(var -> {
+			String varIndexed = BaseModel.varIndexedBaseModel(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(BaseModel.displayNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(BaseModel.classSimpleNameBaseModel(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListBaseModel_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(BaseModel.varIndexedBaseModel(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
 	protected void _query(JsonObject query) {
 		ServiceRequest serviceRequest = siteRequest_.getServiceRequest();
 		JsonObject params = serviceRequest.getParams();
 
 		JsonObject queryParams = Optional.ofNullable(serviceRequest).map(ServiceRequest::getParams).map(or -> or.getJsonObject("query")).orElse(new JsonObject());
-		Long num = searchListBaseModel_.getQueryResponse().getResults().getNumFound();
+		Long num = searchListBaseModel_.getQueryResponse().getResponse().getNumFound().longValue();
 		String q = "*:*";
 		String q1 = "objectText";
 		String q2 = "";
@@ -185,27 +269,28 @@ public class BaseModelGenPage extends BaseModelGenPageGen<PageLayout> {
 		}
 		query.put("q", q);
 
-		Integer rows1 = Optional.ofNullable(searchListBaseModel_).map(l -> l.getRows()).orElse(10);
-		Integer start1 = Optional.ofNullable(searchListBaseModel_).map(l -> l.getStart()).orElse(1);
-		Integer start2 = start1 - rows1;
-		Integer start3 = start1 + rows1;
-		Integer rows2 = rows1 / 2;
-		Integer rows3 = rows1 * 2;
+		Long rows1 = Optional.ofNullable(searchListBaseModel_).map(l -> l.getRows()).orElse(10L);
+		Long start1 = Optional.ofNullable(searchListBaseModel_).map(l -> l.getStart()).orElse(1L);
+		Long start2 = start1 - rows1;
+		Long start3 = start1 + rows1;
+		Long rows2 = rows1 / 2;
+		Long rows3 = rows1 * 2;
 		start2 = start2 < 0 ? 0 : start2;
-		JsonArray fqs = new JsonArray();
-		for(String fq : Optional.ofNullable(searchListBaseModel_).map(l -> l.getFilterQueries()).orElse(new String[0])) {
+		JsonObject fqs = new JsonObject();
+		for(String fq : Optional.ofNullable(searchListBaseModel_).map(l -> l.getFilterQueries()).orElse(Arrays.asList())) {
 			if(!StringUtils.contains(fq, "(")) {
 				String fq1 = StringUtils.substringBefore(fq, "_");
 				String fq2 = StringUtils.substringAfter(fq, ":");
 				if(!StringUtils.startsWithAny(fq, "classCanonicalNames_", "archived_", "deleted_", "sessionId", "userKeys"))
-					fqs.add(new JsonObject().put("var", fq1).put("val", fq2));
+					fqs.put(fq1, new JsonObject().put("var", fq1).put("val", fq2).put("displayName", BaseModel.displayNameForClass(fq1)));
 				}
 			}
 		query.put("fq", fqs);
 
 		JsonArray sorts = new JsonArray();
-		for(SortClause sort : Optional.ofNullable(searchListBaseModel_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
-			sorts.add(new JsonObject().put("var", StringUtils.substringBefore(sort.getItem(), "_")).put("order", sort.getOrder().name()));
+		for(String sort : Optional.ofNullable(searchListBaseModel_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
+			String sort1 = StringUtils.substringBefore(sort, "_");
+			sorts.add(new JsonObject().put("var", sort1).put("order", StringUtils.substringAfter(sort, " ")).put("displayName", BaseModel.displayNameForClass(sort1)));
 		}
 		query.put("sort", sorts);
 	}

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
@@ -1157,7 +1157,7 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 */
 	protected void _subjectArea(Wrap<String> w) {
 	}
-	
+
 	/**
 	 * {@inheritDoc}
 	 * DocValues: true
@@ -1166,7 +1166,7 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 * HtmlRow: 36
 	 * HtmlCell: 1
 	 */
-	protected void _subjectAreaDisplayName(Wrap<Integer> w) {
+	protected void _subjectAreaDisplayName(Wrap<String> w) {
 	}
 	
 	/**
@@ -1177,7 +1177,7 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 * HtmlRow: 36
 	 * HtmlCell: 2
 	 */
-	protected void _instructionTypeDisplayName(Wrap<Integer> w) {
+	protected void _instructionTypeDisplayName(Wrap<String> w) {
 	}
 
 	/**

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
@@ -38,7 +38,7 @@ import org.curriki.api.enus.model.base.BaseModel;
  * IconName: file
  *  
  * 
- */ 
+ */
 public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
  
 	/**
@@ -1048,17 +1048,17 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	protected void _ext(Wrap<String> w) {
 	}
 	
-//	/**
-//	 * {@inheritDoc}
-//	 * DocValues: true
-//	 * Persist: true
-//	 * DisplayName: Active
-//	 * HtmlRow: 32
-//	 * HtmlCell: 3
-//	 */
-//	protected void _active(Wrap<String> w) {
-//	}
-	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Resource Files Active
+	 * HtmlRow: 32
+	 * HtmlCell: 3
+	 */
+	protected void _resourceFilesActive(Wrap<String> w) {
+	}
+
 	/**
 	 * {@inheritDoc}
 	 * DocValues: true
@@ -1140,11 +1140,11 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 * {@inheritDoc}
 	 * DocValues: true
 	 * Persist: true
-	 * DisplayName: Display Name
+	 * DisplayName: Education Level Display Name
 	 * HtmlRow: 35
 	 * HtmlCell: 2
 	 */
-	protected void _displayName(Wrap<String> w) {
+	protected void _educationLevelDisplayName(Wrap<String> w) {
 	}
 	
 	/**
@@ -1158,27 +1158,27 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	protected void _subjectArea(Wrap<String> w) {
 	}
 	
-//	/**
-//	 * {@inheritDoc}
-//	 * DocValues: true
-//	 * Persist: true
-//	 * DisplayName: Display Name
-//	 * HtmlRow: 30
-//	 * HtmlCell: 3
-//	 */
-//	protected void _displayName(Wrap<Integer> w) {
-//	}
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Subject Area Display Name
+	 * HtmlRow: 36
+	 * HtmlCell: 1
+	 */
+	protected void _subjectAreaDisplayName(Wrap<Integer> w) {
+	}
 	
-//	/**
-//	 * {@inheritDoc}
-//	 * DocValues: true
-//	 * Persist: true
-//	 * DisplayName: Display Name
-//	 * HtmlRow: 30
-//	 * HtmlCell: 3
-//	 */
-//	protected void _displayName(Wrap<Integer> w) {
-//	}
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Instruction Type Display Name
+	 * HtmlRow: 36
+	 * HtmlCell: 2
+	 */
+	protected void _instructionTypeDisplayName(Wrap<Integer> w) {
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -1186,14 +1186,10 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 * Persist: true
 	 * DisplayName: Name
 	 * HtmlRow: 36
-	 * HtmlCell: 1
+	 * HtmlCell: 3
 	 */
 	protected void _name(Wrap<String> w) {
 	}
-
-//	+ " rl.url, rl.displayseqno, rf.fileid, rf.filename, rf.uploaddate, rf.sequence, rf.uniquename,"
-//	+ " rf.ext, rf.active, rf.tempactive, rf.s3path, rf.SDFstatus, rf.transcoded, rf.lodestar,"
-//	+ " rf.archive, edu.identifier, edu.displayname, sub.subjectarea, sub.displayname, inst.displayname, inst.name"
 	
 	@Override
 	public String toString() {

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResource.java
@@ -992,6 +992,204 @@ public class CurrikiResource extends CurrikiResourceGen <BaseModel> {
 	 */
 	protected void _fileId(Wrap<Integer> w) {
 	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Filename
+	 * HtmlRow: 31
+	 * HtmlCell: 1
+	 */
+	protected void _fileName(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Upload Date
+	 * HtmlRow: 31
+	 * HtmlCell: 2
+	 */
+	protected void _uploadDate(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Sequence
+	 * HtmlRow: 31
+	 * HtmlCell: 3
+	 */
+	protected void _sequence(Wrap<Integer> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Unique Name
+	 * HtmlRow: 32
+	 * HtmlCell: 1
+	 */
+	protected void _uniqueName(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Ext
+	 * HtmlRow: 32
+	 * HtmlCell: 2
+	 */
+	protected void _ext(Wrap<String> w) {
+	}
+	
+//	/**
+//	 * {@inheritDoc}
+//	 * DocValues: true
+//	 * Persist: true
+//	 * DisplayName: Active
+//	 * HtmlRow: 32
+//	 * HtmlCell: 3
+//	 */
+//	protected void _active(Wrap<String> w) {
+//	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Tempactive
+	 * HtmlRow: 33
+	 * HtmlCell: 1
+	 */
+	protected void _tempactive(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: S3 Path
+	 * HtmlRow: 33
+	 * HtmlCell: 2
+	 */
+	protected void _s3path(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: SDF Status
+	 * HtmlRow: 33
+	 * HtmlCell: 3
+	 */
+	protected void _sdfStatus(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Transcoded
+	 * HtmlRow: 34
+	 * HtmlCell: 1
+	 */
+	protected void _transcoded(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Lodestar
+	 * HtmlRow: 34
+	 * HtmlCell: 2
+	 */
+	protected void _lodestar(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Archive
+	 * HtmlRow: 34
+	 * HtmlCell: 3
+	 */
+	protected void _archive(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Identifier
+	 * HtmlRow: 35
+	 * HtmlCell: 1
+	 */
+	protected void _identifier(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Display Name
+	 * HtmlRow: 35
+	 * HtmlCell: 2
+	 */
+	protected void _displayName(Wrap<String> w) {
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Subject Area
+	 * HtmlRow: 35
+	 * HtmlCell: 3
+	 */
+	protected void _subjectArea(Wrap<String> w) {
+	}
+	
+//	/**
+//	 * {@inheritDoc}
+//	 * DocValues: true
+//	 * Persist: true
+//	 * DisplayName: Display Name
+//	 * HtmlRow: 30
+//	 * HtmlCell: 3
+//	 */
+//	protected void _displayName(Wrap<Integer> w) {
+//	}
+	
+//	/**
+//	 * {@inheritDoc}
+//	 * DocValues: true
+//	 * Persist: true
+//	 * DisplayName: Display Name
+//	 * HtmlRow: 30
+//	 * HtmlCell: 3
+//	 */
+//	protected void _displayName(Wrap<Integer> w) {
+//	}
+
+	/**
+	 * {@inheritDoc}
+	 * DocValues: true
+	 * Persist: true
+	 * DisplayName: Name
+	 * HtmlRow: 36
+	 * HtmlCell: 1
+	 */
+	protected void _name(Wrap<String> w) {
+	}
 
 //	+ " rl.url, rl.displayseqno, rf.fileid, rf.filename, rf.uploaddate, rf.sequence, rf.uniquename,"
 //	+ " rf.ext, rf.active, rf.tempactive, rf.s3path, rf.SDFstatus, rf.transcoded, rf.lodestar,"

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceEnUSGenApiServiceImpl.java
@@ -1,18 +1,17 @@
 package org.curriki.api.enus.model.resource;
 
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.user.SiteUser;
-import org.computate.vertx.api.ApiRequest;
-import org.computate.vertx.search.list.SearchResult;
-import org.computate.vertx.verticle.EmailVerticle;
+import org.curriki.api.enus.user.SiteUser;
+import org.curriki.api.enus.request.api.ApiRequest;
+import org.curriki.api.enus.search.SearchResult;
+import org.curriki.api.enus.vertx.MailVerticle;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.computate.vertx.api.BaseApiServiceImpl;
+import org.curriki.api.enus.base.BaseApiServiceImpl;
 import io.vertx.ext.web.client.WebClient;
 import java.util.Objects;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.pgclient.PgPool;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.ext.auth.authorization.AuthorizationProvider;
 import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -23,10 +22,17 @@ import java.util.concurrent.TimeUnit;
 import java.time.Instant;
 import java.util.stream.Collectors;
 import io.vertx.core.json.Json;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrQuery.ORDER;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.commons.lang3.StringUtils;
 import java.security.Principal;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import java.io.PrintWriter;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
 import java.util.Collection;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -65,7 +71,9 @@ import java.net.URLEncoder;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.http.HttpHeaders;
+import org.apache.http.client.utils.URLEncodedUtils;
 import java.nio.charset.Charset;
+import org.apache.http.NameValuePair;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.ext.web.api.service.ServiceResponse;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
@@ -74,18 +82,22 @@ import io.vertx.ext.auth.User;
 import java.util.Optional;
 import java.util.stream.Stream;
 import java.net.URLDecoder;
+import org.apache.solr.util.DateMathParser;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.client.solrj.response.PivotField;
+import org.apache.solr.client.solrj.response.RangeFacet;
+import org.apache.solr.client.solrj.response.FacetField;
 import java.util.Map.Entry;
 import java.util.Iterator;
-import org.computate.search.tool.SearchTool;
-import org.computate.search.response.solr.SolrResponse;
 import java.util.Base64;
 import java.time.ZonedDateTime;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
-import org.curriki.api.enus.model.user.SiteUserEnUSApiServiceImpl;
-import org.computate.vertx.search.list.SearchList;
+import org.curriki.api.enus.user.SiteUserEnUSApiServiceImpl;
+import org.curriki.api.enus.search.SearchList;
 
 
 /**
@@ -103,7 +115,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	@Override
 	public void searchCurrikiResource(ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 
 				List<String> roles = Optional.ofNullable(config.getValue(ConfigKeys.AUTH_ROLES_REQUIRED + "_CurrikiResource")).map(v -> v instanceof JsonArray ? (JsonArray)v : new JsonArray(v.toString())).orElse(new JsonArray()).getList();
@@ -143,7 +155,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -158,20 +170,23 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	}
 
 
+
 	public Future<ServiceResponse> response200SearchCurrikiResource(SearchList<CurrikiResource> listCurrikiResource) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
-			SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_(SiteRequestEnUS.class);
-			SolrResponse responseSearch = listCurrikiResource.getQueryResponse();
-			List<SolrResponse.Doc> solrDocuments = listCurrikiResource.getQueryResponse().getResponse().getDocs();
-			Long searchInMillis = Long.valueOf(responseSearch.getResponseHeader().getqTime());
-			Long startNum = listCurrikiResource.getRequest().getStart();
-			Long foundNum = responseSearch.getResponse().getNumFound();
-			Integer returnedNum = responseSearch.getResponse().getDocs().size();
+			SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_();
+			QueryResponse responseSearch = listCurrikiResource.getQueryResponse();
+			SolrDocumentList solrDocuments = listCurrikiResource.getSolrDocumentList();
+			Long searchInMillis = Long.valueOf(responseSearch.getQTime());
+			Long transmissionInMillis = responseSearch.getElapsedTime();
+			Long startNum = responseSearch.getResults().getStart();
+			Long foundNum = responseSearch.getResults().getNumFound();
+			Integer returnedNum = responseSearch.getResults().size();
 			String searchTime = String.format("%d.%03d sec", TimeUnit.MILLISECONDS.toSeconds(searchInMillis), TimeUnit.MILLISECONDS.toMillis(searchInMillis) - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(searchInMillis)));
+			String transmissionTime = String.format("%d.%03d sec", TimeUnit.MILLISECONDS.toSeconds(transmissionInMillis), TimeUnit.MILLISECONDS.toMillis(transmissionInMillis) - TimeUnit.SECONDS.toSeconds(TimeUnit.MILLISECONDS.toSeconds(transmissionInMillis)));
 			String nextCursorMark = responseSearch.getNextCursorMark();
-			String exceptionSearch = Optional.ofNullable(responseSearch.getError()).map(error -> error.getMsg()).orElse(null);
-			List<String> fls = listCurrikiResource.getRequest().getFields();
+			Exception exceptionSearch = responseSearch.getException();
+			List<String> fls = listCurrikiResource.getFields();
 
 			JsonObject json = new JsonObject();
 			json.put("startNum", startNum);
@@ -179,6 +194,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			json.put("returnedNum", returnedNum);
 			if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves")) {
 				json.put("searchTime", searchTime);
+				json.put("transmissionTime", transmissionTime);
 			}
 			if(nextCursorMark != null) {
 				json.put("nextCursorMark", nextCursorMark);
@@ -188,15 +204,11 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				JsonObject json2 = JsonObject.mapFrom(o);
 				if(fls.size() > 0) {
 					Set<String> fieldNames = new HashSet<String>();
-					for(String fieldName : json2.fieldNames()) {
-						String v = CurrikiResource.varIndexedCurrikiResource(fieldName);
-						if(v != null)
-							fieldNames.add(CurrikiResource.varIndexedCurrikiResource(fieldName));
-					}
-					if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves_docvalues_strings")) {
-						fieldNames.removeAll(Optional.ofNullable(json2.getJsonArray("saves_docvalues_strings")).orElse(new JsonArray()).stream().map(s -> s.toString()).collect(Collectors.toList()));
-						fieldNames.remove("pk_docvalues_long");
-						fieldNames.remove("created_docvalues_date");
+					fieldNames.addAll(json2.fieldNames());
+					if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves")) {
+						fieldNames.removeAll(Optional.ofNullable(json2.getJsonArray("saves")).orElse(new JsonArray()).stream().map(s -> s.toString()).collect(Collectors.toList()));
+						fieldNames.remove("pk");
+						fieldNames.remove("created");
 					}
 					else if(fls.size() >= 1) {
 						fieldNames.removeAll(fls);
@@ -210,42 +222,49 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			});
 			json.put("list", l);
 
-			SolrResponse.FacetFields facetFields = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetFields()).orElse(null);
+			List<FacetField> facetFields = responseSearch.getFacetFields();
 			if(facetFields != null) {
 				JsonObject facetFieldsJson = new JsonObject();
 				json.put("facet_fields", facetFieldsJson);
-				for(SolrResponse.FacetField facetField : facetFields.getFacets().values()) {
+				for(FacetField facetField : facetFields) {
 					String facetFieldVar = StringUtils.substringBefore(facetField.getName(), "_docvalues_");
 					JsonObject facetFieldCounts = new JsonObject();
 					facetFieldsJson.put(facetFieldVar, facetFieldCounts);
-					facetField.getCounts().forEach((name, count) -> {
-						facetFieldCounts.put(name, count);
-					});
+					List<FacetField.Count> facetFieldValues = facetField.getValues();
+					for(Integer i = 0; i < facetFieldValues.size(); i+= 1) {
+						FacetField.Count count = (FacetField.Count)facetFieldValues.get(i);
+						facetFieldCounts.put(count.getName(), count.getCount());
+					}
 				}
 			}
 
-			SolrResponse.FacetRanges facetRanges = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetRanges()).orElse(null);
+			List<RangeFacet> facetRanges = responseSearch.getFacetRanges();
 			if(facetRanges != null) {
 				JsonObject rangeJson = new JsonObject();
 				json.put("facet_ranges", rangeJson);
-				for(SolrResponse.FacetRange rangeFacet : facetRanges.getRanges().values()) {
+				for(RangeFacet rangeFacet : facetRanges) {
 					JsonObject rangeFacetJson = new JsonObject();
 					String rangeFacetVar = StringUtils.substringBefore(rangeFacet.getName(), "_docvalues_");
 					rangeJson.put(rangeFacetVar, rangeFacetJson);
 					JsonObject rangeFacetCountsMap = new JsonObject();
 					rangeFacetJson.put("counts", rangeFacetCountsMap);
-					rangeFacet.getCounts().forEach((name, count) -> {
-						rangeFacetCountsMap.put(name, count);
-					});
+					List<?> rangeFacetCounts = rangeFacet.getCounts();
+					for(Integer i = 0; i < rangeFacetCounts.size(); i+= 1) {
+						RangeFacet.Count count = (RangeFacet.Count)rangeFacetCounts.get(i);
+						rangeFacetCountsMap.put(count.getValue(), count.getCount());
+					}
 				}
 			}
 
-			SolrResponse.FacetPivot facetPivot = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetPivot()).orElse(null);
+			NamedList<List<PivotField>> facetPivot = responseSearch.getFacetPivot();
 			if(facetPivot != null) {
 				JsonObject facetPivotJson = new JsonObject();
 				json.put("facet_pivot", facetPivotJson);
-				for(SolrResponse.Pivot pivot : facetPivot.getPivotMap().values()) {
-					String[] varsIndexed = pivot.getName().trim().split(",");
+				Iterator<Entry<String, List<PivotField>>> facetPivotIterator = responseSearch.getFacetPivot().iterator();
+				while(facetPivotIterator.hasNext()) {
+					Entry<String, List<PivotField>> pivotEntry = facetPivotIterator.next();
+					List<PivotField> pivotFields = pivotEntry.getValue();
+					String[] varsIndexed = pivotEntry.getKey().trim().split(",");
 					String[] entityVars = new String[varsIndexed.length];
 					for(Integer i = 0; i < entityVars.length; i++) {
 						String entityIndexed = varsIndexed[i];
@@ -253,11 +272,11 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					}
 					JsonArray pivotArray = new JsonArray();
 					facetPivotJson.put(StringUtils.join(entityVars, ","), pivotArray);
-					responsePivotSearchCurrikiResource(pivot.getPivotList(), pivotArray);
+					responsePivotSearchCurrikiResource(pivotFields, pivotArray);
 				}
 			}
 			if(exceptionSearch != null) {
-				json.put("exceptionSearch", exceptionSearch);
+				json.put("exceptionSearch", exceptionSearch.getMessage());
 			}
 			promise.complete(ServiceResponse.completedWithJson(Buffer.buffer(Optional.ofNullable(json).orElse(new JsonObject()).encodePrettily())));
 		} catch(Exception ex) {
@@ -266,8 +285,8 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 		}
 		return promise.future();
 	}
-	public void responsePivotSearchCurrikiResource(List<SolrResponse.Pivot> pivots, JsonArray pivotArray) {
-		for(SolrResponse.Pivot pivotField : pivots) {
+	public void responsePivotSearchCurrikiResource(List<PivotField> pivotFields, JsonArray pivotArray) {
+		for(PivotField pivotField : pivotFields) {
 			String entityIndexed = pivotField.getField();
 			String entityVar = StringUtils.substringBefore(entityIndexed, "_docvalues_");
 			JsonObject pivotJson = new JsonObject();
@@ -275,20 +294,22 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			pivotJson.put("field", entityVar);
 			pivotJson.put("value", pivotField.getValue());
 			pivotJson.put("count", pivotField.getCount());
-			Collection<SolrResponse.PivotRange> pivotRanges = pivotField.getRanges().values();
-			List<SolrResponse.Pivot> pivotFields2 = pivotField.getPivotList();
+			List<RangeFacet> pivotRanges = pivotField.getFacetRanges();
+			List<PivotField> pivotFields2 = pivotField.getPivot();
 			if(pivotRanges != null) {
 				JsonObject rangeJson = new JsonObject();
 				pivotJson.put("ranges", rangeJson);
-				for(SolrResponse.PivotRange rangeFacet : pivotRanges) {
+				for(RangeFacet rangeFacet : pivotRanges) {
 					JsonObject rangeFacetJson = new JsonObject();
 					String rangeFacetVar = StringUtils.substringBefore(rangeFacet.getName(), "_docvalues_");
 					rangeJson.put(rangeFacetVar, rangeFacetJson);
 					JsonObject rangeFacetCountsObject = new JsonObject();
 					rangeFacetJson.put("counts", rangeFacetCountsObject);
-					rangeFacet.getCounts().forEach((value, count) -> {
-						rangeFacetCountsObject.put(value, count);
-					});
+					List<?> rangeFacetCounts = rangeFacet.getCounts();
+					for(Integer i = 0; i < rangeFacetCounts.size(); i+= 1) {
+						RangeFacet.Count count = (RangeFacet.Count)rangeFacetCounts.get(i);
+						rangeFacetCountsObject.put(count.getValue(), count.getCount());
+					}
 				}
 			}
 			if(pivotFields2 != null) {
@@ -304,7 +325,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	@Override
 	public void patchCurrikiResource(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("patchCurrikiResource started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 
@@ -327,7 +348,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					searchCurrikiResourceList(siteRequest, false, true, true).onSuccess(listCurrikiResource -> {
 						try {
 							List<String> roles2 = Optional.ofNullable(config.getValue(ConfigKeys.AUTH_ROLES_ADMIN)).map(v -> v instanceof JsonArray ? (JsonArray)v : new JsonArray(v.toString())).orElse(new JsonArray()).getList();
-							if(listCurrikiResource.getQueryResponse().getResponse().getNumFound() > 1
+							if(listCurrikiResource.getQueryResponse().getResults().getNumFound() > 1
 									&& !CollectionUtils.containsAny(siteRequest.getUserResourceRoles(), roles2)
 									&& !CollectionUtils.containsAny(siteRequest.getUserRealmRoles(), roles2)
 									) {
@@ -337,8 +358,8 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 							} else {
 
 								ApiRequest apiRequest = new ApiRequest();
-								apiRequest.setRows(listCurrikiResource.getRequest().getRows());
-								apiRequest.setNumFound(listCurrikiResource.getQueryResponse().getResponse().getNumFound());
+								apiRequest.setRows(listCurrikiResource.getRows());
+								apiRequest.setNumFound(listCurrikiResource.getQueryResponse().getResults().getNumFound());
 								apiRequest.setNumPATCH(0L);
 								apiRequest.initDeepApiRequest(siteRequest);
 								siteRequest.setApiRequest_(apiRequest);
@@ -374,7 +395,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -392,11 +413,10 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	public Future<Void> listPATCHCurrikiResource(ApiRequest apiRequest, SearchList<CurrikiResource> listCurrikiResource) {
 		Promise<Void> promise = Promise.promise();
 		List<Future> futures = new ArrayList<>();
-		SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_(SiteRequestEnUS.class);
+		SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_();
 		listCurrikiResource.getList().forEach(o -> {
-			SiteRequestEnUS siteRequest2 = generateSiteRequest(siteRequest.getUser(), siteRequest.getServiceRequest(), siteRequest.getJsonObject(), SiteRequestEnUS.class);
+			SiteRequestEnUS siteRequest2 = generateSiteRequestEnUS(siteRequest.getUser(), siteRequest.getServiceRequest(), siteRequest.getJsonObject());
 			o.setSiteRequest_(siteRequest2);
-			siteRequest2.setApiRequest_(siteRequest.getApiRequest_());
 			futures.add(Future.future(promise1 -> {
 				patchCurrikiResourceFuture(o, false).onSuccess(a -> {
 					promise1.complete();
@@ -408,19 +428,14 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 		});
 		CompositeFuture.all(futures).onSuccess( a -> {
 			if(apiRequest != null) {
-				apiRequest.setNumPATCH(apiRequest.getNumPATCH() + listCurrikiResource.getQueryResponse().getResponse().getDocs().size());
+				apiRequest.setNumPATCH(apiRequest.getNumPATCH() + listCurrikiResource.getQueryResponse().getResults().size());
 				if(apiRequest.getNumFound() == 1L)
 					listCurrikiResource.first().apiRequestCurrikiResource();
 				eventBus.publish("websocketCurrikiResource", JsonObject.mapFrom(apiRequest).toString());
 			}
 			listCurrikiResource.next().onSuccess(next -> {
 				if(next) {
-					listPATCHCurrikiResource(apiRequest, listCurrikiResource).onSuccess(b -> {
-						promise.complete();
-					}).onFailure(ex -> {
-						LOG.error(String.format("listPATCHCurrikiResource failed. "), ex);
-						promise.fail(ex);
-					});
+					listPATCHCurrikiResource(apiRequest, listCurrikiResource);
 				} else {
 					promise.complete();
 				}
@@ -437,16 +452,16 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	@Override
 	public void patchCurrikiResourceFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
 				searchCurrikiResourceList(siteRequest, false, true, true).onSuccess(listCurrikiResource -> {
 					try {
 						CurrikiResource o = listCurrikiResource.first();
-						if(o != null && listCurrikiResource.getQueryResponse().getResponse().getNumFound() == 1) {
+						if(o != null && listCurrikiResource.getQueryResponse().getResults().getNumFound() == 1) {
 							ApiRequest apiRequest = new ApiRequest();
-							apiRequest.setRows(1L);
+							apiRequest.setRows(1);
 							apiRequest.setNumFound(1L);
 							apiRequest.setNumPATCH(0L);
 							apiRequest.initDeepApiRequest(siteRequest);
@@ -494,7 +509,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				Promise<CurrikiResource> promise1 = Promise.promise();
 				siteRequest.setSqlConnection(sqlConnection);
 				sqlPATCHCurrikiResource(o, inheritPk).onSuccess(currikiResource -> {
-					persistCurrikiResource(currikiResource).onSuccess(c -> {
+					defineCurrikiResource(currikiResource).onSuccess(c -> {
 						relateCurrikiResource(currikiResource).onSuccess(d -> {
 							indexCurrikiResource(currikiResource).onSuccess(e -> {
 								promise1.complete(currikiResource);
@@ -581,630 +596,6 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 							num++;
 							bParams.add(o2.sqlDeleted());
 						break;
-					case "setResourceId":
-							o2.setResourceId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceId());
-						break;
-					case "setLicenseId":
-							o2.setLicenseId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_licenseId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLicenseId());
-						break;
-					case "setContributorId":
-							o2.setContributorId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_contributorId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlContributorId());
-						break;
-					case "setContributionDate":
-							o2.setContributionDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_contributionDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlContributionDate());
-						break;
-					case "setDescription":
-							o2.setDescription(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_description + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDescription());
-						break;
-					case "setTitle":
-							o2.setTitle(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_title + "=$" + num);
-							num++;
-							bParams.add(o2.sqlTitle());
-						break;
-					case "setKeywordsStr":
-							o2.setKeywordsStr(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_keywordsStr + "=$" + num);
-							num++;
-							bParams.add(o2.sqlKeywordsStr());
-						break;
-					case "setGeneratedKeywordsStr":
-							o2.setGeneratedKeywordsStr(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_generatedKeywordsStr + "=$" + num);
-							num++;
-							bParams.add(o2.sqlGeneratedKeywordsStr());
-						break;
-					case "setLanguage":
-							o2.setLanguage(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_language + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLanguage());
-						break;
-					case "setLastEditorId":
-							o2.setLastEditorId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_lastEditorId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLastEditorId());
-						break;
-					case "setLastEditDate":
-							o2.setLastEditDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_lastEditDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLastEditDate());
-						break;
-					case "setCurrikiLicense":
-							o2.setCurrikiLicense(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_currikiLicense + "=$" + num);
-							num++;
-							bParams.add(o2.sqlCurrikiLicense());
-						break;
-					case "setExternalUrl":
-							o2.setExternalUrl(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_externalUrl + "=$" + num);
-							num++;
-							bParams.add(o2.sqlExternalUrl());
-						break;
-					case "setResourceChecked":
-							o2.setResourceChecked(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceChecked + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceChecked());
-						break;
-					case "setContent":
-							o2.setContent(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_content + "=$" + num);
-							num++;
-							bParams.add(o2.sqlContent());
-						break;
-					case "setResourceCheckRequestNote":
-							o2.setResourceCheckRequestNote(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceCheckRequestNote + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceCheckRequestNote());
-						break;
-					case "setResourceCheckDate":
-							o2.setResourceCheckDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceCheckDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceCheckDate());
-						break;
-					case "setResourceCheckId":
-							o2.setResourceCheckId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceCheckId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceCheckId());
-						break;
-					case "setResourceCheckNote":
-							o2.setResourceCheckNote(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_resourceCheckNote + "=$" + num);
-							num++;
-							bParams.add(o2.sqlResourceCheckNote());
-						break;
-					case "setStudentFacing":
-							o2.setStudentFacing(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_studentFacing + "=$" + num);
-							num++;
-							bParams.add(o2.sqlStudentFacing());
-						break;
-					case "setSource":
-							o2.setSource(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_source + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSource());
-						break;
-					case "setReviewStatus":
-							o2.setReviewStatus(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_reviewStatus + "=$" + num);
-							num++;
-							bParams.add(o2.sqlReviewStatus());
-						break;
-					case "setLastReviewDate":
-							o2.setLastReviewDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_lastReviewDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLastReviewDate());
-						break;
-					case "setReviewByID":
-							o2.setReviewByID(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_reviewByID + "=$" + num);
-							num++;
-							bParams.add(o2.sqlReviewByID());
-						break;
-					case "setReviewRating":
-							o2.setReviewRating(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_reviewRating + "=$" + num);
-							num++;
-							bParams.add(o2.sqlReviewRating());
-						break;
-					case "setTechnicalCompleteness":
-							o2.setTechnicalCompleteness(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_technicalCompleteness + "=$" + num);
-							num++;
-							bParams.add(o2.sqlTechnicalCompleteness());
-						break;
-					case "setContentAccuracy":
-							o2.setContentAccuracy(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_contentAccuracy + "=$" + num);
-							num++;
-							bParams.add(o2.sqlContentAccuracy());
-						break;
-					case "setPedagogy":
-							o2.setPedagogy(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_pedagogy + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPedagogy());
-						break;
-					case "setRatingComment":
-							o2.setRatingComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_ratingComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlRatingComment());
-						break;
-					case "setStandardsAlignment":
-							o2.setStandardsAlignment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_standardsAlignment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlStandardsAlignment());
-						break;
-					case "setStandardsAlignmentComment":
-							o2.setStandardsAlignmentComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_standardsAlignmentComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlStandardsAlignmentComment());
-						break;
-					case "setSubjectMatter":
-							o2.setSubjectMatter(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_subjectMatter + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSubjectMatter());
-						break;
-					case "setSubjectMatterComment":
-							o2.setSubjectMatterComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_subjectMatterComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSubjectMatterComment());
-						break;
-					case "setSupportsTeaching":
-							o2.setSupportsTeaching(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_supportsTeaching + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSupportsTeaching());
-						break;
-					case "setSupportsTeachingComment":
-							o2.setSupportsTeachingComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_supportsTeachingComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSupportsTeachingComment());
-						break;
-					case "setAssessmentsQuality":
-							o2.setAssessmentsQuality(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_assessmentsQuality + "=$" + num);
-							num++;
-							bParams.add(o2.sqlAssessmentsQuality());
-						break;
-					case "setAssessmentsQualityComment":
-							o2.setAssessmentsQualityComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_assessmentsQualityComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlAssessmentsQualityComment());
-						break;
-					case "setInteractivityQuality":
-							o2.setInteractivityQuality(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_interactivityQuality + "=$" + num);
-							num++;
-							bParams.add(o2.sqlInteractivityQuality());
-						break;
-					case "setInteractivityQualityComment":
-							o2.setInteractivityQualityComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_interactivityQualityComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlInteractivityQualityComment());
-						break;
-					case "setInstructionalQuality":
-							o2.setInstructionalQuality(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_instructionalQuality + "=$" + num);
-							num++;
-							bParams.add(o2.sqlInstructionalQuality());
-						break;
-					case "setInstructionalQualityComment":
-							o2.setInstructionalQualityComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_instructionalQualityComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlInstructionalQualityComment());
-						break;
-					case "setDeeperLearning":
-							o2.setDeeperLearning(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_deeperLearning + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDeeperLearning());
-						break;
-					case "setDeeperLearningComment":
-							o2.setDeeperLearningComment(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_deeperLearningComment + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDeeperLearningComment());
-						break;
-					case "setPartner":
-							o2.setPartner(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_partner + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPartner());
-						break;
-					case "setCreateDate":
-							o2.setCreateDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_createDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlCreateDate());
-						break;
-					case "setType":
-							o2.setType(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_type + "=$" + num);
-							num++;
-							bParams.add(o2.sqlType());
-						break;
-					case "setFeatured":
-							o2.setFeatured(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_featured + "=$" + num);
-							num++;
-							bParams.add(o2.sqlFeatured());
-						break;
-					case "setPage":
-							o2.setPage(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_page + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPage());
-						break;
-					case "setActive":
-							o2.setActive(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_active + "=$" + num);
-							num++;
-							bParams.add(o2.sqlActive());
-						break;
-					case "setPublic":
-							o2.setPublic(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_Public + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPublic());
-						break;
-					case "setXwd_id":
-							o2.setXwd_id(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_xwd_id + "=$" + num);
-							num++;
-							bParams.add(o2.sqlXwd_id());
-						break;
-					case "setMediaType":
-							o2.setMediaType(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_mediaType + "=$" + num);
-							num++;
-							bParams.add(o2.sqlMediaType());
-						break;
-					case "setAccess":
-							o2.setAccess(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_access + "=$" + num);
-							num++;
-							bParams.add(o2.sqlAccess());
-						break;
-					case "setMemberRating":
-							o2.setMemberRating(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_memberRating + "=$" + num);
-							num++;
-							bParams.add(o2.sqlMemberRating());
-						break;
-					case "setAligned":
-							o2.setAligned(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_aligned + "=$" + num);
-							num++;
-							bParams.add(o2.sqlAligned());
-						break;
-					case "setPageUrl":
-							o2.setPageUrl(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_pageUrl + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPageUrl());
-						break;
-					case "setIndexed":
-							o2.setIndexed(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_indexed + "=$" + num);
-							num++;
-							bParams.add(o2.sqlIndexed());
-						break;
-					case "setLastIndexDate":
-							o2.setLastIndexDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_lastIndexDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlLastIndexDate());
-						break;
-					case "setIndexRequired":
-							o2.setIndexRequired(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_indexRequired + "=$" + num);
-							num++;
-							bParams.add(o2.sqlIndexRequired());
-						break;
-					case "setIndexRequiredDate":
-							o2.setIndexRequiredDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_indexRequiredDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlIndexRequiredDate());
-						break;
-					case "setRescrape":
-							o2.setRescrape(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_rescrape + "=$" + num);
-							num++;
-							bParams.add(o2.sqlRescrape());
-						break;
-					case "setGoButton":
-							o2.setGoButton(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_goButton + "=$" + num);
-							num++;
-							bParams.add(o2.sqlGoButton());
-						break;
-					case "setDownloadButton":
-							o2.setDownloadButton(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_downloadButton + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDownloadButton());
-						break;
-					case "setTopOfSearch":
-							o2.setTopOfSearch(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_topOfSearch + "=$" + num);
-							num++;
-							bParams.add(o2.sqlTopOfSearch());
-						break;
-					case "setRemove":
-							o2.setRemove(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_remove + "=$" + num);
-							num++;
-							bParams.add(o2.sqlRemove());
-						break;
-					case "setSpam":
-							o2.setSpam(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_spam + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSpam());
-						break;
-					case "setTopOfSearchInt":
-							o2.setTopOfSearchInt(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_topOfSearchInt + "=$" + num);
-							num++;
-							bParams.add(o2.sqlTopOfSearchInt());
-						break;
-					case "setPartnerInt":
-							o2.setPartnerInt(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_partnerInt + "=$" + num);
-							num++;
-							bParams.add(o2.sqlPartnerInt());
-						break;
-					case "setReviewResource":
-							o2.setReviewResource(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_reviewResource + "=$" + num);
-							num++;
-							bParams.add(o2.sqlReviewResource());
-						break;
-					case "setOldUrl":
-							o2.setOldUrl(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_oldUrl + "=$" + num);
-							num++;
-							bParams.add(o2.sqlOldUrl());
-						break;
-					case "setContentDisplayOk":
-							o2.setContentDisplayOk(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_contentDisplayOk + "=$" + num);
-							num++;
-							bParams.add(o2.sqlContentDisplayOk());
-						break;
-					case "setMetadata":
-							o2.setMetadata(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_metadata + "=$" + num);
-							num++;
-							bParams.add(o2.sqlMetadata());
-						break;
-					case "setApprovalStatus":
-							o2.setApprovalStatus(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_approvalStatus + "=$" + num);
-							num++;
-							bParams.add(o2.sqlApprovalStatus());
-						break;
-					case "setApprovalStatusDate":
-							o2.setApprovalStatusDate(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_approvalStatusDate + "=$" + num);
-							num++;
-							bParams.add(o2.sqlApprovalStatusDate());
-						break;
-					case "setSpamUser":
-							o2.setSpamUser(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_spamUser + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSpamUser());
-						break;
-					case "setUrl":
-							o2.setUrl(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_url + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUrl());
-						break;
-					case "setDisplaySeqNo":
-							o2.setDisplaySeqNo(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_displaySeqNo + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDisplaySeqNo());
-						break;
-					case "setFileId":
-							o2.setFileId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(CurrikiResource.VAR_fileId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlFileId());
-						break;
 				}
 			}
 			bSql.append(" WHERE pk=$" + num);
@@ -1244,6 +635,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 		return promise.future();
 	}
 
+
 	public Future<ServiceResponse> response200PATCHCurrikiResource(SiteRequestEnUS siteRequest) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
@@ -1261,7 +653,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	@Override
 	public void postCurrikiResource(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("postCurrikiResource started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 
@@ -1282,7 +674,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					));
 				} else {
 					ApiRequest apiRequest = new ApiRequest();
-					apiRequest.setRows(1L);
+					apiRequest.setRows(1);
 					apiRequest.setNumFound(1L);
 					apiRequest.setNumPATCH(0L);
 					apiRequest.initDeepApiRequest(siteRequest);
@@ -1299,16 +691,16 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
 					if(softCommit == null && commitWithin == null)
 						softCommit = true;
-					if(softCommit != null)
+					if(softCommit)
 						query.put("softCommit", softCommit);
 					if(commitWithin != null)
 						query.put("commitWithin", commitWithin);
 					params.put("query", query);
-					JsonObject context = new JsonObject().put("params", params).put("user", siteRequest.getUserPrincipal());
+					JsonObject context = new JsonObject().put("params", params).put("user", Optional.ofNullable(siteRequest.getUser()).map(user -> user.attributes().getJsonObject("tokenPrincipal")).orElse(null));
 					JsonObject json = new JsonObject().put("context", context);
 					eventBus.request("ActiveLearningStudio-API-enUS-CurrikiResource", json, new DeliveryOptions().addHeader("action", "postCurrikiResourceFuture")).onSuccess(a -> {
 						JsonObject responseMessage = (JsonObject)a.body();
-						JsonObject responseBody = new JsonObject(Buffer.buffer(JsonUtil.BASE64_DECODER.decode(responseMessage.getString("payload"))));
+						JsonObject responseBody = new JsonObject(new String(Base64.getDecoder().decode(responseMessage.getString("payload")), Charset.forName("UTF-8")));
 						apiRequest.setPk(Long.parseLong(responseBody.getString("pk")));
 						eventHandler.handle(Future.succeededFuture(ServiceResponse.completedWithJson(Buffer.buffer(responseBody.encodePrettily()))));
 						LOG.debug(String.format("postCurrikiResource succeeded. "));
@@ -1322,7 +714,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -1339,9 +731,9 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	@Override
 	public void postCurrikiResourceFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			ApiRequest apiRequest = new ApiRequest();
-			apiRequest.setRows(1L);
+			apiRequest.setRows(1);
 			apiRequest.setNumFound(1L);
 			apiRequest.setNumPATCH(0L);
 			apiRequest.initDeepApiRequest(siteRequest);
@@ -1355,7 +747,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				eventHandler.handle(Future.failedFuture(ex));
 			});
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -1378,7 +770,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				siteRequest.setSqlConnection(sqlConnection);
 				createCurrikiResource(siteRequest).onSuccess(currikiResource -> {
 					sqlPOSTCurrikiResource(currikiResource, inheritPk).onSuccess(b -> {
-						persistCurrikiResource(currikiResource).onSuccess(c -> {
+						defineCurrikiResource(currikiResource).onSuccess(c -> {
 							relateCurrikiResource(currikiResource).onSuccess(d -> {
 								indexCurrikiResource(currikiResource).onSuccess(e -> {
 									promise1.complete(currikiResource);
@@ -1473,24 +865,6 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				Set<String> entityVars = jsonObject.fieldNames();
 				for(String entityVar : entityVars) {
 					switch(entityVar) {
-					case CurrikiResource.VAR_sessionId:
-						o2.setSessionId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_sessionId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSessionId());
-						break;
-					case CurrikiResource.VAR_userKey:
-						o2.setUserKey(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_userKey + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserKey());
-						break;
 					case CurrikiResource.VAR_inheritPk:
 						o2.setInheritPk(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1527,707 +901,23 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 						num++;
 						bParams.add(o2.sqlDeleted());
 						break;
-					case CurrikiResource.VAR_resourceId:
-						o2.setResourceId(jsonObject.getString(entityVar));
+					case CurrikiResource.VAR_sessionId:
+						o2.setSessionId(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(CurrikiResource.VAR_resourceId + "=$" + num);
+						bSql.append(CurrikiResource.VAR_sessionId + "=$" + num);
 						num++;
-						bParams.add(o2.sqlResourceId());
+						bParams.add(o2.sqlSessionId());
 						break;
-					case CurrikiResource.VAR_licenseId:
-						o2.setLicenseId(jsonObject.getString(entityVar));
+					case CurrikiResource.VAR_userKey:
+						o2.setUserKey(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(CurrikiResource.VAR_licenseId + "=$" + num);
+						bSql.append(CurrikiResource.VAR_userKey + "=$" + num);
 						num++;
-						bParams.add(o2.sqlLicenseId());
-						break;
-					case CurrikiResource.VAR_contributorId:
-						o2.setContributorId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_contributorId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlContributorId());
-						break;
-					case CurrikiResource.VAR_contributionDate:
-						o2.setContributionDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_contributionDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlContributionDate());
-						break;
-					case CurrikiResource.VAR_description:
-						o2.setDescription(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_description + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDescription());
-						break;
-					case CurrikiResource.VAR_title:
-						o2.setTitle(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_title + "=$" + num);
-						num++;
-						bParams.add(o2.sqlTitle());
-						break;
-					case CurrikiResource.VAR_keywordsStr:
-						o2.setKeywordsStr(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_keywordsStr + "=$" + num);
-						num++;
-						bParams.add(o2.sqlKeywordsStr());
-						break;
-					case CurrikiResource.VAR_generatedKeywordsStr:
-						o2.setGeneratedKeywordsStr(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_generatedKeywordsStr + "=$" + num);
-						num++;
-						bParams.add(o2.sqlGeneratedKeywordsStr());
-						break;
-					case CurrikiResource.VAR_language:
-						o2.setLanguage(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_language + "=$" + num);
-						num++;
-						bParams.add(o2.sqlLanguage());
-						break;
-					case CurrikiResource.VAR_lastEditorId:
-						o2.setLastEditorId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_lastEditorId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlLastEditorId());
-						break;
-					case CurrikiResource.VAR_lastEditDate:
-						o2.setLastEditDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_lastEditDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlLastEditDate());
-						break;
-					case CurrikiResource.VAR_currikiLicense:
-						o2.setCurrikiLicense(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_currikiLicense + "=$" + num);
-						num++;
-						bParams.add(o2.sqlCurrikiLicense());
-						break;
-					case CurrikiResource.VAR_externalUrl:
-						o2.setExternalUrl(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_externalUrl + "=$" + num);
-						num++;
-						bParams.add(o2.sqlExternalUrl());
-						break;
-					case CurrikiResource.VAR_resourceChecked:
-						o2.setResourceChecked(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_resourceChecked + "=$" + num);
-						num++;
-						bParams.add(o2.sqlResourceChecked());
-						break;
-					case CurrikiResource.VAR_content:
-						o2.setContent(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_content + "=$" + num);
-						num++;
-						bParams.add(o2.sqlContent());
-						break;
-					case CurrikiResource.VAR_resourceCheckRequestNote:
-						o2.setResourceCheckRequestNote(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_resourceCheckRequestNote + "=$" + num);
-						num++;
-						bParams.add(o2.sqlResourceCheckRequestNote());
-						break;
-					case CurrikiResource.VAR_resourceCheckDate:
-						o2.setResourceCheckDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_resourceCheckDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlResourceCheckDate());
-						break;
-					case CurrikiResource.VAR_resourceCheckId:
-						o2.setResourceCheckId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_resourceCheckId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlResourceCheckId());
-						break;
-					case CurrikiResource.VAR_resourceCheckNote:
-						o2.setResourceCheckNote(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_resourceCheckNote + "=$" + num);
-						num++;
-						bParams.add(o2.sqlResourceCheckNote());
-						break;
-					case CurrikiResource.VAR_studentFacing:
-						o2.setStudentFacing(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_studentFacing + "=$" + num);
-						num++;
-						bParams.add(o2.sqlStudentFacing());
-						break;
-					case CurrikiResource.VAR_source:
-						o2.setSource(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_source + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSource());
-						break;
-					case CurrikiResource.VAR_reviewStatus:
-						o2.setReviewStatus(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_reviewStatus + "=$" + num);
-						num++;
-						bParams.add(o2.sqlReviewStatus());
-						break;
-					case CurrikiResource.VAR_lastReviewDate:
-						o2.setLastReviewDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_lastReviewDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlLastReviewDate());
-						break;
-					case CurrikiResource.VAR_reviewByID:
-						o2.setReviewByID(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_reviewByID + "=$" + num);
-						num++;
-						bParams.add(o2.sqlReviewByID());
-						break;
-					case CurrikiResource.VAR_reviewRating:
-						o2.setReviewRating(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_reviewRating + "=$" + num);
-						num++;
-						bParams.add(o2.sqlReviewRating());
-						break;
-					case CurrikiResource.VAR_technicalCompleteness:
-						o2.setTechnicalCompleteness(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_technicalCompleteness + "=$" + num);
-						num++;
-						bParams.add(o2.sqlTechnicalCompleteness());
-						break;
-					case CurrikiResource.VAR_contentAccuracy:
-						o2.setContentAccuracy(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_contentAccuracy + "=$" + num);
-						num++;
-						bParams.add(o2.sqlContentAccuracy());
-						break;
-					case CurrikiResource.VAR_pedagogy:
-						o2.setPedagogy(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_pedagogy + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPedagogy());
-						break;
-					case CurrikiResource.VAR_ratingComment:
-						o2.setRatingComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_ratingComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlRatingComment());
-						break;
-					case CurrikiResource.VAR_standardsAlignment:
-						o2.setStandardsAlignment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_standardsAlignment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlStandardsAlignment());
-						break;
-					case CurrikiResource.VAR_standardsAlignmentComment:
-						o2.setStandardsAlignmentComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_standardsAlignmentComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlStandardsAlignmentComment());
-						break;
-					case CurrikiResource.VAR_subjectMatter:
-						o2.setSubjectMatter(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_subjectMatter + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSubjectMatter());
-						break;
-					case CurrikiResource.VAR_subjectMatterComment:
-						o2.setSubjectMatterComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_subjectMatterComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSubjectMatterComment());
-						break;
-					case CurrikiResource.VAR_supportsTeaching:
-						o2.setSupportsTeaching(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_supportsTeaching + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSupportsTeaching());
-						break;
-					case CurrikiResource.VAR_supportsTeachingComment:
-						o2.setSupportsTeachingComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_supportsTeachingComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSupportsTeachingComment());
-						break;
-					case CurrikiResource.VAR_assessmentsQuality:
-						o2.setAssessmentsQuality(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_assessmentsQuality + "=$" + num);
-						num++;
-						bParams.add(o2.sqlAssessmentsQuality());
-						break;
-					case CurrikiResource.VAR_assessmentsQualityComment:
-						o2.setAssessmentsQualityComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_assessmentsQualityComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlAssessmentsQualityComment());
-						break;
-					case CurrikiResource.VAR_interactivityQuality:
-						o2.setInteractivityQuality(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_interactivityQuality + "=$" + num);
-						num++;
-						bParams.add(o2.sqlInteractivityQuality());
-						break;
-					case CurrikiResource.VAR_interactivityQualityComment:
-						o2.setInteractivityQualityComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_interactivityQualityComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlInteractivityQualityComment());
-						break;
-					case CurrikiResource.VAR_instructionalQuality:
-						o2.setInstructionalQuality(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_instructionalQuality + "=$" + num);
-						num++;
-						bParams.add(o2.sqlInstructionalQuality());
-						break;
-					case CurrikiResource.VAR_instructionalQualityComment:
-						o2.setInstructionalQualityComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_instructionalQualityComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlInstructionalQualityComment());
-						break;
-					case CurrikiResource.VAR_deeperLearning:
-						o2.setDeeperLearning(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_deeperLearning + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDeeperLearning());
-						break;
-					case CurrikiResource.VAR_deeperLearningComment:
-						o2.setDeeperLearningComment(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_deeperLearningComment + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDeeperLearningComment());
-						break;
-					case CurrikiResource.VAR_partner:
-						o2.setPartner(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_partner + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPartner());
-						break;
-					case CurrikiResource.VAR_createDate:
-						o2.setCreateDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_createDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlCreateDate());
-						break;
-					case CurrikiResource.VAR_type:
-						o2.setType(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_type + "=$" + num);
-						num++;
-						bParams.add(o2.sqlType());
-						break;
-					case CurrikiResource.VAR_featured:
-						o2.setFeatured(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_featured + "=$" + num);
-						num++;
-						bParams.add(o2.sqlFeatured());
-						break;
-					case CurrikiResource.VAR_page:
-						o2.setPage(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_page + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPage());
-						break;
-					case CurrikiResource.VAR_active:
-						o2.setActive(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_active + "=$" + num);
-						num++;
-						bParams.add(o2.sqlActive());
-						break;
-					case CurrikiResource.VAR_Public:
-						o2.setPublic(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_Public + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPublic());
-						break;
-					case CurrikiResource.VAR_xwd_id:
-						o2.setXwd_id(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_xwd_id + "=$" + num);
-						num++;
-						bParams.add(o2.sqlXwd_id());
-						break;
-					case CurrikiResource.VAR_mediaType:
-						o2.setMediaType(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_mediaType + "=$" + num);
-						num++;
-						bParams.add(o2.sqlMediaType());
-						break;
-					case CurrikiResource.VAR_access:
-						o2.setAccess(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_access + "=$" + num);
-						num++;
-						bParams.add(o2.sqlAccess());
-						break;
-					case CurrikiResource.VAR_memberRating:
-						o2.setMemberRating(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_memberRating + "=$" + num);
-						num++;
-						bParams.add(o2.sqlMemberRating());
-						break;
-					case CurrikiResource.VAR_aligned:
-						o2.setAligned(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_aligned + "=$" + num);
-						num++;
-						bParams.add(o2.sqlAligned());
-						break;
-					case CurrikiResource.VAR_pageUrl:
-						o2.setPageUrl(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_pageUrl + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPageUrl());
-						break;
-					case CurrikiResource.VAR_indexed:
-						o2.setIndexed(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_indexed + "=$" + num);
-						num++;
-						bParams.add(o2.sqlIndexed());
-						break;
-					case CurrikiResource.VAR_lastIndexDate:
-						o2.setLastIndexDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_lastIndexDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlLastIndexDate());
-						break;
-					case CurrikiResource.VAR_indexRequired:
-						o2.setIndexRequired(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_indexRequired + "=$" + num);
-						num++;
-						bParams.add(o2.sqlIndexRequired());
-						break;
-					case CurrikiResource.VAR_indexRequiredDate:
-						o2.setIndexRequiredDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_indexRequiredDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlIndexRequiredDate());
-						break;
-					case CurrikiResource.VAR_rescrape:
-						o2.setRescrape(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_rescrape + "=$" + num);
-						num++;
-						bParams.add(o2.sqlRescrape());
-						break;
-					case CurrikiResource.VAR_goButton:
-						o2.setGoButton(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_goButton + "=$" + num);
-						num++;
-						bParams.add(o2.sqlGoButton());
-						break;
-					case CurrikiResource.VAR_downloadButton:
-						o2.setDownloadButton(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_downloadButton + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDownloadButton());
-						break;
-					case CurrikiResource.VAR_topOfSearch:
-						o2.setTopOfSearch(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_topOfSearch + "=$" + num);
-						num++;
-						bParams.add(o2.sqlTopOfSearch());
-						break;
-					case CurrikiResource.VAR_remove:
-						o2.setRemove(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_remove + "=$" + num);
-						num++;
-						bParams.add(o2.sqlRemove());
-						break;
-					case CurrikiResource.VAR_spam:
-						o2.setSpam(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_spam + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSpam());
-						break;
-					case CurrikiResource.VAR_topOfSearchInt:
-						o2.setTopOfSearchInt(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_topOfSearchInt + "=$" + num);
-						num++;
-						bParams.add(o2.sqlTopOfSearchInt());
-						break;
-					case CurrikiResource.VAR_partnerInt:
-						o2.setPartnerInt(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_partnerInt + "=$" + num);
-						num++;
-						bParams.add(o2.sqlPartnerInt());
-						break;
-					case CurrikiResource.VAR_reviewResource:
-						o2.setReviewResource(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_reviewResource + "=$" + num);
-						num++;
-						bParams.add(o2.sqlReviewResource());
-						break;
-					case CurrikiResource.VAR_oldUrl:
-						o2.setOldUrl(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_oldUrl + "=$" + num);
-						num++;
-						bParams.add(o2.sqlOldUrl());
-						break;
-					case CurrikiResource.VAR_contentDisplayOk:
-						o2.setContentDisplayOk(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_contentDisplayOk + "=$" + num);
-						num++;
-						bParams.add(o2.sqlContentDisplayOk());
-						break;
-					case CurrikiResource.VAR_metadata:
-						o2.setMetadata(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_metadata + "=$" + num);
-						num++;
-						bParams.add(o2.sqlMetadata());
-						break;
-					case CurrikiResource.VAR_approvalStatus:
-						o2.setApprovalStatus(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_approvalStatus + "=$" + num);
-						num++;
-						bParams.add(o2.sqlApprovalStatus());
-						break;
-					case CurrikiResource.VAR_approvalStatusDate:
-						o2.setApprovalStatusDate(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_approvalStatusDate + "=$" + num);
-						num++;
-						bParams.add(o2.sqlApprovalStatusDate());
-						break;
-					case CurrikiResource.VAR_spamUser:
-						o2.setSpamUser(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_spamUser + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSpamUser());
-						break;
-					case CurrikiResource.VAR_url:
-						o2.setUrl(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_url + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUrl());
-						break;
-					case CurrikiResource.VAR_displaySeqNo:
-						o2.setDisplaySeqNo(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_displaySeqNo + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDisplaySeqNo());
-						break;
-					case CurrikiResource.VAR_fileId:
-						o2.setFileId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(CurrikiResource.VAR_fileId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlFileId());
+						bParams.add(o2.sqlUserKey());
 						break;
 					}
 				}
@@ -2266,6 +956,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 		return promise.future();
 	}
 
+
 	public Future<ServiceResponse> response200POSTCurrikiResource(CurrikiResource o) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
@@ -2284,7 +975,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	@Override
 	public void putimportCurrikiResource(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("putimportCurrikiResource started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 
@@ -2307,8 +998,8 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					try {
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
-						apiRequest.setRows(Long.valueOf(jsonArray.size()));
-						apiRequest.setNumFound(Long.valueOf(jsonArray.size()));
+						apiRequest.setRows(jsonArray.size());
+						apiRequest.setNumFound(new Integer(jsonArray.size()).longValue());
 						apiRequest.setNumPATCH(0L);
 						apiRequest.initDeepApiRequest(siteRequest);
 						siteRequest.setApiRequest_(apiRequest);
@@ -2340,7 +1031,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -2373,12 +1064,12 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
 					if(softCommit == null && commitWithin == null)
 						softCommit = true;
-					if(softCommit != null)
+					if(softCommit)
 						query.put("softCommit", softCommit);
 					if(commitWithin != null)
 						query.put("commitWithin", commitWithin);
 					params.put("query", query);
-					JsonObject context = new JsonObject().put("params", params).put("user", siteRequest.getUserPrincipal());
+					JsonObject context = new JsonObject().put("params", params).put("user", Optional.ofNullable(siteRequest.getUser()).map(user -> user.attributes().getJsonObject("tokenPrincipal")).orElse(null));
 					JsonObject json = new JsonObject().put("context", context);
 					eventBus.request("ActiveLearningStudio-API-enUS-CurrikiResource", json, new DeliveryOptions().addHeader("action", "putimportCurrikiResourceFuture")).onSuccess(a -> {
 						promise1.complete();
@@ -2404,10 +1095,10 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	@Override
 	public void putimportCurrikiResourceFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				ApiRequest apiRequest = new ApiRequest();
-				apiRequest.setRows(1L);
+				apiRequest.setRows(1);
 				apiRequest.setNumFound(1L);
 				apiRequest.setNumPATCH(0L);
 				apiRequest.initDeepApiRequest(siteRequest);
@@ -2419,11 +1110,11 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 				SearchList<CurrikiResource> searchList = new SearchList<CurrikiResource>();
 				searchList.setStore(true);
-				searchList.q("*:*");
+				searchList.setQuery("*:*");
 				searchList.setC(CurrikiResource.class);
-				searchList.fq("deleted_docvalues_boolean:false");
-				searchList.fq("archived_docvalues_boolean:false");
-				searchList.fq("inheritPk_docvalues_string:" + SearchTool.escapeQueryChars(body.getString("pk")));
+				searchList.addFilterQuery("deleted_docvalues_boolean:false");
+				searchList.addFilterQuery("archived_docvalues_boolean:false");
+				searchList.addFilterQuery("inheritPk_docvalues_string:" + ClientUtils.escapeQueryChars(body.getString("pk")));
 				searchList.promiseDeepForClass(siteRequest).onSuccess(a -> {
 					try {
 						if(searchList.size() >= 1) {
@@ -2455,7 +1146,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 										body2.put("set" + StringUtils.capitalize(f), bodyVal);
 									}
 								} else {
-									o2.persistForClass(f, bodyVal);
+									o2.defineForClass(f, bodyVal);
 									o2.relateForClass(f, bodyVal);
 									if(!StringUtils.containsAny(f, "pk", "created", "setCreated") && !Objects.equals(o.obtainForClass(f), o2.obtainForClass(f)))
 										body2.put("set" + StringUtils.capitalize(f), bodyVal);
@@ -2501,7 +1192,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				eventHandler.handle(Future.failedFuture(ex));
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -2514,6 +1205,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			}
 		});
 	}
+
 
 	public Future<ServiceResponse> response200PUTImportCurrikiResource(SiteRequestEnUS siteRequest) {
 		Promise<ServiceResponse> promise = Promise.promise();
@@ -2536,7 +1228,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	@Override
 	public void searchpageCurrikiResource(ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 
 				List<String> roles = Optional.ofNullable(config.getValue(ConfigKeys.AUTH_ROLES_REQUIRED + "_CurrikiResource")).map(v -> v instanceof JsonArray ? (JsonArray)v : new JsonArray(v.toString())).orElse(new JsonArray()).getList();
@@ -2576,7 +1268,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -2593,14 +1285,13 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 
 	public void searchpageCurrikiResourcePageInit(CurrikiResourcePage page, SearchList<CurrikiResource> listCurrikiResource) {
 	}
-
 	public String templateSearchPageCurrikiResource() {
 		return Optional.ofNullable(config.getString(ConfigKeys.TEMPLATE_PATH)).orElse("templates") + "/enUS/CurrikiResourcePage";
 	}
 	public Future<ServiceResponse> response200SearchPageCurrikiResource(SearchList<CurrikiResource> listCurrikiResource) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
-			SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_(SiteRequestEnUS.class);
+			SiteRequestEnUS siteRequest = listCurrikiResource.getSiteRequest_();
 			CurrikiResourcePage page = new CurrikiResourcePage();
 			MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap();
 			siteRequest.setRequestHeaders(requestHeaders);
@@ -2658,7 +1349,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	}
 
 	public void searchCurrikiResourceQ(SearchList<CurrikiResource> searchList, String entityVar, String valueIndexed, String varIndexed) {
-		searchList.q(varIndexed + ":" + ("*".equals(valueIndexed) ? valueIndexed : SearchTool.escapeQueryChars(valueIndexed)));
+		searchList.setQuery(varIndexed + ":" + ("*".equals(valueIndexed) ? valueIndexed : ClientUtils.escapeQueryChars(valueIndexed)));
 		if(!"*".equals(entityVar)) {
 		}
 	}
@@ -2670,30 +1361,30 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			String[] fqs = StringUtils.substringBefore(StringUtils.substringAfter(valueIndexed, "["), "]").split(" TO ");
 			if(fqs.length != 2)
 				throw new RuntimeException(String.format("\"%s\" invalid range query. ", valueIndexed));
-			String fq1 = fqs[0].equals("*") ? fqs[0] : CurrikiResource.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[0]);
-			String fq2 = fqs[1].equals("*") ? fqs[1] : CurrikiResource.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[1]);
+			String fq1 = fqs[0].equals("*") ? fqs[0] : CurrikiResource.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), fqs[0]);
+			String fq2 = fqs[1].equals("*") ? fqs[1] : CurrikiResource.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), fqs[1]);
 			 return varIndexed + ":[" + fq1 + " TO " + fq2 + "]";
 		} else {
-			return varIndexed + ":" + SearchTool.escapeQueryChars(CurrikiResource.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), valueIndexed)).replace("\\", "\\\\");
+			return varIndexed + ":" + ClientUtils.escapeQueryChars(CurrikiResource.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), valueIndexed)).replace("\\", "\\\\");
 		}
 	}
 
 	public void searchCurrikiResourceSort(SearchList<CurrikiResource> searchList, String entityVar, String valueIndexed, String varIndexed) {
 		if(varIndexed == null)
 			throw new RuntimeException(String.format("\"%s\" is not an indexed entity. ", entityVar));
-		searchList.sort(varIndexed, valueIndexed);
+		searchList.addSort(varIndexed, ORDER.valueOf(valueIndexed));
 	}
 
-	public void searchCurrikiResourceRows(SearchList<CurrikiResource> searchList, Long valueRows) {
-			searchList.rows(valueRows != null ? valueRows : 10L);
+	public void searchCurrikiResourceRows(SearchList<CurrikiResource> searchList, Integer valueRows) {
+			searchList.setRows(valueRows != null ? valueRows : 10);
 	}
 
-	public void searchCurrikiResourceStart(SearchList<CurrikiResource> searchList, Long valueStart) {
-		searchList.start(valueStart);
+	public void searchCurrikiResourceStart(SearchList<CurrikiResource> searchList, Integer valueStart) {
+		searchList.setStart(valueStart);
 	}
 
 	public void searchCurrikiResourceVar(SearchList<CurrikiResource> searchList, String var, String value) {
-		searchList.getSiteRequest_(SiteRequestEnUS.class).getRequestVars().put(var, value);
+		searchList.getSiteRequest_().getRequestVars().put(var, value);
 	}
 
 	public void searchCurrikiResourceUri(SearchList<CurrikiResource> searchList) {
@@ -2738,20 +1429,17 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			SearchList<CurrikiResource> searchList = new SearchList<CurrikiResource>();
 			searchList.setPopulate(populate);
 			searchList.setStore(store);
-			searchList.q("*:*");
+			searchList.setQuery("*:*");
 			searchList.setC(CurrikiResource.class);
 			searchList.setSiteRequest_(siteRequest);
-			if(entityList != null) {
-				for(String v : entityList) {
-					searchList.fl(CurrikiResource.varIndexedCurrikiResource(v));
-				}
-			}
+			if(entityList != null)
+				searchList.addFields(entityList);
 
 			String id = serviceRequest.getParams().getJsonObject("path").getString("id");
 			if(id != null && NumberUtils.isCreatable(id)) {
-				searchList.fq("(pk_docvalues_long:" + SearchTool.escapeQueryChars(id) + " OR objectId_docvalues_string:" + SearchTool.escapeQueryChars(id) + ")");
+				searchList.addFilterQuery("(pk_docvalues_long:" + ClientUtils.escapeQueryChars(id) + " OR objectId_docvalues_string:" + ClientUtils.escapeQueryChars(id) + ")");
 			} else if(id != null) {
-				searchList.fq("objectId_docvalues_string:" + SearchTool.escapeQueryChars(id));
+				searchList.addFilterQuery("objectId_docvalues_string:" + ClientUtils.escapeQueryChars(id));
 			}
 
 			serviceRequest.getParams().getJsonObject("query").forEach(paramRequest -> {
@@ -2759,8 +1447,8 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				String valueIndexed = null;
 				String varIndexed = null;
 				String valueSort = null;
-				Long valueStart = null;
-				Long valueRows = null;
+				Integer valueStart = null;
+				Integer valueRows = null;
 				String valueCursorMark = null;
 				String paramName = paramRequest.getKey();
 				Object paramValuesObject = paramRequest.getValue();
@@ -2778,7 +1466,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 								entityVar = entityVars[i];
 								varsIndexed[i] = CurrikiResource.varIndexedCurrikiResource(entityVar);
 							}
-							searchList.facetPivot((solrLocalParams == null ? "" : solrLocalParams) + StringUtils.join(varsIndexed, ","));
+							searchList.add("facet.pivot", (solrLocalParams == null ? "" : solrLocalParams) + StringUtils.join(varsIndexed, ","));
 						}
 					} else if(paramValuesObject != null) {
 						for(Object paramObject : paramObjects) {
@@ -2797,7 +1485,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 											foundQ = mQ.find();
 										}
 										mQ.appendTail(sb);
-										searchList.q(sb.toString());
+										searchList.setQuery(sb.toString());
 									}
 									break;
 								case "fq":
@@ -2814,7 +1502,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 											foundFq = mFq.find();
 										}
 										mFq.appendTail(sb);
-										searchList.fq(sb.toString());
+										searchList.addFilterQuery(sb.toString());
 									}
 									break;
 								case "sort":
@@ -2824,29 +1512,29 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 									searchCurrikiResourceSort(searchList, entityVar, valueIndexed, varIndexed);
 									break;
 								case "start":
-									valueStart = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									valueStart = paramObject instanceof Integer ? (Integer)paramObject : Integer.parseInt(paramObject.toString());
 									searchCurrikiResourceStart(searchList, valueStart);
 									break;
 								case "rows":
-									valueRows = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									valueRows = paramObject instanceof Integer ? (Integer)paramObject : Integer.parseInt(paramObject.toString());
 									searchCurrikiResourceRows(searchList, valueRows);
 									break;
 								case "facet":
-									searchList.facet((Boolean)paramObject);
+									searchList.add("facet", ((Boolean)paramObject).toString());
 									break;
 								case "facet.range.start":
 									String startMathStr = (String)paramObject;
-									Date start = SearchTool.parseMath(startMathStr);
-									searchList.facetRangeStart(start.toInstant().toString());
+									Date start = DateMathParser.parseMath(null, startMathStr);
+									searchList.add("facet.range.start", start.toInstant().toString());
 									break;
 								case "facet.range.end":
 									String endMathStr = (String)paramObject;
-									Date end = SearchTool.parseMath(endMathStr);
-									searchList.facetRangeEnd(end.toInstant().toString());
+									Date end = DateMathParser.parseMath(null, endMathStr);
+									searchList.add("facet.range.end", end.toInstant().toString());
 									break;
 								case "facet.range.gap":
 									String gap = (String)paramObject;
-									searchList.facetRangeGap(gap);
+									searchList.add("facet.range.gap", gap);
 									break;
 								case "facet.range":
 									Matcher mFacetRange = Pattern.compile("(?:(\\{![^\\}]+\\}))?(.*)").matcher((String)paramObject);
@@ -2855,14 +1543,14 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 										String solrLocalParams = mFacetRange.group(1);
 										entityVar = mFacetRange.group(2).trim();
 										varIndexed = CurrikiResource.varIndexedCurrikiResource(entityVar);
-										searchList.facetRange((solrLocalParams == null ? "" : solrLocalParams) + varIndexed);
+										searchList.add("facet.range", (solrLocalParams == null ? "" : solrLocalParams) + varIndexed);
 									}
 									break;
 								case "facet.field":
 									entityVar = (String)paramObject;
 									varIndexed = CurrikiResource.varIndexedCurrikiResource(entityVar);
 									if(varIndexed != null)
-										searchList.facetField(varIndexed);
+										searchList.addFacetField(varIndexed);
 									break;
 								case "var":
 									entityVar = StringUtils.trim(StringUtils.substringBefore((String)paramObject, ":"));
@@ -2871,7 +1559,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 									break;
 								case "cursorMark":
 									valueCursorMark = (String)paramObject;
-									searchList.cursorMark((String)paramObject);
+									searchList.add("cursorMark", (String)paramObject);
 									break;
 							}
 						}
@@ -2882,7 +1570,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 				}
 			});
 			if("*:*".equals(searchList.getQuery()) && searchList.getSorts().size() == 0) {
-				searchList.sort("created_docvalues_date", "desc");
+				searchList.addSort("created_docvalues_date", ORDER.desc);
 			}
 			searchCurrikiResource2(siteRequest, populate, store, modify, searchList);
 			searchList.promiseDeepForClass(siteRequest).onSuccess(a -> {
@@ -2900,7 +1588,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 	public void searchCurrikiResource2(SiteRequestEnUS siteRequest, Boolean populate, Boolean store, Boolean modify, SearchList<CurrikiResource> searchList) {
 	}
 
-	public Future<Void> persistCurrikiResource(CurrikiResource o) {
+	public Future<Void> defineCurrikiResource(CurrikiResource o) {
 		Promise<Void> promise = Promise.promise();
 		try {
 			SiteRequestEnUS siteRequest = o.getSiteRequest_();
@@ -2917,25 +1605,25 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 							Object columnValue = definition.getValue(i);
 							if(!"pk".equals(columnName)) {
 								try {
-									o.persistForClass(columnName, columnValue);
+									o.defineForClass(columnName, columnValue);
 								} catch(Exception e) {
-									LOG.error(String.format("persistCurrikiResource failed. "), e);
+									LOG.error(String.format("defineCurrikiResource failed. "), e);
 								}
 							}
 						}
 					}
 					promise.complete();
 				} catch(Exception ex) {
-					LOG.error(String.format("persistCurrikiResource failed. "), ex);
+					LOG.error(String.format("defineCurrikiResource failed. "), ex);
 					promise.fail(ex);
 				}
 			}).onFailure(ex -> {
 				RuntimeException ex2 = new RuntimeException(ex);
-				LOG.error(String.format("persistCurrikiResource failed. "), ex2);
+				LOG.error(String.format("defineCurrikiResource failed. "), ex2);
 				promise.fail(ex2);
 			});
 		} catch(Exception ex) {
-			LOG.error(String.format("persistCurrikiResource failed. "), ex);
+			LOG.error(String.format("defineCurrikiResource failed. "), ex);
 			promise.fail(ex);
 		}
 		return promise.future();
@@ -2953,12 +1641,8 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			SiteRequestEnUS siteRequest = o.getSiteRequest_();
 			ApiRequest apiRequest = siteRequest.getApiRequest_();
 			o.promiseDeepForClass(siteRequest).onSuccess(a -> {
-				JsonObject json = new JsonObject();
-				JsonObject add = new JsonObject();
-				json.put("add", add);
-				JsonObject doc = new JsonObject();
-				add.put("doc", doc);
-				o.indexCurrikiResource(doc);
+				SolrInputDocument document = new SolrInputDocument();
+				o.indexCurrikiResource(document);
 				String solrHostName = siteRequest.getConfig().getString(ConfigKeys.SOLR_HOST_NAME);
 				Integer solrPort = siteRequest.getConfig().getInteger(ConfigKeys.SOLR_PORT);
 				String solrCollection = siteRequest.getConfig().getString(ConfigKeys.SOLR_COLLECTION);
@@ -2969,6 +1653,7 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					else if(softCommit == null)
 						softCommit = false;
 				String solrRequestUri = String.format("/solr/%s/update%s%s%s", solrCollection, "?overwrite=true&wt=json", softCommit ? "&softCommit=true" : "", commitWithin != null ? ("&commitWithin=" + commitWithin) : "");
+				JsonArray json = new JsonArray().add(new JsonObject(document.toMap(new HashMap<String, Object>())));
 				webClient.post(solrPort, solrHostName, solrRequestUri).putHeader("Content-Type", "application/json").expect(ResponsePredicate.SC_OK).sendBuffer(json.toBuffer()).onSuccess(b -> {
 					promise.complete();
 				}).onFailure(ex -> {
@@ -3014,13 +1699,13 @@ public class CurrikiResourceEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
 					if(softCommit == null && commitWithin == null)
 						softCommit = true;
-					if(softCommit != null)
+					if(softCommit)
 						query.put("softCommit", softCommit);
 					if(commitWithin != null)
 						query.put("commitWithin", commitWithin);
 					query.put("q", "*:*").put("fq", new JsonArray().add("pk:" + o.getPk()));
 					params.put("query", query);
-					JsonObject context = new JsonObject().put("params", params).put("user", siteRequest.getUserPrincipal());
+					JsonObject context = new JsonObject().put("params", params).put("user", Optional.ofNullable(siteRequest.getUser()).map(user -> user.attributes().getJsonObject("tokenPrincipal")).orElse(null));
 					JsonObject json = new JsonObject().put("context", context);
 					eventBus.request("ActiveLearningStudio-API-enUS-CurrikiResource", json, new DeliveryOptions().addHeader("action", "patchCurrikiResourceFuture")).onSuccess(c -> {
 						JsonObject responseMessage = (JsonObject)c.body();

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPage.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPage.java
@@ -1,25 +1,20 @@
 package org.curriki.api.enus.model.resource;
 
-import java.lang.String;
-import java.lang.Long;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-import java.util.List;
-import java.math.BigDecimal;
-import java.lang.Integer;
-import org.curriki.api.enus.base.BaseModelPage;
+import org.curriki.api.enus.page.PageLayout;
+import org.curriki.api.enus.model.base.BaseModelPage;
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.user.SiteUser;
+import org.curriki.api.enus.model.user.SiteUser;
 import java.io.IOException;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import org.curriki.api.enus.search.SearchList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.page.PageLayout;
+import org.computate.vertx.search.list.SearchList;
+import org.computate.search.wrap.Wrap;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.core.json.JsonArray;
@@ -27,19 +22,22 @@ import java.net.URLDecoder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.apache.solr.common.util.SimpleOrderedMap;
 import java.util.stream.Collectors;
 import java.util.Arrays;
-import org.apache.solr.client.solrj.response.QueryResponse;
+import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.math.MathContext;
 import org.apache.commons.collections.CollectionUtils;
 import java.util.Objects;
-import org.apache.solr.client.solrj.SolrQuery.SortClause;
 import io.vertx.core.Promise;
 import org.curriki.api.enus.config.ConfigKeys;
+import org.computate.search.response.solr.SolrResponse;
+import java.util.HashMap;
+import org.computate.search.tool.TimeTool;
+import java.time.ZoneId;
 
 
 /**
@@ -54,11 +52,91 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	protected void _searchListCurrikiResource_(Wrap<SearchList<CurrikiResource>> w) {
 	}
 
+	protected void _pageResponse(Wrap<String> w) {
+		if(searchListCurrikiResource_ != null)
+			w.o(JsonObject.mapFrom(searchListCurrikiResource_.getQueryResponse()).toString());
+	}
+
+	protected void _defaultZoneId(Wrap<String> w) {
+		w.o(Optional.ofNullable(siteRequest_.getRequestVars().get(VAR_defaultZoneId)).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE)));
+	}
+
+	/**
+	 * Ignore: true
+	 **/
+	protected void _defaultTimeZone(Wrap<ZoneId> w) {
+		w.o(ZoneId.of(defaultZoneId));
+	}
+
+	protected void _defaultLocaleId(Wrap<String> w) {
+		w.o(Optional.ofNullable(siteRequest_.getRequestHeaders().get("Accept-Language")).map(acceptLanguage -> StringUtils.substringBefore(acceptLanguage, ",")).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_LOCALE)));
+	}
+
+	/**
+	 * Ignore: true
+	 **/
+	protected void _defaultLocale(Wrap<Locale> w) {
+		w.o(Locale.forLanguageTag(defaultLocaleId));
+	}
+
+	protected void _defaultRangeGap(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeGap()).orElse("+1DAY"));
+	}
+
+	protected void _defaultRangeEnd(Wrap<ZonedDateTime> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeEnd()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(ZonedDateTime.now(defaultTimeZone).toLocalDate().atStartOfDay(defaultTimeZone).plusDays(1)));
+	}
+
+	protected void _defaultRangeStart(Wrap<ZonedDateTime> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeStart()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(defaultRangeEnd.minusDays(7).toLocalDate().atStartOfDay(defaultTimeZone)));
+	}
+
+	protected void _defaultRangeVar(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRanges()).orElse(Arrays.asList()).stream().findFirst().map(v -> { if(v.contains("}")) return StringUtils.substringBefore(StringUtils.substringAfterLast(v, "}"), "_"); else return StringUtils.substringBefore(v, "_"); }).orElse("created"));
+	}
+
+	protected void _defaultFacetSort(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetSort()).orElse("index"));
+	}
+
+	protected void _defaultFacetLimit(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetLimit()).orElse(1));
+	}
+
+	protected void _defaultFacetMinCount(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetMinCount()).orElse(1));
+	}
+
+	protected void _defaultPivotMinCount(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetPivotMinCount()).orElse(0));
+	}
+
+	@Override
+	protected void _defaultPivotVars(List<String> l) {
+		Optional.ofNullable(searchListCurrikiResource_.getFacetPivots()).orElse(Arrays.asList()).forEach(facetPivot -> {
+			String facetPivot2 = facetPivot;
+			if(StringUtils.contains(facetPivot2, "}"))
+				facetPivot2 = StringUtils.substringAfterLast(facetPivot2, "}");
+			String[] parts = facetPivot2.split(",");
+			for(String part : parts) {
+				if(StringUtils.isNotBlank(part)) {
+					String var = StringUtils.substringBefore(part, "_");
+					if(StringUtils.isNotBlank(var))
+						l.add(var);
+				}
+			}
+		});
+	}
+
 	/**
 	 * {@inheritDoc}
 	 **/
 	protected void _listCurrikiResource(JsonArray l) {
 		Optional.ofNullable(searchListCurrikiResource_).map(o -> o.getList()).orElse(Arrays.asList()).stream().map(o -> JsonObject.mapFrom(o)).forEach(o -> l.add(o));
+	}
+
+	protected void _facetCounts(Wrap<SolrResponse.FacetCounts> w) {
+		w.o(searchListCurrikiResource_.getQueryResponse().getFacetCounts());
 	}
 
 	protected void _currikiResourceCount(Wrap<Integer> w) {
@@ -73,6 +151,11 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	protected void _pk(Wrap<Long> w) {
 		if(currikiResourceCount == 1)
 			w.o(currikiResource_.getPk());
+	}
+
+	protected void _id(Wrap<String> w) {
+		if(currikiResourceCount == 1)
+			w.o(currikiResource_.getId());
 	}
 
 	@Override
@@ -119,7 +202,7 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 		JsonArray pages = new JsonArray();
 		Long start = searchListCurrikiResource_.getStart().longValue();
 		Long rows = searchListCurrikiResource_.getRows().longValue();
-		Long foundNum = searchListCurrikiResource_.getQueryResponse().getResults().getNumFound();
+		Long foundNum = searchListCurrikiResource_.getQueryResponse().getResponse().getNumFound().longValue();
 		Long startNum = start + 1L;
 		Long endNum = start + rows;
 		Long floorMod = Math.floorMod(foundNum, rows);
@@ -160,12 +243,64 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	}
 
 	@Override
+	protected void _varsQ(JsonObject vars) {
+		CurrikiResource.varsQForClass().forEach(var -> {
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", Optional.ofNullable(searchListCurrikiResource_.getRequest().getQuery()).filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsFq(JsonObject vars) {
+		Map<String, SolrResponse.FacetField> facetFields = Optional.ofNullable(facetCounts).map(c -> c.getFacetFields()).map(f -> f.getFacets()).orElse(new HashMap<String,SolrResponse.FacetField>());
+		CurrikiResource.varsFqForClass().forEach(var -> {
+			String varIndexed = CurrikiResource.varIndexedCurrikiResource(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListCurrikiResource_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			Optional.ofNullable(facetFields.get(varIndexed)).ifPresent(facetField -> {
+				JsonObject facetJson = new JsonObject();
+				JsonObject counts = new JsonObject();
+				facetJson.put("var", var);
+				facetField.getCounts().forEach((val, count) -> {
+					counts.put(val, count);
+				});
+				facetJson.put("counts", counts);
+				json.put("facetField", facetJson);
+			});
+			if(defaultPivotVars.contains(var)) {
+				json.put("pivot", true);
+			}
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsRange(JsonObject vars) {
+		CurrikiResource.varsRangeForClass().forEach(var -> {
+			String varIndexed = CurrikiResource.varIndexedCurrikiResource(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListCurrikiResource_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
 	protected void _query(JsonObject query) {
 		ServiceRequest serviceRequest = siteRequest_.getServiceRequest();
 		JsonObject params = serviceRequest.getParams();
 
 		JsonObject queryParams = Optional.ofNullable(serviceRequest).map(ServiceRequest::getParams).map(or -> or.getJsonObject("query")).orElse(new JsonObject());
-		Long num = searchListCurrikiResource_.getQueryResponse().getResults().getNumFound();
+		Long num = searchListCurrikiResource_.getQueryResponse().getResponse().getNumFound().longValue();
 		String q = "*:*";
 		String q1 = "objectText";
 		String q2 = "";
@@ -193,27 +328,28 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 		}
 		query.put("q", q);
 
-		Integer rows1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getRows()).orElse(10);
-		Integer start1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getStart()).orElse(1);
-		Integer start2 = start1 - rows1;
-		Integer start3 = start1 + rows1;
-		Integer rows2 = rows1 / 2;
-		Integer rows3 = rows1 * 2;
+		Long rows1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getRows()).orElse(10L);
+		Long start1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getStart()).orElse(1L);
+		Long start2 = start1 - rows1;
+		Long start3 = start1 + rows1;
+		Long rows2 = rows1 / 2;
+		Long rows3 = rows1 * 2;
 		start2 = start2 < 0 ? 0 : start2;
-		JsonArray fqs = new JsonArray();
-		for(String fq : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getFilterQueries()).orElse(new String[0])) {
+		JsonObject fqs = new JsonObject();
+		for(String fq : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getFilterQueries()).orElse(Arrays.asList())) {
 			if(!StringUtils.contains(fq, "(")) {
 				String fq1 = StringUtils.substringBefore(fq, "_");
 				String fq2 = StringUtils.substringAfter(fq, ":");
 				if(!StringUtils.startsWithAny(fq, "classCanonicalNames_", "archived_", "deleted_", "sessionId", "userKeys"))
-					fqs.add(new JsonObject().put("var", fq1).put("val", fq2));
+					fqs.put(fq1, new JsonObject().put("var", fq1).put("val", fq2).put("displayName", CurrikiResource.displayNameForClass(fq1)));
 				}
 			}
 		query.put("fq", fqs);
 
 		JsonArray sorts = new JsonArray();
-		for(SortClause sort : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
-			sorts.add(new JsonObject().put("var", StringUtils.substringBefore(sort.getItem(), "_")).put("order", sort.getOrder().name()));
+		for(String sort : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
+			String sort1 = StringUtils.substringBefore(sort, "_");
+			sorts.add(new JsonObject().put("var", sort1).put("order", StringUtils.substringAfter(sort, " ")).put("displayName", CurrikiResource.displayNameForClass(sort1)));
 		}
 		query.put("sort", sorts);
 	}

--- a/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPage.java
+++ b/src/main/java/org/curriki/api/enus/model/resource/CurrikiResourceGenPage.java
@@ -1,20 +1,25 @@
 package org.curriki.api.enus.model.resource;
 
-import org.curriki.api.enus.page.PageLayout;
-import org.curriki.api.enus.model.base.BaseModelPage;
-import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.user.SiteUser;
-import java.io.IOException;
-import io.vertx.core.http.HttpServerRequest;
-import io.vertx.core.http.HttpServerResponse;
-import org.computate.vertx.search.list.SearchList;
-import org.computate.search.wrap.Wrap;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.time.LocalDate;
+import java.lang.String;
+import java.lang.Long;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Locale;
+import java.util.List;
+import java.math.BigDecimal;
+import java.lang.Integer;
+import org.curriki.api.enus.base.BaseModelPage;
+import org.curriki.api.enus.request.SiteRequestEnUS;
+import org.curriki.api.enus.user.SiteUser;
+import java.io.IOException;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+import org.curriki.api.enus.search.SearchList;
+import org.curriki.api.enus.wrap.Wrap;
+import org.curriki.api.enus.page.PageLayout;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.LocalDate;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.core.json.JsonArray;
@@ -22,22 +27,19 @@ import java.net.URLDecoder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
-import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import java.util.stream.Collectors;
 import java.util.Arrays;
-import java.math.BigDecimal;
+import org.apache.solr.client.solrj.response.QueryResponse;
 import java.math.RoundingMode;
 import java.math.MathContext;
 import org.apache.commons.collections.CollectionUtils;
 import java.util.Objects;
+import org.apache.solr.client.solrj.SolrQuery.SortClause;
 import io.vertx.core.Promise;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.computate.search.response.solr.SolrResponse;
-import java.util.HashMap;
-import org.computate.search.tool.TimeTool;
-import java.time.ZoneId;
 
 
 /**
@@ -52,91 +54,11 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	protected void _searchListCurrikiResource_(Wrap<SearchList<CurrikiResource>> w) {
 	}
 
-	protected void _pageResponse(Wrap<String> w) {
-		if(searchListCurrikiResource_ != null)
-			w.o(JsonObject.mapFrom(searchListCurrikiResource_.getQueryResponse()).toString());
-	}
-
-	protected void _defaultZoneId(Wrap<String> w) {
-		w.o(Optional.ofNullable(siteRequest_.getRequestVars().get(VAR_defaultZoneId)).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE)));
-	}
-
-	/**
-	 * Ignore: true
-	 **/
-	protected void _defaultTimeZone(Wrap<ZoneId> w) {
-		w.o(ZoneId.of(defaultZoneId));
-	}
-
-	protected void _defaultLocaleId(Wrap<String> w) {
-		w.o(Optional.ofNullable(siteRequest_.getRequestHeaders().get("Accept-Language")).map(acceptLanguage -> StringUtils.substringBefore(acceptLanguage, ",")).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_LOCALE)));
-	}
-
-	/**
-	 * Ignore: true
-	 **/
-	protected void _defaultLocale(Wrap<Locale> w) {
-		w.o(Locale.forLanguageTag(defaultLocaleId));
-	}
-
-	protected void _defaultRangeGap(Wrap<String> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeGap()).orElse("+1DAY"));
-	}
-
-	protected void _defaultRangeEnd(Wrap<ZonedDateTime> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeEnd()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(ZonedDateTime.now(defaultTimeZone).toLocalDate().atStartOfDay(defaultTimeZone).plusDays(1)));
-	}
-
-	protected void _defaultRangeStart(Wrap<ZonedDateTime> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRangeStart()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(defaultRangeEnd.minusDays(7).toLocalDate().atStartOfDay(defaultTimeZone)));
-	}
-
-	protected void _defaultRangeVar(Wrap<String> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetRanges()).orElse(Arrays.asList()).stream().findFirst().map(v -> { if(v.contains("}")) return StringUtils.substringBefore(StringUtils.substringAfterLast(v, "}"), "_"); else return StringUtils.substringBefore(v, "_"); }).orElse("created"));
-	}
-
-	protected void _defaultFacetSort(Wrap<String> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetSort()).orElse("index"));
-	}
-
-	protected void _defaultFacetLimit(Wrap<Integer> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetLimit()).orElse(1));
-	}
-
-	protected void _defaultFacetMinCount(Wrap<Integer> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetMinCount()).orElse(1));
-	}
-
-	protected void _defaultPivotMinCount(Wrap<Integer> w) {
-		w.o(Optional.ofNullable(searchListCurrikiResource_.getFacetPivotMinCount()).orElse(0));
-	}
-
-	@Override
-	protected void _defaultPivotVars(List<String> l) {
-		Optional.ofNullable(searchListCurrikiResource_.getFacetPivots()).orElse(Arrays.asList()).forEach(facetPivot -> {
-			String facetPivot2 = facetPivot;
-			if(StringUtils.contains(facetPivot2, "}"))
-				facetPivot2 = StringUtils.substringAfterLast(facetPivot2, "}");
-			String[] parts = facetPivot2.split(",");
-			for(String part : parts) {
-				if(StringUtils.isNotBlank(part)) {
-					String var = StringUtils.substringBefore(part, "_");
-					if(StringUtils.isNotBlank(var))
-						l.add(var);
-				}
-			}
-		});
-	}
-
 	/**
 	 * {@inheritDoc}
 	 **/
 	protected void _listCurrikiResource(JsonArray l) {
 		Optional.ofNullable(searchListCurrikiResource_).map(o -> o.getList()).orElse(Arrays.asList()).stream().map(o -> JsonObject.mapFrom(o)).forEach(o -> l.add(o));
-	}
-
-	protected void _facetCounts(Wrap<SolrResponse.FacetCounts> w) {
-		w.o(searchListCurrikiResource_.getQueryResponse().getFacetCounts());
 	}
 
 	protected void _currikiResourceCount(Wrap<Integer> w) {
@@ -151,11 +73,6 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	protected void _pk(Wrap<Long> w) {
 		if(currikiResourceCount == 1)
 			w.o(currikiResource_.getPk());
-	}
-
-	protected void _id(Wrap<String> w) {
-		if(currikiResourceCount == 1)
-			w.o(currikiResource_.getId());
 	}
 
 	@Override
@@ -182,7 +99,7 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 
 	@Override
 	protected void _pageUri(Wrap<String> c) {
-		c.o("/resource");
+		c.o("/api/resource");
 	}
 
 	@Override
@@ -202,7 +119,7 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 		JsonArray pages = new JsonArray();
 		Long start = searchListCurrikiResource_.getStart().longValue();
 		Long rows = searchListCurrikiResource_.getRows().longValue();
-		Long foundNum = searchListCurrikiResource_.getQueryResponse().getResponse().getNumFound().longValue();
+		Long foundNum = searchListCurrikiResource_.getQueryResponse().getResults().getNumFound();
 		Long startNum = start + 1L;
 		Long endNum = start + rows;
 		Long floorMod = Math.floorMod(foundNum, rows);
@@ -243,67 +160,12 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 	}
 
 	@Override
-	protected void _varsQ(JsonObject vars) {
-		CurrikiResource.varsQForClass().forEach(var -> {
-			JsonObject json = new JsonObject();
-			json.put("var", var);
-			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("val", Optional.ofNullable(searchListCurrikiResource_.getRequest().getQuery()).filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
-			vars.put(var, json);
-		});
-	}
-
-	@Override
-	protected void _varsFq(JsonObject vars) {
-		Map<String, SolrResponse.FacetField> facetFields = Optional.ofNullable(facetCounts).map(c -> c.getFacetFields()).map(f -> f.getFacets()).orElse(new HashMap<String,SolrResponse.FacetField>());
-		CurrikiResource.varsFqForClass().forEach(var -> {
-			String varIndexed = CurrikiResource.varIndexedCurrikiResource(var);
-			String varStored = CurrikiResource.varStoredCurrikiResource(var);
-			JsonObject json = new JsonObject();
-			json.put("var", var);
-			json.put("varStored", varStored);
-			json.put("varIndexed", varIndexed);
-			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("val", searchListCurrikiResource_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
-			Optional.ofNullable(facetFields.get(varIndexed)).ifPresent(facetField -> {
-				JsonObject facetJson = new JsonObject();
-				JsonObject counts = new JsonObject();
-				facetJson.put("var", var);
-				facetField.getCounts().forEach((val, count) -> {
-					counts.put(val, count);
-				});
-				facetJson.put("counts", counts);
-				json.put("facetField", facetJson);
-			});
-			if(defaultPivotVars.contains(var)) {
-				json.put("pivot", true);
-			}
-			vars.put(var, json);
-		});
-	}
-
-	@Override
-	protected void _varsRange(JsonObject vars) {
-		CurrikiResource.varsRangeForClass().forEach(var -> {
-			String varIndexed = CurrikiResource.varIndexedCurrikiResource(var);
-			JsonObject json = new JsonObject();
-			json.put("var", var);
-			json.put("displayName", Optional.ofNullable(CurrikiResource.displayNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("classSimpleName", Optional.ofNullable(CurrikiResource.classSimpleNameCurrikiResource(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
-			json.put("val", searchListCurrikiResource_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(CurrikiResource.varIndexedCurrikiResource(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
-			vars.put(var, json);
-		});
-	}
-
-	@Override
 	protected void _query(JsonObject query) {
 		ServiceRequest serviceRequest = siteRequest_.getServiceRequest();
 		JsonObject params = serviceRequest.getParams();
 
 		JsonObject queryParams = Optional.ofNullable(serviceRequest).map(ServiceRequest::getParams).map(or -> or.getJsonObject("query")).orElse(new JsonObject());
-		Long num = searchListCurrikiResource_.getQueryResponse().getResponse().getNumFound().longValue();
+		Long num = searchListCurrikiResource_.getQueryResponse().getResults().getNumFound();
 		String q = "*:*";
 		String q1 = "objectText";
 		String q2 = "";
@@ -331,28 +193,27 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 		}
 		query.put("q", q);
 
-		Long rows1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getRows()).orElse(10L);
-		Long start1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getStart()).orElse(1L);
-		Long start2 = start1 - rows1;
-		Long start3 = start1 + rows1;
-		Long rows2 = rows1 / 2;
-		Long rows3 = rows1 * 2;
+		Integer rows1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getRows()).orElse(10);
+		Integer start1 = Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getStart()).orElse(1);
+		Integer start2 = start1 - rows1;
+		Integer start3 = start1 + rows1;
+		Integer rows2 = rows1 / 2;
+		Integer rows3 = rows1 * 2;
 		start2 = start2 < 0 ? 0 : start2;
-		JsonObject fqs = new JsonObject();
-		for(String fq : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getFilterQueries()).orElse(Arrays.asList())) {
+		JsonArray fqs = new JsonArray();
+		for(String fq : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getFilterQueries()).orElse(new String[0])) {
 			if(!StringUtils.contains(fq, "(")) {
 				String fq1 = StringUtils.substringBefore(fq, "_");
 				String fq2 = StringUtils.substringAfter(fq, ":");
 				if(!StringUtils.startsWithAny(fq, "classCanonicalNames_", "archived_", "deleted_", "sessionId", "userKeys"))
-					fqs.put(fq1, new JsonObject().put("var", fq1).put("val", fq2).put("displayName", CurrikiResource.displayNameForClass(fq1)));
+					fqs.add(new JsonObject().put("var", fq1).put("val", fq2));
 				}
 			}
 		query.put("fq", fqs);
 
 		JsonArray sorts = new JsonArray();
-		for(String sort : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
-			String sort1 = StringUtils.substringBefore(sort, "_");
-			sorts.add(new JsonObject().put("var", sort1).put("order", StringUtils.substringAfter(sort, " ")).put("displayName", CurrikiResource.displayNameForClass(sort1)));
+		for(SortClause sort : Optional.ofNullable(searchListCurrikiResource_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
+			sorts.add(new JsonObject().put("var", StringUtils.substringBefore(sort.getItem(), "_")).put("order", sort.getOrder().name()));
 		}
 		query.put("sort", sorts);
 	}
@@ -364,7 +225,7 @@ public class CurrikiResourceGenPage extends CurrikiResourceGenPageGen<BaseModelP
 
 	@Override
 	protected void _pageImageUri(Wrap<String> c) {
-			c.o("/png/resource-999.png");
+			c.o("/png/api/resource-999.png");
 	}
 
 	@Override

--- a/src/main/java/org/curriki/api/enus/model/user/SiteUserEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/curriki/api/enus/model/user/SiteUserEnUSGenApiServiceImpl.java
@@ -1,18 +1,17 @@
 package org.curriki.api.enus.model.user;
 
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.model.user.SiteUser;
-import org.computate.vertx.api.ApiRequest;
-import org.computate.vertx.search.list.SearchResult;
-import org.computate.vertx.verticle.EmailVerticle;
+import org.curriki.api.enus.user.SiteUser;
+import org.curriki.api.enus.request.api.ApiRequest;
+import org.curriki.api.enus.search.SearchResult;
+import org.curriki.api.enus.vertx.MailVerticle;
 import org.curriki.api.enus.config.ConfigKeys;
-import org.computate.vertx.api.BaseApiServiceImpl;
+import org.curriki.api.enus.base.BaseApiServiceImpl;
 import io.vertx.ext.web.client.WebClient;
 import java.util.Objects;
 import io.vertx.core.WorkerExecutor;
 import io.vertx.core.eventbus.EventBus;
 import io.vertx.pgclient.PgPool;
-import io.vertx.core.json.impl.JsonUtil;
 import io.vertx.ext.auth.authorization.AuthorizationProvider;
 import io.vertx.ext.web.templ.handlebars.HandlebarsTemplateEngine;
 import io.vertx.core.eventbus.DeliveryOptions;
@@ -23,10 +22,17 @@ import java.util.concurrent.TimeUnit;
 import java.time.Instant;
 import java.util.stream.Collectors;
 import io.vertx.core.json.Json;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrQuery.ORDER;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.client.solrj.util.ClientUtils;
 import org.apache.commons.lang3.StringUtils;
 import java.security.Principal;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import java.io.PrintWriter;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
 import java.util.Collection;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -65,7 +71,9 @@ import java.net.URLEncoder;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.http.HttpHeaders;
+import org.apache.http.client.utils.URLEncodedUtils;
 import java.nio.charset.Charset;
+import org.apache.http.NameValuePair;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.ext.web.api.service.ServiceResponse;
 import io.vertx.ext.web.client.predicate.ResponsePredicate;
@@ -74,18 +82,22 @@ import io.vertx.ext.auth.User;
 import java.util.Optional;
 import java.util.stream.Stream;
 import java.net.URLDecoder;
+import org.apache.solr.util.DateMathParser;
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
+import org.apache.solr.common.util.NamedList;
+import org.apache.solr.client.solrj.response.PivotField;
+import org.apache.solr.client.solrj.response.RangeFacet;
+import org.apache.solr.client.solrj.response.FacetField;
 import java.util.Map.Entry;
 import java.util.Iterator;
-import org.computate.search.tool.SearchTool;
-import org.computate.search.response.solr.SolrResponse;
 import java.util.Base64;
 import java.time.ZonedDateTime;
+import org.apache.solr.common.util.SimpleOrderedMap;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
-import org.curriki.api.enus.model.user.SiteUserEnUSApiServiceImpl;
-import org.computate.vertx.search.list.SearchList;
+import org.curriki.api.enus.user.SiteUserEnUSApiServiceImpl;
+import org.curriki.api.enus.search.SearchList;
 
 
 /**
@@ -103,7 +115,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	@Override
 	public void searchSiteUser(ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				{
 					searchSiteUserList(siteRequest, false, true, false).onSuccess(listSiteUser -> {
@@ -124,7 +136,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -139,20 +151,23 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	}
 
 
+
 	public Future<ServiceResponse> response200SearchSiteUser(SearchList<SiteUser> listSiteUser) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
-			SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_(SiteRequestEnUS.class);
-			SolrResponse responseSearch = listSiteUser.getQueryResponse();
-			List<SolrResponse.Doc> solrDocuments = listSiteUser.getQueryResponse().getResponse().getDocs();
-			Long searchInMillis = Long.valueOf(responseSearch.getResponseHeader().getqTime());
-			Long startNum = listSiteUser.getRequest().getStart();
-			Long foundNum = responseSearch.getResponse().getNumFound();
-			Integer returnedNum = responseSearch.getResponse().getDocs().size();
+			SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_();
+			QueryResponse responseSearch = listSiteUser.getQueryResponse();
+			SolrDocumentList solrDocuments = listSiteUser.getSolrDocumentList();
+			Long searchInMillis = Long.valueOf(responseSearch.getQTime());
+			Long transmissionInMillis = responseSearch.getElapsedTime();
+			Long startNum = responseSearch.getResults().getStart();
+			Long foundNum = responseSearch.getResults().getNumFound();
+			Integer returnedNum = responseSearch.getResults().size();
 			String searchTime = String.format("%d.%03d sec", TimeUnit.MILLISECONDS.toSeconds(searchInMillis), TimeUnit.MILLISECONDS.toMillis(searchInMillis) - TimeUnit.SECONDS.toMillis(TimeUnit.MILLISECONDS.toSeconds(searchInMillis)));
+			String transmissionTime = String.format("%d.%03d sec", TimeUnit.MILLISECONDS.toSeconds(transmissionInMillis), TimeUnit.MILLISECONDS.toMillis(transmissionInMillis) - TimeUnit.SECONDS.toSeconds(TimeUnit.MILLISECONDS.toSeconds(transmissionInMillis)));
 			String nextCursorMark = responseSearch.getNextCursorMark();
-			String exceptionSearch = Optional.ofNullable(responseSearch.getError()).map(error -> error.getMsg()).orElse(null);
-			List<String> fls = listSiteUser.getRequest().getFields();
+			Exception exceptionSearch = responseSearch.getException();
+			List<String> fls = listSiteUser.getFields();
 
 			JsonObject json = new JsonObject();
 			json.put("startNum", startNum);
@@ -160,6 +175,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			json.put("returnedNum", returnedNum);
 			if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves")) {
 				json.put("searchTime", searchTime);
+				json.put("transmissionTime", transmissionTime);
 			}
 			if(nextCursorMark != null) {
 				json.put("nextCursorMark", nextCursorMark);
@@ -169,15 +185,11 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				JsonObject json2 = JsonObject.mapFrom(o);
 				if(fls.size() > 0) {
 					Set<String> fieldNames = new HashSet<String>();
-					for(String fieldName : json2.fieldNames()) {
-						String v = SiteUser.varIndexedSiteUser(fieldName);
-						if(v != null)
-							fieldNames.add(SiteUser.varIndexedSiteUser(fieldName));
-					}
-					if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves_docvalues_strings")) {
-						fieldNames.removeAll(Optional.ofNullable(json2.getJsonArray("saves_docvalues_strings")).orElse(new JsonArray()).stream().map(s -> s.toString()).collect(Collectors.toList()));
-						fieldNames.remove("pk_docvalues_long");
-						fieldNames.remove("created_docvalues_date");
+					fieldNames.addAll(json2.fieldNames());
+					if(fls.size() == 1 && fls.stream().findFirst().orElse(null).equals("saves")) {
+						fieldNames.removeAll(Optional.ofNullable(json2.getJsonArray("saves")).orElse(new JsonArray()).stream().map(s -> s.toString()).collect(Collectors.toList()));
+						fieldNames.remove("pk");
+						fieldNames.remove("created");
 					}
 					else if(fls.size() >= 1) {
 						fieldNames.removeAll(fls);
@@ -191,42 +203,49 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			});
 			json.put("list", l);
 
-			SolrResponse.FacetFields facetFields = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetFields()).orElse(null);
+			List<FacetField> facetFields = responseSearch.getFacetFields();
 			if(facetFields != null) {
 				JsonObject facetFieldsJson = new JsonObject();
 				json.put("facet_fields", facetFieldsJson);
-				for(SolrResponse.FacetField facetField : facetFields.getFacets().values()) {
+				for(FacetField facetField : facetFields) {
 					String facetFieldVar = StringUtils.substringBefore(facetField.getName(), "_docvalues_");
 					JsonObject facetFieldCounts = new JsonObject();
 					facetFieldsJson.put(facetFieldVar, facetFieldCounts);
-					facetField.getCounts().forEach((name, count) -> {
-						facetFieldCounts.put(name, count);
-					});
+					List<FacetField.Count> facetFieldValues = facetField.getValues();
+					for(Integer i = 0; i < facetFieldValues.size(); i+= 1) {
+						FacetField.Count count = (FacetField.Count)facetFieldValues.get(i);
+						facetFieldCounts.put(count.getName(), count.getCount());
+					}
 				}
 			}
 
-			SolrResponse.FacetRanges facetRanges = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetRanges()).orElse(null);
+			List<RangeFacet> facetRanges = responseSearch.getFacetRanges();
 			if(facetRanges != null) {
 				JsonObject rangeJson = new JsonObject();
 				json.put("facet_ranges", rangeJson);
-				for(SolrResponse.FacetRange rangeFacet : facetRanges.getRanges().values()) {
+				for(RangeFacet rangeFacet : facetRanges) {
 					JsonObject rangeFacetJson = new JsonObject();
 					String rangeFacetVar = StringUtils.substringBefore(rangeFacet.getName(), "_docvalues_");
 					rangeJson.put(rangeFacetVar, rangeFacetJson);
 					JsonObject rangeFacetCountsMap = new JsonObject();
 					rangeFacetJson.put("counts", rangeFacetCountsMap);
-					rangeFacet.getCounts().forEach((name, count) -> {
-						rangeFacetCountsMap.put(name, count);
-					});
+					List<?> rangeFacetCounts = rangeFacet.getCounts();
+					for(Integer i = 0; i < rangeFacetCounts.size(); i+= 1) {
+						RangeFacet.Count count = (RangeFacet.Count)rangeFacetCounts.get(i);
+						rangeFacetCountsMap.put(count.getValue(), count.getCount());
+					}
 				}
 			}
 
-			SolrResponse.FacetPivot facetPivot = Optional.ofNullable(responseSearch.getFacetCounts()).map(f -> f.getFacetPivot()).orElse(null);
+			NamedList<List<PivotField>> facetPivot = responseSearch.getFacetPivot();
 			if(facetPivot != null) {
 				JsonObject facetPivotJson = new JsonObject();
 				json.put("facet_pivot", facetPivotJson);
-				for(SolrResponse.Pivot pivot : facetPivot.getPivotMap().values()) {
-					String[] varsIndexed = pivot.getName().trim().split(",");
+				Iterator<Entry<String, List<PivotField>>> facetPivotIterator = responseSearch.getFacetPivot().iterator();
+				while(facetPivotIterator.hasNext()) {
+					Entry<String, List<PivotField>> pivotEntry = facetPivotIterator.next();
+					List<PivotField> pivotFields = pivotEntry.getValue();
+					String[] varsIndexed = pivotEntry.getKey().trim().split(",");
 					String[] entityVars = new String[varsIndexed.length];
 					for(Integer i = 0; i < entityVars.length; i++) {
 						String entityIndexed = varsIndexed[i];
@@ -234,11 +253,11 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					}
 					JsonArray pivotArray = new JsonArray();
 					facetPivotJson.put(StringUtils.join(entityVars, ","), pivotArray);
-					responsePivotSearchSiteUser(pivot.getPivotList(), pivotArray);
+					responsePivotSearchSiteUser(pivotFields, pivotArray);
 				}
 			}
 			if(exceptionSearch != null) {
-				json.put("exceptionSearch", exceptionSearch);
+				json.put("exceptionSearch", exceptionSearch.getMessage());
 			}
 			promise.complete(ServiceResponse.completedWithJson(Buffer.buffer(Optional.ofNullable(json).orElse(new JsonObject()).encodePrettily())));
 		} catch(Exception ex) {
@@ -247,8 +266,8 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 		}
 		return promise.future();
 	}
-	public void responsePivotSearchSiteUser(List<SolrResponse.Pivot> pivots, JsonArray pivotArray) {
-		for(SolrResponse.Pivot pivotField : pivots) {
+	public void responsePivotSearchSiteUser(List<PivotField> pivotFields, JsonArray pivotArray) {
+		for(PivotField pivotField : pivotFields) {
 			String entityIndexed = pivotField.getField();
 			String entityVar = StringUtils.substringBefore(entityIndexed, "_docvalues_");
 			JsonObject pivotJson = new JsonObject();
@@ -256,20 +275,22 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			pivotJson.put("field", entityVar);
 			pivotJson.put("value", pivotField.getValue());
 			pivotJson.put("count", pivotField.getCount());
-			Collection<SolrResponse.PivotRange> pivotRanges = pivotField.getRanges().values();
-			List<SolrResponse.Pivot> pivotFields2 = pivotField.getPivotList();
+			List<RangeFacet> pivotRanges = pivotField.getFacetRanges();
+			List<PivotField> pivotFields2 = pivotField.getPivot();
 			if(pivotRanges != null) {
 				JsonObject rangeJson = new JsonObject();
 				pivotJson.put("ranges", rangeJson);
-				for(SolrResponse.PivotRange rangeFacet : pivotRanges) {
+				for(RangeFacet rangeFacet : pivotRanges) {
 					JsonObject rangeFacetJson = new JsonObject();
 					String rangeFacetVar = StringUtils.substringBefore(rangeFacet.getName(), "_docvalues_");
 					rangeJson.put(rangeFacetVar, rangeFacetJson);
 					JsonObject rangeFacetCountsObject = new JsonObject();
 					rangeFacetJson.put("counts", rangeFacetCountsObject);
-					rangeFacet.getCounts().forEach((value, count) -> {
-						rangeFacetCountsObject.put(value, count);
-					});
+					List<?> rangeFacetCounts = rangeFacet.getCounts();
+					for(Integer i = 0; i < rangeFacetCounts.size(); i+= 1) {
+						RangeFacet.Count count = (RangeFacet.Count)rangeFacetCounts.get(i);
+						rangeFacetCountsObject.put(count.getValue(), count.getCount());
+					}
 				}
 			}
 			if(pivotFields2 != null) {
@@ -285,14 +306,14 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	@Override
 	public void patchSiteUser(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("patchSiteUser started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 				{
 					searchSiteUserList(siteRequest, false, true, true).onSuccess(listSiteUser -> {
 						try {
 							List<String> roles2 = Optional.ofNullable(config.getValue(ConfigKeys.AUTH_ROLES_ADMIN)).map(v -> v instanceof JsonArray ? (JsonArray)v : new JsonArray(v.toString())).orElse(new JsonArray()).getList();
-							if(listSiteUser.getQueryResponse().getResponse().getNumFound() > 1
+							if(listSiteUser.getQueryResponse().getResults().getNumFound() > 1
 									&& !CollectionUtils.containsAny(siteRequest.getUserResourceRoles(), roles2)
 									&& !CollectionUtils.containsAny(siteRequest.getUserRealmRoles(), roles2)
 									) {
@@ -302,8 +323,8 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 							} else {
 
 								ApiRequest apiRequest = new ApiRequest();
-								apiRequest.setRows(listSiteUser.getRequest().getRows());
-								apiRequest.setNumFound(listSiteUser.getQueryResponse().getResponse().getNumFound());
+								apiRequest.setRows(listSiteUser.getRows());
+								apiRequest.setNumFound(listSiteUser.getQueryResponse().getResults().getNumFound());
 								apiRequest.setNumPATCH(0L);
 								apiRequest.initDeepApiRequest(siteRequest);
 								siteRequest.setApiRequest_(apiRequest);
@@ -339,7 +360,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -357,11 +378,10 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	public Future<Void> listPATCHSiteUser(ApiRequest apiRequest, SearchList<SiteUser> listSiteUser) {
 		Promise<Void> promise = Promise.promise();
 		List<Future> futures = new ArrayList<>();
-		SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_(SiteRequestEnUS.class);
+		SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_();
 		listSiteUser.getList().forEach(o -> {
-			SiteRequestEnUS siteRequest2 = generateSiteRequest(siteRequest.getUser(), siteRequest.getServiceRequest(), siteRequest.getJsonObject(), SiteRequestEnUS.class);
+			SiteRequestEnUS siteRequest2 = generateSiteRequestEnUS(siteRequest.getUser(), siteRequest.getServiceRequest(), siteRequest.getJsonObject());
 			o.setSiteRequest_(siteRequest2);
-			siteRequest2.setApiRequest_(siteRequest.getApiRequest_());
 			futures.add(Future.future(promise1 -> {
 				patchSiteUserFuture(o, false).onSuccess(a -> {
 					promise1.complete();
@@ -373,19 +393,14 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 		});
 		CompositeFuture.all(futures).onSuccess( a -> {
 			if(apiRequest != null) {
-				apiRequest.setNumPATCH(apiRequest.getNumPATCH() + listSiteUser.getQueryResponse().getResponse().getDocs().size());
+				apiRequest.setNumPATCH(apiRequest.getNumPATCH() + listSiteUser.getQueryResponse().getResults().size());
 				if(apiRequest.getNumFound() == 1L)
 					listSiteUser.first().apiRequestSiteUser();
 				eventBus.publish("websocketSiteUser", JsonObject.mapFrom(apiRequest).toString());
 			}
 			listSiteUser.next().onSuccess(next -> {
 				if(next) {
-					listPATCHSiteUser(apiRequest, listSiteUser).onSuccess(b -> {
-						promise.complete();
-					}).onFailure(ex -> {
-						LOG.error(String.format("listPATCHSiteUser failed. "), ex);
-						promise.fail(ex);
-					});
+					listPATCHSiteUser(apiRequest, listSiteUser);
 				} else {
 					promise.complete();
 				}
@@ -402,16 +417,16 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	@Override
 	public void patchSiteUserFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
 				searchSiteUserList(siteRequest, false, true, true).onSuccess(listSiteUser -> {
 					try {
 						SiteUser o = listSiteUser.first();
-						if(o != null && listSiteUser.getQueryResponse().getResponse().getNumFound() == 1) {
+						if(o != null && listSiteUser.getQueryResponse().getResults().getNumFound() == 1) {
 							ApiRequest apiRequest = new ApiRequest();
-							apiRequest.setRows(1L);
+							apiRequest.setRows(1);
 							apiRequest.setNumFound(1L);
 							apiRequest.setNumPATCH(0L);
 							apiRequest.initDeepApiRequest(siteRequest);
@@ -459,7 +474,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				Promise<SiteUser> promise1 = Promise.promise();
 				siteRequest.setSqlConnection(sqlConnection);
 				sqlPATCHSiteUser(o, inheritPk).onSuccess(siteUser -> {
-					persistSiteUser(siteUser).onSuccess(c -> {
+					defineSiteUser(siteUser).onSuccess(c -> {
 						relateSiteUser(siteUser).onSuccess(d -> {
 							indexSiteUser(siteUser).onSuccess(e -> {
 								promise1.complete(siteUser);
@@ -546,70 +561,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 							num++;
 							bParams.add(o2.sqlDeleted());
 						break;
-					case "setUserId":
-							o2.setUserId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserId());
-						break;
-					case "setUserName":
-							o2.setUserName(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userName + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserName());
-						break;
-					case "setUserEmail":
-							o2.setUserEmail(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userEmail + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserEmail());
-						break;
-					case "setUserFirstName":
-							o2.setUserFirstName(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userFirstName + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserFirstName());
-						break;
-					case "setUserLastName":
-							o2.setUserLastName(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userLastName + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserLastName());
-						break;
-					case "setUserFullName":
-							o2.setUserFullName(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_userFullName + "=$" + num);
-							num++;
-							bParams.add(o2.sqlUserFullName());
-						break;
-					case "setSeeArchived":
-							o2.setSeeArchived(jsonObject.getBoolean(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_seeArchived + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSeeArchived());
-						break;
-					case "setSeeDeleted":
-							o2.setSeeDeleted(jsonObject.getBoolean(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(SiteUser.VAR_seeDeleted + "=$" + num);
-							num++;
-							bParams.add(o2.sqlSeeDeleted());
-						break;
 				}
 			}
 			bSql.append(" WHERE pk=$" + num);
@@ -649,6 +600,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 		return promise.future();
 	}
 
+
 	public Future<ServiceResponse> response200PATCHSiteUser(SiteRequestEnUS siteRequest) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
@@ -666,12 +618,12 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	@Override
 	public void postSiteUser(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("postSiteUser started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 				{
 					ApiRequest apiRequest = new ApiRequest();
-					apiRequest.setRows(1L);
+					apiRequest.setRows(1);
 					apiRequest.setNumFound(1L);
 					apiRequest.setNumPATCH(0L);
 					apiRequest.initDeepApiRequest(siteRequest);
@@ -688,16 +640,16 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
 					if(softCommit == null && commitWithin == null)
 						softCommit = true;
-					if(softCommit != null)
+					if(softCommit)
 						query.put("softCommit", softCommit);
 					if(commitWithin != null)
 						query.put("commitWithin", commitWithin);
 					params.put("query", query);
-					JsonObject context = new JsonObject().put("params", params).put("user", siteRequest.getUserPrincipal());
+					JsonObject context = new JsonObject().put("params", params).put("user", Optional.ofNullable(siteRequest.getUser()).map(user -> user.attributes().getJsonObject("tokenPrincipal")).orElse(null));
 					JsonObject json = new JsonObject().put("context", context);
 					eventBus.request("ActiveLearningStudio-API-enUS-SiteUser", json, new DeliveryOptions().addHeader("action", "postSiteUserFuture")).onSuccess(a -> {
 						JsonObject responseMessage = (JsonObject)a.body();
-						JsonObject responseBody = new JsonObject(Buffer.buffer(JsonUtil.BASE64_DECODER.decode(responseMessage.getString("payload"))));
+						JsonObject responseBody = new JsonObject(new String(Base64.getDecoder().decode(responseMessage.getString("payload")), Charset.forName("UTF-8")));
 						apiRequest.setPk(Long.parseLong(responseBody.getString("pk")));
 						eventHandler.handle(Future.succeededFuture(ServiceResponse.completedWithJson(Buffer.buffer(responseBody.encodePrettily()))));
 						LOG.debug(String.format("postSiteUser succeeded. "));
@@ -711,7 +663,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -728,9 +680,9 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	@Override
 	public void postSiteUserFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			ApiRequest apiRequest = new ApiRequest();
-			apiRequest.setRows(1L);
+			apiRequest.setRows(1);
 			apiRequest.setNumFound(1L);
 			apiRequest.setNumPATCH(0L);
 			apiRequest.initDeepApiRequest(siteRequest);
@@ -744,7 +696,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				eventHandler.handle(Future.failedFuture(ex));
 			});
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -767,7 +719,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				siteRequest.setSqlConnection(sqlConnection);
 				createSiteUser(siteRequest).onSuccess(siteUser -> {
 					sqlPOSTSiteUser(siteUser, inheritPk).onSuccess(b -> {
-						persistSiteUser(siteUser).onSuccess(c -> {
+						defineSiteUser(siteUser).onSuccess(c -> {
 							relateSiteUser(siteUser).onSuccess(d -> {
 								indexSiteUser(siteUser).onSuccess(e -> {
 									promise1.complete(siteUser);
@@ -857,37 +809,11 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				num++;
 				bParams.add(siteRequest.getUserKey());
 			}
-			if(siteRequest.getUserId() != null) {
-				if(bParams.size() > 0) {
-					bSql.append(", ");
-				}
-				bSql.append("userId=$" + num);
-				num++;
-				bParams.add(siteRequest.getUserId());
-			}
 
 			if(jsonObject != null) {
 				Set<String> entityVars = jsonObject.fieldNames();
 				for(String entityVar : entityVars) {
 					switch(entityVar) {
-					case SiteUser.VAR_sessionId:
-						o2.setSessionId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_sessionId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSessionId());
-						break;
-					case SiteUser.VAR_userKey:
-						o2.setUserKey(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_userKey + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserKey());
-						break;
 					case SiteUser.VAR_inheritPk:
 						o2.setInheritPk(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -924,77 +850,23 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 						num++;
 						bParams.add(o2.sqlDeleted());
 						break;
-					case SiteUser.VAR_userId:
-						o2.setUserId(jsonObject.getString(entityVar));
+					case SiteUser.VAR_sessionId:
+						o2.setSessionId(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(SiteUser.VAR_userId + "=$" + num);
+						bSql.append(SiteUser.VAR_sessionId + "=$" + num);
 						num++;
-						bParams.add(o2.sqlUserId());
+						bParams.add(o2.sqlSessionId());
 						break;
-					case SiteUser.VAR_userName:
-						o2.setUserName(jsonObject.getString(entityVar));
+					case SiteUser.VAR_userKey:
+						o2.setUserKey(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(SiteUser.VAR_userName + "=$" + num);
+						bSql.append(SiteUser.VAR_userKey + "=$" + num);
 						num++;
-						bParams.add(o2.sqlUserName());
-						break;
-					case SiteUser.VAR_userEmail:
-						o2.setUserEmail(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_userEmail + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserEmail());
-						break;
-					case SiteUser.VAR_userFirstName:
-						o2.setUserFirstName(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_userFirstName + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserFirstName());
-						break;
-					case SiteUser.VAR_userLastName:
-						o2.setUserLastName(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_userLastName + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserLastName());
-						break;
-					case SiteUser.VAR_userFullName:
-						o2.setUserFullName(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_userFullName + "=$" + num);
-						num++;
-						bParams.add(o2.sqlUserFullName());
-						break;
-					case SiteUser.VAR_seeArchived:
-						o2.setSeeArchived(jsonObject.getBoolean(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_seeArchived + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSeeArchived());
-						break;
-					case SiteUser.VAR_seeDeleted:
-						o2.setSeeDeleted(jsonObject.getBoolean(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(SiteUser.VAR_seeDeleted + "=$" + num);
-						num++;
-						bParams.add(o2.sqlSeeDeleted());
+						bParams.add(o2.sqlUserKey());
 						break;
 					}
 				}
@@ -1033,6 +905,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 		return promise.future();
 	}
 
+
 	public Future<ServiceResponse> response200POSTSiteUser(SiteUser o) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
@@ -1051,15 +924,15 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	@Override
 	public void putimportSiteUser(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
 		LOG.debug(String.format("putimportSiteUser started. "));
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				siteRequest.setJsonObject(body);
 				{
 					try {
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
-						apiRequest.setRows(Long.valueOf(jsonArray.size()));
-						apiRequest.setNumFound(Long.valueOf(jsonArray.size()));
+						apiRequest.setRows(jsonArray.size());
+						apiRequest.setNumFound(new Integer(jsonArray.size()).longValue());
 						apiRequest.setNumPATCH(0L);
 						apiRequest.initDeepApiRequest(siteRequest);
 						siteRequest.setApiRequest_(apiRequest);
@@ -1091,7 +964,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -1124,12 +997,12 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					Integer commitWithin = Optional.ofNullable(siteRequest.getServiceRequest().getParams()).map(p -> p.getJsonObject("query")).map( q -> q.getInteger("commitWithin")).orElse(null);
 					if(softCommit == null && commitWithin == null)
 						softCommit = true;
-					if(softCommit != null)
+					if(softCommit)
 						query.put("softCommit", softCommit);
 					if(commitWithin != null)
 						query.put("commitWithin", commitWithin);
 					params.put("query", query);
-					JsonObject context = new JsonObject().put("params", params).put("user", siteRequest.getUserPrincipal());
+					JsonObject context = new JsonObject().put("params", params).put("user", Optional.ofNullable(siteRequest.getUser()).map(user -> user.attributes().getJsonObject("tokenPrincipal")).orElse(null));
 					JsonObject json = new JsonObject().put("context", context);
 					eventBus.request("ActiveLearningStudio-API-enUS-SiteUser", json, new DeliveryOptions().addHeader("action", "putimportSiteUserFuture")).onSuccess(a -> {
 						promise1.complete();
@@ -1155,10 +1028,10 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	@Override
 	public void putimportSiteUserFuture(JsonObject body, ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				ApiRequest apiRequest = new ApiRequest();
-				apiRequest.setRows(1L);
+				apiRequest.setRows(1);
 				apiRequest.setNumFound(1L);
 				apiRequest.setNumPATCH(0L);
 				apiRequest.initDeepApiRequest(siteRequest);
@@ -1170,11 +1043,11 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 				SearchList<SiteUser> searchList = new SearchList<SiteUser>();
 				searchList.setStore(true);
-				searchList.q("*:*");
+				searchList.setQuery("*:*");
 				searchList.setC(SiteUser.class);
-				searchList.fq("deleted_docvalues_boolean:false");
-				searchList.fq("archived_docvalues_boolean:false");
-				searchList.fq("inheritPk_docvalues_string:" + SearchTool.escapeQueryChars(body.getString("pk")));
+				searchList.addFilterQuery("deleted_docvalues_boolean:false");
+				searchList.addFilterQuery("archived_docvalues_boolean:false");
+				searchList.addFilterQuery("inheritPk_docvalues_string:" + ClientUtils.escapeQueryChars(body.getString("pk")));
 				searchList.promiseDeepForClass(siteRequest).onSuccess(a -> {
 					try {
 						if(searchList.size() >= 1) {
@@ -1206,7 +1079,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 										body2.put("set" + StringUtils.capitalize(f), bodyVal);
 									}
 								} else {
-									o2.persistForClass(f, bodyVal);
+									o2.defineForClass(f, bodyVal);
 									o2.relateForClass(f, bodyVal);
 									if(!StringUtils.containsAny(f, "pk", "created", "setCreated") && !Objects.equals(o.obtainForClass(f), o2.obtainForClass(f)))
 										body2.put("set" + StringUtils.capitalize(f), bodyVal);
@@ -1252,7 +1125,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				eventHandler.handle(Future.failedFuture(ex));
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -1265,6 +1138,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			}
 		});
 	}
+
 
 	public Future<ServiceResponse> response200PUTImportSiteUser(SiteRequestEnUS siteRequest) {
 		Promise<ServiceResponse> promise = Promise.promise();
@@ -1287,7 +1161,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	@Override
 	public void searchpageSiteUser(ServiceRequest serviceRequest, Handler<AsyncResult<ServiceResponse>> eventHandler) {
-		user(serviceRequest, SiteRequestEnUS.class, SiteUser.class, "ActiveLearningStudio-API-enUS-SiteUser", "postSiteUserFuture", "patchSiteUserFuture").onSuccess(siteRequest -> {
+		user(serviceRequest).onSuccess(siteRequest -> {
 			try {
 				{
 					searchSiteUserList(siteRequest, false, true, false).onSuccess(listSiteUser -> {
@@ -1308,7 +1182,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				error(null, eventHandler, ex);
 			}
 		}).onFailure(ex -> {
-			if("Inactive Token".equals(ex.getMessage()) || StringUtils.startsWith(ex.getMessage(), "invalid_grant:")) {
+			if("Inactive Token".equals(ex.getMessage()) || "invalid_grant: Refresh token expired".equals(ex.getMessage())) {
 				try {
 					eventHandler.handle(Future.succeededFuture(new ServiceResponse(302, "Found", null, MultiMap.caseInsensitiveMultiMap().add(HttpHeaders.LOCATION, "/logout?redirect_uri=" + URLEncoder.encode(serviceRequest.getExtra().getString("uri"), "UTF-8")))));
 				} catch(Exception ex2) {
@@ -1325,14 +1199,13 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 
 	public void searchpageSiteUserPageInit(SiteUserPage page, SearchList<SiteUser> listSiteUser) {
 	}
-
 	public String templateSearchPageSiteUser() {
 		return Optional.ofNullable(config.getString(ConfigKeys.TEMPLATE_PATH)).orElse("templates") + "/enUS/SiteUserPage";
 	}
 	public Future<ServiceResponse> response200SearchPageSiteUser(SearchList<SiteUser> listSiteUser) {
 		Promise<ServiceResponse> promise = Promise.promise();
 		try {
-			SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_(SiteRequestEnUS.class);
+			SiteRequestEnUS siteRequest = listSiteUser.getSiteRequest_();
 			SiteUserPage page = new SiteUserPage();
 			MultiMap requestHeaders = MultiMap.caseInsensitiveMultiMap();
 			siteRequest.setRequestHeaders(requestHeaders);
@@ -1390,7 +1263,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	}
 
 	public void searchSiteUserQ(SearchList<SiteUser> searchList, String entityVar, String valueIndexed, String varIndexed) {
-		searchList.q(varIndexed + ":" + ("*".equals(valueIndexed) ? valueIndexed : SearchTool.escapeQueryChars(valueIndexed)));
+		searchList.setQuery(varIndexed + ":" + ("*".equals(valueIndexed) ? valueIndexed : ClientUtils.escapeQueryChars(valueIndexed)));
 		if(!"*".equals(entityVar)) {
 		}
 	}
@@ -1402,30 +1275,30 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			String[] fqs = StringUtils.substringBefore(StringUtils.substringAfter(valueIndexed, "["), "]").split(" TO ");
 			if(fqs.length != 2)
 				throw new RuntimeException(String.format("\"%s\" invalid range query. ", valueIndexed));
-			String fq1 = fqs[0].equals("*") ? fqs[0] : SiteUser.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[0]);
-			String fq2 = fqs[1].equals("*") ? fqs[1] : SiteUser.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), fqs[1]);
+			String fq1 = fqs[0].equals("*") ? fqs[0] : SiteUser.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), fqs[0]);
+			String fq2 = fqs[1].equals("*") ? fqs[1] : SiteUser.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), fqs[1]);
 			 return varIndexed + ":[" + fq1 + " TO " + fq2 + "]";
 		} else {
-			return varIndexed + ":" + SearchTool.escapeQueryChars(SiteUser.staticSearchFqForClass(entityVar, searchList.getSiteRequest_(SiteRequestEnUS.class), valueIndexed)).replace("\\", "\\\\");
+			return varIndexed + ":" + ClientUtils.escapeQueryChars(SiteUser.staticSolrFqForClass(entityVar, searchList.getSiteRequest_(), valueIndexed)).replace("\\", "\\\\");
 		}
 	}
 
 	public void searchSiteUserSort(SearchList<SiteUser> searchList, String entityVar, String valueIndexed, String varIndexed) {
 		if(varIndexed == null)
 			throw new RuntimeException(String.format("\"%s\" is not an indexed entity. ", entityVar));
-		searchList.sort(varIndexed, valueIndexed);
+		searchList.addSort(varIndexed, ORDER.valueOf(valueIndexed));
 	}
 
-	public void searchSiteUserRows(SearchList<SiteUser> searchList, Long valueRows) {
-			searchList.rows(valueRows != null ? valueRows : 10L);
+	public void searchSiteUserRows(SearchList<SiteUser> searchList, Integer valueRows) {
+			searchList.setRows(valueRows != null ? valueRows : 10);
 	}
 
-	public void searchSiteUserStart(SearchList<SiteUser> searchList, Long valueStart) {
-		searchList.start(valueStart);
+	public void searchSiteUserStart(SearchList<SiteUser> searchList, Integer valueStart) {
+		searchList.setStart(valueStart);
 	}
 
 	public void searchSiteUserVar(SearchList<SiteUser> searchList, String var, String value) {
-		searchList.getSiteRequest_(SiteRequestEnUS.class).getRequestVars().put(var, value);
+		searchList.getSiteRequest_().getRequestVars().put(var, value);
 	}
 
 	public void searchSiteUserUri(SearchList<SiteUser> searchList) {
@@ -1470,20 +1343,17 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			SearchList<SiteUser> searchList = new SearchList<SiteUser>();
 			searchList.setPopulate(populate);
 			searchList.setStore(store);
-			searchList.q("*:*");
+			searchList.setQuery("*:*");
 			searchList.setC(SiteUser.class);
 			searchList.setSiteRequest_(siteRequest);
-			if(entityList != null) {
-				for(String v : entityList) {
-					searchList.fl(SiteUser.varIndexedSiteUser(v));
-				}
-			}
+			if(entityList != null)
+				searchList.addFields(entityList);
 
 			String id = serviceRequest.getParams().getJsonObject("path").getString("id");
 			if(id != null && NumberUtils.isCreatable(id)) {
-				searchList.fq("(pk_docvalues_long:" + SearchTool.escapeQueryChars(id) + " OR objectId_docvalues_string:" + SearchTool.escapeQueryChars(id) + ")");
+				searchList.addFilterQuery("(pk_docvalues_long:" + ClientUtils.escapeQueryChars(id) + " OR objectId_docvalues_string:" + ClientUtils.escapeQueryChars(id) + ")");
 			} else if(id != null) {
-				searchList.fq("objectId_docvalues_string:" + SearchTool.escapeQueryChars(id));
+				searchList.addFilterQuery("objectId_docvalues_string:" + ClientUtils.escapeQueryChars(id));
 			}
 
 			List<String> roles = Optional.ofNullable(config.getValue(ConfigKeys.AUTH_ROLES_REQUIRED + "_SiteUser")).map(v -> v instanceof JsonArray ? (JsonArray)v : new JsonArray(v.toString())).orElse(new JsonArray()).getList();
@@ -1494,7 +1364,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					&& (modify || !CollectionUtils.containsAny(siteRequest.getUserResourceRoles(), roleReads))
 					&& (modify || !CollectionUtils.containsAny(siteRequest.getUserRealmRoles(), roleReads))
 					) {
-				searchList.fq("sessionId_docvalues_string:" + SearchTool.escapeQueryChars(Optional.ofNullable(siteRequest.getSessionId()).orElse("-----")) + " OR " + "sessionId_docvalues_string:" + SearchTool.escapeQueryChars(Optional.ofNullable(siteRequest.getSessionIdBefore()).orElse("-----"))
+				searchList.addFilterQuery("sessionId_docvalues_string:" + ClientUtils.escapeQueryChars(Optional.ofNullable(siteRequest.getSessionId()).orElse("-----")) + " OR " + "sessionId_docvalues_string:" + ClientUtils.escapeQueryChars(Optional.ofNullable(siteRequest.getSessionIdBefore()).orElse("-----"))
 						+ " OR userKeys_docvalues_longs:" + Optional.ofNullable(siteRequest.getUserKey()).orElse(0L));
 			}
 
@@ -1503,8 +1373,8 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				String valueIndexed = null;
 				String varIndexed = null;
 				String valueSort = null;
-				Long valueStart = null;
-				Long valueRows = null;
+				Integer valueStart = null;
+				Integer valueRows = null;
 				String valueCursorMark = null;
 				String paramName = paramRequest.getKey();
 				Object paramValuesObject = paramRequest.getValue();
@@ -1522,7 +1392,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 								entityVar = entityVars[i];
 								varsIndexed[i] = SiteUser.varIndexedSiteUser(entityVar);
 							}
-							searchList.facetPivot((solrLocalParams == null ? "" : solrLocalParams) + StringUtils.join(varsIndexed, ","));
+							searchList.add("facet.pivot", (solrLocalParams == null ? "" : solrLocalParams) + StringUtils.join(varsIndexed, ","));
 						}
 					} else if(paramValuesObject != null) {
 						for(Object paramObject : paramObjects) {
@@ -1541,7 +1411,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 											foundQ = mQ.find();
 										}
 										mQ.appendTail(sb);
-										searchList.q(sb.toString());
+										searchList.setQuery(sb.toString());
 									}
 									break;
 								case "fq":
@@ -1558,7 +1428,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 											foundFq = mFq.find();
 										}
 										mFq.appendTail(sb);
-										searchList.fq(sb.toString());
+										searchList.addFilterQuery(sb.toString());
 									}
 									break;
 								case "sort":
@@ -1568,29 +1438,29 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 									searchSiteUserSort(searchList, entityVar, valueIndexed, varIndexed);
 									break;
 								case "start":
-									valueStart = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									valueStart = paramObject instanceof Integer ? (Integer)paramObject : Integer.parseInt(paramObject.toString());
 									searchSiteUserStart(searchList, valueStart);
 									break;
 								case "rows":
-									valueRows = paramObject instanceof Long ? (Long)paramObject : Long.parseLong(paramObject.toString());
+									valueRows = paramObject instanceof Integer ? (Integer)paramObject : Integer.parseInt(paramObject.toString());
 									searchSiteUserRows(searchList, valueRows);
 									break;
 								case "facet":
-									searchList.facet((Boolean)paramObject);
+									searchList.add("facet", ((Boolean)paramObject).toString());
 									break;
 								case "facet.range.start":
 									String startMathStr = (String)paramObject;
-									Date start = SearchTool.parseMath(startMathStr);
-									searchList.facetRangeStart(start.toInstant().toString());
+									Date start = DateMathParser.parseMath(null, startMathStr);
+									searchList.add("facet.range.start", start.toInstant().toString());
 									break;
 								case "facet.range.end":
 									String endMathStr = (String)paramObject;
-									Date end = SearchTool.parseMath(endMathStr);
-									searchList.facetRangeEnd(end.toInstant().toString());
+									Date end = DateMathParser.parseMath(null, endMathStr);
+									searchList.add("facet.range.end", end.toInstant().toString());
 									break;
 								case "facet.range.gap":
 									String gap = (String)paramObject;
-									searchList.facetRangeGap(gap);
+									searchList.add("facet.range.gap", gap);
 									break;
 								case "facet.range":
 									Matcher mFacetRange = Pattern.compile("(?:(\\{![^\\}]+\\}))?(.*)").matcher((String)paramObject);
@@ -1599,14 +1469,14 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 										String solrLocalParams = mFacetRange.group(1);
 										entityVar = mFacetRange.group(2).trim();
 										varIndexed = SiteUser.varIndexedSiteUser(entityVar);
-										searchList.facetRange((solrLocalParams == null ? "" : solrLocalParams) + varIndexed);
+										searchList.add("facet.range", (solrLocalParams == null ? "" : solrLocalParams) + varIndexed);
 									}
 									break;
 								case "facet.field":
 									entityVar = (String)paramObject;
 									varIndexed = SiteUser.varIndexedSiteUser(entityVar);
 									if(varIndexed != null)
-										searchList.facetField(varIndexed);
+										searchList.addFacetField(varIndexed);
 									break;
 								case "var":
 									entityVar = StringUtils.trim(StringUtils.substringBefore((String)paramObject, ":"));
@@ -1615,7 +1485,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 									break;
 								case "cursorMark":
 									valueCursorMark = (String)paramObject;
-									searchList.cursorMark((String)paramObject);
+									searchList.add("cursorMark", (String)paramObject);
 									break;
 							}
 						}
@@ -1626,7 +1496,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 				}
 			});
 			if("*:*".equals(searchList.getQuery()) && searchList.getSorts().size() == 0) {
-				searchList.sort("created_docvalues_date", "desc");
+				searchList.addSort("created_docvalues_date", ORDER.desc);
 			}
 			searchSiteUser2(siteRequest, populate, store, modify, searchList);
 			searchList.promiseDeepForClass(siteRequest).onSuccess(a -> {
@@ -1644,7 +1514,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 	public void searchSiteUser2(SiteRequestEnUS siteRequest, Boolean populate, Boolean store, Boolean modify, SearchList<SiteUser> searchList) {
 	}
 
-	public Future<Void> persistSiteUser(SiteUser o) {
+	public Future<Void> defineSiteUser(SiteUser o) {
 		Promise<Void> promise = Promise.promise();
 		try {
 			SiteRequestEnUS siteRequest = o.getSiteRequest_();
@@ -1661,25 +1531,25 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 							Object columnValue = definition.getValue(i);
 							if(!"pk".equals(columnName)) {
 								try {
-									o.persistForClass(columnName, columnValue);
+									o.defineForClass(columnName, columnValue);
 								} catch(Exception e) {
-									LOG.error(String.format("persistSiteUser failed. "), e);
+									LOG.error(String.format("defineSiteUser failed. "), e);
 								}
 							}
 						}
 					}
 					promise.complete();
 				} catch(Exception ex) {
-					LOG.error(String.format("persistSiteUser failed. "), ex);
+					LOG.error(String.format("defineSiteUser failed. "), ex);
 					promise.fail(ex);
 				}
 			}).onFailure(ex -> {
 				RuntimeException ex2 = new RuntimeException(ex);
-				LOG.error(String.format("persistSiteUser failed. "), ex2);
+				LOG.error(String.format("defineSiteUser failed. "), ex2);
 				promise.fail(ex2);
 			});
 		} catch(Exception ex) {
-			LOG.error(String.format("persistSiteUser failed. "), ex);
+			LOG.error(String.format("defineSiteUser failed. "), ex);
 			promise.fail(ex);
 		}
 		return promise.future();
@@ -1697,12 +1567,8 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			SiteRequestEnUS siteRequest = o.getSiteRequest_();
 			ApiRequest apiRequest = siteRequest.getApiRequest_();
 			o.promiseDeepForClass(siteRequest).onSuccess(a -> {
-				JsonObject json = new JsonObject();
-				JsonObject add = new JsonObject();
-				json.put("add", add);
-				JsonObject doc = new JsonObject();
-				add.put("doc", doc);
-				o.indexSiteUser(doc);
+				SolrInputDocument document = new SolrInputDocument();
+				o.indexSiteUser(document);
 				String solrHostName = siteRequest.getConfig().getString(ConfigKeys.SOLR_HOST_NAME);
 				Integer solrPort = siteRequest.getConfig().getInteger(ConfigKeys.SOLR_PORT);
 				String solrCollection = siteRequest.getConfig().getString(ConfigKeys.SOLR_COLLECTION);
@@ -1713,6 +1579,7 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					else if(softCommit == null)
 						softCommit = false;
 				String solrRequestUri = String.format("/solr/%s/update%s%s%s", solrCollection, "?overwrite=true&wt=json", softCommit ? "&softCommit=true" : "", commitWithin != null ? ("&commitWithin=" + commitWithin) : "");
+				JsonArray json = new JsonArray().add(new JsonObject(document.toMap(new HashMap<String, Object>())));
 				webClient.post(solrPort, solrHostName, solrRequestUri).putHeader("Content-Type", "application/json").expect(ResponsePredicate.SC_OK).sendBuffer(json.toBuffer()).onSuccess(b -> {
 					promise.complete();
 				}).onFailure(ex -> {

--- a/src/main/java/org/curriki/api/enus/model/user/SiteUserGenPage.java
+++ b/src/main/java/org/curriki/api/enus/model/user/SiteUserGenPage.java
@@ -1,18 +1,14 @@
 package org.curriki.api.enus.model.user;
 
-import java.util.List;
-import java.lang.Long;
-import java.lang.String;
-import java.lang.Boolean;
-import org.curriki.api.enus.base.BaseModelPage;
+import org.curriki.api.enus.page.PageLayout;
+import org.curriki.api.enus.model.base.BaseModelPage;
 import org.curriki.api.enus.request.SiteRequestEnUS;
-import org.curriki.api.enus.user.SiteUser;
+import org.curriki.api.enus.model.user.SiteUser;
 import java.io.IOException;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
-import org.curriki.api.enus.search.SearchList;
-import org.curriki.api.enus.wrap.Wrap;
-import org.curriki.api.enus.page.PageLayout;
+import org.computate.vertx.search.list.SearchList;
+import org.computate.search.wrap.Wrap;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.LocalDate;
@@ -26,20 +22,22 @@ import java.net.URLDecoder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import java.util.Map;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.apache.solr.common.util.SimpleOrderedMap;
 import java.util.stream.Collectors;
 import java.util.Arrays;
-import org.apache.solr.client.solrj.response.QueryResponse;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.math.MathContext;
 import org.apache.commons.collections.CollectionUtils;
 import java.util.Objects;
-import org.apache.solr.client.solrj.SolrQuery.SortClause;
 import io.vertx.core.Promise;
 import org.curriki.api.enus.config.ConfigKeys;
+import org.computate.search.response.solr.SolrResponse;
+import java.util.HashMap;
+import org.computate.search.tool.TimeTool;
+import java.time.ZoneId;
 
 
 /**
@@ -54,11 +52,91 @@ public class SiteUserGenPage extends SiteUserGenPageGen<BaseModelPage> {
 	protected void _searchListSiteUser_(Wrap<SearchList<SiteUser>> w) {
 	}
 
+	protected void _pageResponse(Wrap<String> w) {
+		if(searchListSiteUser_ != null)
+			w.o(JsonObject.mapFrom(searchListSiteUser_.getQueryResponse()).toString());
+	}
+
+	protected void _defaultZoneId(Wrap<String> w) {
+		w.o(Optional.ofNullable(siteRequest_.getRequestVars().get(VAR_defaultZoneId)).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_ZONE)));
+	}
+
+	/**
+	 * Ignore: true
+	 **/
+	protected void _defaultTimeZone(Wrap<ZoneId> w) {
+		w.o(ZoneId.of(defaultZoneId));
+	}
+
+	protected void _defaultLocaleId(Wrap<String> w) {
+		w.o(Optional.ofNullable(siteRequest_.getRequestHeaders().get("Accept-Language")).map(acceptLanguage -> StringUtils.substringBefore(acceptLanguage, ",")).orElse(siteRequest_.getConfig().getString(ConfigKeys.SITE_LOCALE)));
+	}
+
+	/**
+	 * Ignore: true
+	 **/
+	protected void _defaultLocale(Wrap<Locale> w) {
+		w.o(Locale.forLanguageTag(defaultLocaleId));
+	}
+
+	protected void _defaultRangeGap(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetRangeGap()).orElse("+1DAY"));
+	}
+
+	protected void _defaultRangeEnd(Wrap<ZonedDateTime> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetRangeEnd()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(ZonedDateTime.now(defaultTimeZone).toLocalDate().atStartOfDay(defaultTimeZone).plusDays(1)));
+	}
+
+	protected void _defaultRangeStart(Wrap<ZonedDateTime> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetRangeStart()).map(s -> TimeTool.parseZonedDateTime(defaultTimeZone, s)).orElse(defaultRangeEnd.minusDays(7).toLocalDate().atStartOfDay(defaultTimeZone)));
+	}
+
+	protected void _defaultRangeVar(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetRanges()).orElse(Arrays.asList()).stream().findFirst().map(v -> { if(v.contains("}")) return StringUtils.substringBefore(StringUtils.substringAfterLast(v, "}"), "_"); else return StringUtils.substringBefore(v, "_"); }).orElse("created"));
+	}
+
+	protected void _defaultFacetSort(Wrap<String> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetSort()).orElse("index"));
+	}
+
+	protected void _defaultFacetLimit(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetLimit()).orElse(1));
+	}
+
+	protected void _defaultFacetMinCount(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetMinCount()).orElse(1));
+	}
+
+	protected void _defaultPivotMinCount(Wrap<Integer> w) {
+		w.o(Optional.ofNullable(searchListSiteUser_.getFacetPivotMinCount()).orElse(0));
+	}
+
+	@Override
+	protected void _defaultPivotVars(List<String> l) {
+		Optional.ofNullable(searchListSiteUser_.getFacetPivots()).orElse(Arrays.asList()).forEach(facetPivot -> {
+			String facetPivot2 = facetPivot;
+			if(StringUtils.contains(facetPivot2, "}"))
+				facetPivot2 = StringUtils.substringAfterLast(facetPivot2, "}");
+			String[] parts = facetPivot2.split(",");
+			for(String part : parts) {
+				if(StringUtils.isNotBlank(part)) {
+					String var = StringUtils.substringBefore(part, "_");
+					if(StringUtils.isNotBlank(var))
+						l.add(var);
+				}
+			}
+		});
+	}
+
 	/**
 	 * {@inheritDoc}
 	 **/
 	protected void _listSiteUser(JsonArray l) {
 		Optional.ofNullable(searchListSiteUser_).map(o -> o.getList()).orElse(Arrays.asList()).stream().map(o -> JsonObject.mapFrom(o)).forEach(o -> l.add(o));
+	}
+
+	protected void _facetCounts(Wrap<SolrResponse.FacetCounts> w) {
+		w.o(searchListSiteUser_.getQueryResponse().getFacetCounts());
 	}
 
 	protected void _siteUserCount(Wrap<Integer> w) {
@@ -73,6 +151,11 @@ public class SiteUserGenPage extends SiteUserGenPageGen<BaseModelPage> {
 	protected void _pk(Wrap<Long> w) {
 		if(siteUserCount == 1)
 			w.o(siteUser_.getPk());
+	}
+
+	protected void _id(Wrap<String> w) {
+		if(siteUserCount == 1)
+			w.o(siteUser_.getId());
 	}
 
 	@Override
@@ -119,7 +202,7 @@ public class SiteUserGenPage extends SiteUserGenPageGen<BaseModelPage> {
 		JsonArray pages = new JsonArray();
 		Long start = searchListSiteUser_.getStart().longValue();
 		Long rows = searchListSiteUser_.getRows().longValue();
-		Long foundNum = searchListSiteUser_.getQueryResponse().getResults().getNumFound();
+		Long foundNum = searchListSiteUser_.getQueryResponse().getResponse().getNumFound().longValue();
 		Long startNum = start + 1L;
 		Long endNum = start + rows;
 		Long floorMod = Math.floorMod(foundNum, rows);
@@ -160,12 +243,64 @@ public class SiteUserGenPage extends SiteUserGenPageGen<BaseModelPage> {
 	}
 
 	@Override
+	protected void _varsQ(JsonObject vars) {
+		SiteUser.varsQForClass().forEach(var -> {
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(SiteUser.displayNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(SiteUser.classSimpleNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", Optional.ofNullable(searchListSiteUser_.getRequest().getQuery()).filter(fq -> fq.startsWith(SiteUser.varIndexedSiteUser(var) + ":")).map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsFq(JsonObject vars) {
+		Map<String, SolrResponse.FacetField> facetFields = Optional.ofNullable(facetCounts).map(c -> c.getFacetFields()).map(f -> f.getFacets()).orElse(new HashMap<String,SolrResponse.FacetField>());
+		SiteUser.varsFqForClass().forEach(var -> {
+			String varIndexed = SiteUser.varIndexedSiteUser(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(SiteUser.displayNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(SiteUser.classSimpleNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListSiteUser_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(SiteUser.varIndexedSiteUser(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			Optional.ofNullable(facetFields.get(varIndexed)).ifPresent(facetField -> {
+				JsonObject facetJson = new JsonObject();
+				JsonObject counts = new JsonObject();
+				facetJson.put("var", var);
+				facetField.getCounts().forEach((val, count) -> {
+					counts.put(val, count);
+				});
+				facetJson.put("counts", counts);
+				json.put("facetField", facetJson);
+			});
+			if(defaultPivotVars.contains(var)) {
+				json.put("pivot", true);
+			}
+			vars.put(var, json);
+		});
+	}
+
+	@Override
+	protected void _varsRange(JsonObject vars) {
+		SiteUser.varsRangeForClass().forEach(var -> {
+			String varIndexed = SiteUser.varIndexedSiteUser(var);
+			JsonObject json = new JsonObject();
+			json.put("var", var);
+			json.put("displayName", Optional.ofNullable(SiteUser.displayNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("classSimpleName", Optional.ofNullable(SiteUser.classSimpleNameSiteUser(var)).map(d -> StringUtils.isBlank(d) ? var : d).orElse(var));
+			json.put("val", searchListSiteUser_.getRequest().getFilterQueries().stream().filter(fq -> fq.startsWith(SiteUser.varIndexedSiteUser(var) + ":")).findFirst().map(s -> StringUtils.substringAfter(s, ":")).orElse(null));
+			vars.put(var, json);
+		});
+	}
+
+	@Override
 	protected void _query(JsonObject query) {
 		ServiceRequest serviceRequest = siteRequest_.getServiceRequest();
 		JsonObject params = serviceRequest.getParams();
 
 		JsonObject queryParams = Optional.ofNullable(serviceRequest).map(ServiceRequest::getParams).map(or -> or.getJsonObject("query")).orElse(new JsonObject());
-		Long num = searchListSiteUser_.getQueryResponse().getResults().getNumFound();
+		Long num = searchListSiteUser_.getQueryResponse().getResponse().getNumFound().longValue();
 		String q = "*:*";
 		String q1 = "objectText";
 		String q2 = "";
@@ -193,27 +328,28 @@ public class SiteUserGenPage extends SiteUserGenPageGen<BaseModelPage> {
 		}
 		query.put("q", q);
 
-		Integer rows1 = Optional.ofNullable(searchListSiteUser_).map(l -> l.getRows()).orElse(10);
-		Integer start1 = Optional.ofNullable(searchListSiteUser_).map(l -> l.getStart()).orElse(1);
-		Integer start2 = start1 - rows1;
-		Integer start3 = start1 + rows1;
-		Integer rows2 = rows1 / 2;
-		Integer rows3 = rows1 * 2;
+		Long rows1 = Optional.ofNullable(searchListSiteUser_).map(l -> l.getRows()).orElse(10L);
+		Long start1 = Optional.ofNullable(searchListSiteUser_).map(l -> l.getStart()).orElse(1L);
+		Long start2 = start1 - rows1;
+		Long start3 = start1 + rows1;
+		Long rows2 = rows1 / 2;
+		Long rows3 = rows1 * 2;
 		start2 = start2 < 0 ? 0 : start2;
-		JsonArray fqs = new JsonArray();
-		for(String fq : Optional.ofNullable(searchListSiteUser_).map(l -> l.getFilterQueries()).orElse(new String[0])) {
+		JsonObject fqs = new JsonObject();
+		for(String fq : Optional.ofNullable(searchListSiteUser_).map(l -> l.getFilterQueries()).orElse(Arrays.asList())) {
 			if(!StringUtils.contains(fq, "(")) {
 				String fq1 = StringUtils.substringBefore(fq, "_");
 				String fq2 = StringUtils.substringAfter(fq, ":");
 				if(!StringUtils.startsWithAny(fq, "classCanonicalNames_", "archived_", "deleted_", "sessionId", "userKeys"))
-					fqs.add(new JsonObject().put("var", fq1).put("val", fq2));
+					fqs.put(fq1, new JsonObject().put("var", fq1).put("val", fq2).put("displayName", SiteUser.displayNameForClass(fq1)));
 				}
 			}
 		query.put("fq", fqs);
 
 		JsonArray sorts = new JsonArray();
-		for(SortClause sort : Optional.ofNullable(searchListSiteUser_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
-			sorts.add(new JsonObject().put("var", StringUtils.substringBefore(sort.getItem(), "_")).put("order", sort.getOrder().name()));
+		for(String sort : Optional.ofNullable(searchListSiteUser_).map(l -> l.getSorts()).orElse(Arrays.asList())) {
+			String sort1 = StringUtils.substringBefore(sort, "_");
+			sorts.add(new JsonObject().put("var", sort1).put("order", StringUtils.substringAfter(sort, " ")).put("displayName", SiteUser.displayNameForClass(sort1)));
 		}
 		query.put("sort", sorts);
 	}

--- a/src/main/java/org/curriki/api/enus/request/SiteRequestEnUS.java
+++ b/src/main/java/org/curriki/api/enus/request/SiteRequestEnUS.java
@@ -219,6 +219,13 @@ public class SiteRequestEnUS extends SiteRequestEnUSGen<Object> implements Compu
 	}
 
 	/**
+	 * Description: The request language. 
+	 */
+	protected void _lang(Wrap<String> w) {
+		w.o("enUS");
+	}
+
+	/**
 	 * Description: The primary key of object of the request
 	 */
 	protected void _requestPk(Wrap<Long> c) {

--- a/src/main/java/org/curriki/api/enus/vertx/WorkerVerticle.java
+++ b/src/main/java/org/curriki/api/enus/vertx/WorkerVerticle.java
@@ -579,17 +579,19 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 			Integer sequence = row.getInteger(80);
 			String uniqueName = row.getString(81);
 			String ext = row.getString(82);
-			// String active = row.getString(83);
-			String tempactive = row.getString(83);
-			String s3path = row.getString(84);
-			String sdfStatus = row.getString(85);
-			String transcoded = row.getString(86);
-			String lodestar = row.getString(87);
-			String archive = row.getString(88);
-			String identifier = row.getString(89);
-			String displayName = row.getString(90);
-			String subjectArea = row.getString(91);
-			String name = row.getString(92);			
+			String resourceFilesActive = row.getString(83);
+			String tempactive = row.getString(84);
+			String s3path = row.getString(85);
+			String sdfStatus = row.getString(86);
+			String transcoded = row.getString(87);
+			String lodestar = row.getString(88);
+			String archive = row.getString(89);
+			String identifier = row.getString(90);
+			String educationLevelDisplayName = row.getString(91);
+			String subjectArea = row.getString(92);
+			String subjectAreaDisplayName = row.getString(93);
+			String instructionTypeDisplayName = row.getString(94);
+			String name = row.getString(95);
 			JsonObject body = new JsonObject();
 			body.put(CurrikiResource.VAR_saves, new JsonArray()
 					.add(CurrikiResource.VAR_inheritPk)
@@ -679,6 +681,7 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 					.add(CurrikiResource.VAR_sequence)
 					.add(CurrikiResource.VAR_uniqueName)
 					.add(CurrikiResource.VAR_ext)
+					.add(CurrikiResource.VAR_resourceFilesActive)
 					.add(CurrikiResource.VAR_tempactive)
 					.add(CurrikiResource.VAR_s3path)
 					.add(CurrikiResource.VAR_sdfStatus)
@@ -686,8 +689,10 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 					.add(CurrikiResource.VAR_lodestar)
 					.add(CurrikiResource.VAR_archive)
 					.add(CurrikiResource.VAR_identifier)
-					.add(CurrikiResource.VAR_displayName)
+					.add(CurrikiResource.VAR_educationLevelDisplayName)
 					.add(CurrikiResource.VAR_subjectArea)
+					.add(CurrikiResource.VAR_subjectAreaDisplayName)
+					.add(CurrikiResource.VAR_instructionTypeDisplayName)
 					.add(CurrikiResource.VAR_name)
 					);
 
@@ -775,6 +780,7 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 			body.put(CurrikiResource.VAR_sequence, sequence);
 			body.put(CurrikiResource.VAR_uniqueName, uniqueName);
 			body.put(CurrikiResource.VAR_ext, ext);
+			body.put(CurrikiResource.VAR_resourceFilesActive, resourceFilesActive);
 			body.put(CurrikiResource.VAR_tempactive, tempactive);
 			body.put(CurrikiResource.VAR_s3path, s3path);
 			body.put(CurrikiResource.VAR_sdfStatus, sdfStatus);
@@ -782,8 +788,10 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 			body.put(CurrikiResource.VAR_lodestar, lodestar);
 			body.put(CurrikiResource.VAR_archive, archive);
 			body.put(CurrikiResource.VAR_identifier, identifier);
-			body.put(CurrikiResource.VAR_displayName, displayName);
+			body.put(CurrikiResource.VAR_educationLevelDisplayName, educationLevelDisplayName);
 			body.put(CurrikiResource.VAR_subjectArea, subjectArea);
+			body.put(CurrikiResource.VAR_subjectAreaDisplayName, subjectAreaDisplayName);
+			body.put(CurrikiResource.VAR_instructionTypeDisplayName, instructionTypeDisplayName);
 			body.put(CurrikiResource.VAR_name, name);			
 
 			JsonObject params = new JsonObject();

--- a/src/main/java/org/curriki/api/enus/vertx/WorkerVerticle.java
+++ b/src/main/java/org/curriki/api/enus/vertx/WorkerVerticle.java
@@ -410,7 +410,10 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 						+ " r.downloadbutton, r.topofsearch, r.remove, r.spam, r.topofsearchint, r.partnerint,"
 						+ " r.reviewresource, r.oldurl, r.contentdisplayok, r.metadata, r.approvalStatus,"
 						+ " r.approvalStatusDate, r.spamUser,"
-						+ " rl.url, rl.displayseqno, rf.fileid"
+						+ " rl.url, rl.displayseqno, rf.fileid, rf.filename, rf.uploaddate, rf.sequence,"
+						+ " rf.uniquename, rf.ext, rf.active, rf.tempactive, rf.s3path, rf.SDFstatus,"
+						+ " rf.transcoded, rf.lodestar, rf.archive, edu.identifier, edu.displayname,"
+						+ " sub.subjectarea, sub.displayname, inst.displayname, inst.name"
 						+ " from currikidb.resources as r"
 						+ " LEFT JOIN resourcelinks as rl on r.resourceid = rl.resourceid"
 						+ " LEFT JOIN resourcefiles as rf on r.resourceid = rf.resourceid"
@@ -571,6 +574,22 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 			String url = row.getString(75);
 			Integer displaySeqNo = row.getInteger(76);
 			Integer fileId = row.getInteger(77);
+			String fileName = row.getString(78);
+			String uploadDate = row.getString(79);
+			Integer sequence = row.getInteger(80);
+			String uniqueName = row.getString(81);
+			String ext = row.getString(82);
+			// String active = row.getString(83);
+			String tempactive = row.getString(83);
+			String s3path = row.getString(84);
+			String sdfStatus = row.getString(85);
+			String transcoded = row.getString(86);
+			String lodestar = row.getString(87);
+			String archive = row.getString(88);
+			String identifier = row.getString(89);
+			String displayName = row.getString(90);
+			String subjectArea = row.getString(91);
+			String name = row.getString(92);			
 			JsonObject body = new JsonObject();
 			body.put(CurrikiResource.VAR_saves, new JsonArray()
 					.add(CurrikiResource.VAR_inheritPk)
@@ -655,6 +674,21 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 					.add(CurrikiResource.VAR_url)
 					.add(CurrikiResource.VAR_displaySeqNo)
 					.add(CurrikiResource.VAR_fileId)
+					.add(CurrikiResource.VAR_fileName)
+					.add(CurrikiResource.VAR_uploadDate)
+					.add(CurrikiResource.VAR_sequence)
+					.add(CurrikiResource.VAR_uniqueName)
+					.add(CurrikiResource.VAR_ext)
+					.add(CurrikiResource.VAR_tempactive)
+					.add(CurrikiResource.VAR_s3path)
+					.add(CurrikiResource.VAR_sdfStatus)
+					.add(CurrikiResource.VAR_transcoded)
+					.add(CurrikiResource.VAR_lodestar)
+					.add(CurrikiResource.VAR_archive)
+					.add(CurrikiResource.VAR_identifier)
+					.add(CurrikiResource.VAR_displayName)
+					.add(CurrikiResource.VAR_subjectArea)
+					.add(CurrikiResource.VAR_name)
 					);
 
 			body.put(CurrikiResource.VAR_pk, Optional.ofNullable(resourceId).map(v -> v.toString()).orElse(null));
@@ -736,6 +770,21 @@ public class WorkerVerticle extends WorkerVerticleGen<AbstractVerticle> {
 			body.put(CurrikiResource.VAR_url, url);
 			body.put(CurrikiResource.VAR_displaySeqNo, displaySeqNo);
 			body.put(CurrikiResource.VAR_fileId, fileId);
+			body.put(CurrikiResource.VAR_fileName, fileName);
+			body.put(CurrikiResource.VAR_uploadDate, uploadDate);
+			body.put(CurrikiResource.VAR_sequence, sequence);
+			body.put(CurrikiResource.VAR_uniqueName, uniqueName);
+			body.put(CurrikiResource.VAR_ext, ext);
+			body.put(CurrikiResource.VAR_tempactive, tempactive);
+			body.put(CurrikiResource.VAR_s3path, s3path);
+			body.put(CurrikiResource.VAR_sdfStatus, sdfStatus);
+			body.put(CurrikiResource.VAR_transcoded, transcoded);
+			body.put(CurrikiResource.VAR_lodestar, lodestar);
+			body.put(CurrikiResource.VAR_archive, archive);
+			body.put(CurrikiResource.VAR_identifier, identifier);
+			body.put(CurrikiResource.VAR_displayName, displayName);
+			body.put(CurrikiResource.VAR_subjectArea, subjectArea);
+			body.put(CurrikiResource.VAR_name, name);			
 
 			JsonObject params = new JsonObject();
 			params.put("body", body);

--- a/src/main/resources/templates/enUS/BaseModelGenPage.hbs
+++ b/src/main/resources/templates/enUS/BaseModelGenPage.hbs
@@ -26,16 +26,145 @@
 				if(pk != null) {
 				}
 				websocketBaseModel(websocketBaseModelInner);
+				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
+				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlBaseModel"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadBaseModelPage"}}{{> "htmTitleBaseModelPage"}}{{> "htmMetaBaseModelPage"}}{{> "htmStyleBaseModelPage"}}{{> "htmScriptsBaseModelPage"}}{{> "htmScriptBaseModelPage"}}{{/inline}}
+{{#*inline "htmBodySearchBaseModelPage"}}		<!-- #*inline "htmBodySearchBaseModelPage" -->
+	<div>
+{{#each varsQ}}
+		<div class="w3-padding ">
+			<label for="fqBaseModel_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<input id="fqBaseModel_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
+			<div class="pageSearchVal w3-tiny "></div>
+		</div>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyFiltersBaseModelPage"}}		<!-- #*inline "htmBodyFiltersBaseModelPage" -->
+	<div>
+{{#each varsFq }}
+		<div class="w3-padding ">
+			<label for="fqBaseModel_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<div class="w3-cell-row ">
+				<div class="w3-cell w3-cell-top ">
+					<button id="buttonFacetBaseModel_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
+				</div>
+				<div class="w3-cell w3-cell-top ">
+					<input id="fqBaseModel_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
+				</div>
+			</div>
+		</div>
+		<div class="w3-padding w3-tiny ">
+			<div class="pageSearchVal " id="pageSearchVal-fqBaseModel_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
+			<div class="pageSearchVal " id="pageSearchVal-buttonFacetBaseModel_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
+		</div>
+		<ol class="pageFacetField " id="pageFacetFieldBaseModel_{{ @key }}">
+{{#each facetField.counts }}
+			<li class="">{{ @key }}: {{ this }}</li>
+{{/each}}
+		</ol>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyRangeBaseModelPage"}}		<!-- #*inline "htmBodyRangeBaseModelPage" -->
+	<table class="w3-padding ">
+		<tr>			<td class="w3-padding w3-tiny " colspan="2">
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-BaseModel">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-BaseModel">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-BaseModel">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-BaseModel">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+		<tr class="">
+			<td class="">
+			<span>Range Gap</span>
+			</td>
+			<td class="">
+				<select
+ name="facet.range.gap" id="pageFacetRangeGap-BaseModel" onchange="facetRangeChange(this, 'BaseModel'); ">
+					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
+					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
+					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
+					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
+					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
+					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
+					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
+				</select>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range Start</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-BaseModel" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'BaseModel'); "/></span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range End</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2"
+			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-BaseModel" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'BaseModel'); "/></span>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+{{#each varsRange }}
+		<tr class="">
+			<td class="">
+				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeBaseModel_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'BaseModel'); "/></span>
+			</td>
+			<td class="">
+			<label for="pageFacetRangeBaseModel_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{#*inline "htmBodyPivotBaseModelPage"}}		<!-- #*inline "htmBodyPivotBaseModelPage" -->
+		<div class="w3-padding w3-tiny pageSearchVal " id="pageSearchVal-pivotBaseModel">
+{{#if defaultPivotVars }}
+			<div class="pageSearchVal " id="pageSearchVal-pivotBaseModel">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
+{{/if}}
+		</div>
+		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenBaseModel">
+{{#each defaultPivotVars }}
+			<div class="pageSearchVal pageSearchVal-hiddenBaseModel " id="pageSearchVal-hiddenBaseModel_{{ this }}">{{ this }}</div>
+{{/each}}
+		</div>
+	<table class="w3-table ">
+{{#each varsFq }}
+		<tr class="">
+			<td class="">
+				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotBaseModel_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'BaseModel'); "/></span>
+			</td>
+			<td class="w3-cell ">
+			<label for="pageFacetPivotBaseModel_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{/inline}}
+{{/inline}}
+{{#*inline "htmBodyMenuBaseModelPage"}}		<!-- #*inline "htmBodyMenuBaseModelPage" -->
+{{> "htmBodyMenuPageLayout"}}{{/inline}}
+{{#*inline "htmBodyGraphBaseModelPage"}}		<!-- #*inline "htmBodyGraphBaseModelPage" -->
+<div id="htmBodyGraphPageLayout" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0BaseModelPage"}}		<!-- #*inline "htmBodyCount0BaseModelPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 				{{/if}}
 				<span class=""></span>
 			</a>
@@ -43,7 +172,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses + " site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
 				{{/if}}
 				<span class=""></span>
 			</span>
@@ -53,7 +182,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3- w3-hover-">
 			{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 			{{/if}}
 				<span class=""></span>
 			</a>
@@ -63,13 +192,12 @@
 				<span class="">{{baseModel_.objectTitle}}</span>
 			</span>
 		</h2>
-{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1BaseModelPage"}}		<!-- #*inline "htmBodyCount1BaseModelPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class=""></span>
 			</a>
@@ -107,7 +235,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class=""></span>
 			</a>
@@ -143,14 +271,18 @@
 {{> "table1BaseModelPage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormBaseModelPage"}}	{{#if pk}}
+{{#*inline "htmFormBaseModelPage"}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="BaseModelForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
+		<form action="" id="BaseModelForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
+{{#if id}}
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
+{{/if}}
 			<input name="focusId" type="hidden"/>
+			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
+{{#if id}}
 {{#block "htmForm_searchpageBaseModel"}}{{/block}}
-	{{/if}}
+{{/if}}
 {{/inline}}
 {{#*inline "htmBodyStartBaseModelPage"}}
 {{> "htmBodyStartPageLayout"}}
@@ -160,6 +292,47 @@
 {{/inline}}
 {{#*inline "htmBodyBaseModelPage"}}
 {{#block "htmBodyStart"}}{{/block}}
+	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
+			<span title="Filters" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
+		</div>
+<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
+	<div class="w3-bar w3- ">
+		<span class="w3-bar-item w3-padding ">Search</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodySearch"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
+	<div class="w3-bar w3- ">
+		<span class="w3-bar-item w3-padding ">Filters</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyFilters"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
+	<div class="w3-bar w3- ">
+		<span class="w3-bar-item w3-padding ">Range</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyRange"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
+	<div class="w3-bar w3- ">
+		<span class="w3-bar-item w3-padding ">Pivot</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyPivot"}}{{/block}}
+	</div>
+</div>
+	</div>
+<div class="pageContent w3-content ">
+{{#block "htmBodyMenu"}}{{/block}}
+{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq baseModelCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -173,8 +346,10 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
+{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
+</div>
 {{/inline}}
 {{#*inline "table1BaseModelPage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -276,7 +451,7 @@
 					name="suggestBaseModel"
 					id="suggestBaseModel{{id}}"
 					autocomplete="off"
-					oninput="suggestBaseModelObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListBaseModel{{id}}'), {{pk}}; "
+					oninput="suggestBaseModelObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListBaseModel{{id}}'), {{pk}}; "
 					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = 'null?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listBaseModel}}
 					value="{{query2}}"
@@ -332,32 +507,83 @@
 	{{/eq}}
 {{/inline}}
 
+{{#*inline "htmInheritPk"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelInheritPk">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputInheritPk"}}
+													</div>
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3- "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_inheritPk')); $('#{{classApiMethodMethod}}_inheritPk').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#BaseModelForm :input[name=pk]').val() }], 'setInheritPk', null, function() { addGlow($('#{{classApiMethodMethod}}_inheritPk')); }, function() { addError($('#{{classApiMethodMethod}}_inheritPk')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputInheritPk"}}
+														<input
+															type="text"
+															title="An optional inherited primary key from a legacy system for this object in the database"
+															id="{{classApiMethodMethod}}_inheritPk"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInheritPk classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
+																name="setInheritPk"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInheritPk classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
+																name="setInheritPk"
+		{{else}}
+																class="valueInheritPk w3-input w3-border classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
+																name="inheritPk"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInheritPk', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_inheritPk')); }, function() { addError($('#{{classApiMethodMethod}}_inheritPk')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{baseModel_.inheritPk}}"
+	{{/eq}}
+														/>
+
+{{/inline}}
+
 {{#*inline "htmCreated"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelCreated">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label>created</label>
+													<label for="{{classApiMethodMethod}}_created">created</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputCreated"}}
-															</span>
-														</div>
+														{{> "inputCreated"}}
 													</div>
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputCreated"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Created " title="{{formatZonedDateTime baseModel_.created 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime baseModel_.created 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+														<span class="varBaseModel{{pk}}Created " title="{{formatZonedDateTime baseModel_.created 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' defaultLocaleId defaultZoneId}}">{{formatZonedDateTime baseModel_.created 'EEE MMM d yyyy h:mm a zz' defaultLocaleId defaultZoneId}}</span>
 	{{/eq}}
 {{/inline}}
 
@@ -386,65 +612,169 @@
 
 {{#*inline "inputModified"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Modified " title="{{formatZonedDateTime baseModel_.modified 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime baseModel_.modified 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+														<span class="varBaseModel{{pk}}Modified " title="{{formatZonedDateTime baseModel_.modified 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' defaultLocaleId defaultZoneId}}">{{formatZonedDateTime baseModel_.modified 'EEE MMM d yyyy h:mm a zz' defaultLocaleId defaultZoneId}}</span>
 	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmArchived"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelArchived">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label>archived</label>
+													<label for="{{classApiMethodMethod}}_archived">archived</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputArchived"}}
-															</span>
-														</div>
+														{{> "inputArchived"}}
 													</div>
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputArchived"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Archived ">{{baseModel_.archived}}</span>
+															<input
+																type="checkbox"
+																id="{{classApiMethodMethod}}_archived"
+																value="true"
+	{{else}}
+														<select
+															id="{{classApiMethodMethod}}_archived"
 	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															class="classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
+															name="setArchived"
+	{{else}}
+		{{#eq 'Page' classApiMethodMethod}}
+																class="classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
+																name="setArchived"
+		{{else}}
+																class="setArchived valueArchived classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
+																name="setArchived"
+		{{/eq}}
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setArchived', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_archived')); }, function() { addError($('#{{classApiMethodMethod}}_archived')); }); "
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+		{{#if baseModel_.archived}}
+																checked="checked"
+		{{/if}}
+																/>
+	{{else}}
+															>
+															<option value="" selected="selected"></option>
+															<option value="true">true</option>
+															<option value="false">false</option>
+														</select>
+	{{/eq}}
+
 {{/inline}}
 
 {{#*inline "htmDeleted"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelDeleted">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label>deleted</label>
+													<label for="{{classApiMethodMethod}}_deleted">deleted</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDeleted"}}
-															</span>
-														</div>
+														{{> "inputDeleted"}}
 													</div>
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeleted"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Deleted ">{{baseModel_.deleted}}</span>
+															<input
+																type="checkbox"
+																id="{{classApiMethodMethod}}_deleted"
+																value="true"
+	{{else}}
+														<select
+															id="{{classApiMethodMethod}}_deleted"
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															class="classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
+															name="setDeleted"
+	{{else}}
+		{{#eq 'Page' classApiMethodMethod}}
+																class="classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
+																name="setDeleted"
+		{{else}}
+																class="setDeleted valueDeleted classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
+																name="setDeleted"
+		{{/eq}}
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeleted', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_deleted')); }, function() { addError($('#{{classApiMethodMethod}}_deleted')); }); "
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+		{{#if baseModel_.deleted}}
+																checked="checked"
+		{{/if}}
+																/>
+	{{else}}
+															>
+															<option value="" selected="selected"></option>
+															<option value="true">true</option>
+															<option value="false">false</option>
+														</select>
+	{{/eq}}
+
+{{/inline}}
+
+{{#*inline "htmSessionId"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelSessionId">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputSessionId"}}
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputSessionId"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varBaseModel{{pk}}SessionId ">{{baseModel_.sessionId}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmUserKey"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}BaseModelUserKey">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserKey"}}
+													</div>
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserKey"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varBaseModel{{pk}}UserKey ">{{baseModel_.userKey}}</span>
 	{{/eq}}
 {{/inline}}
 

--- a/src/main/resources/templates/enUS/BaseModelGenPage.hbs
+++ b/src/main/resources/templates/enUS/BaseModelGenPage.hbs
@@ -26,145 +26,16 @@
 				if(pk != null) {
 				}
 				websocketBaseModel(websocketBaseModelInner);
-				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
-				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlBaseModel"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadBaseModelPage"}}{{> "htmTitleBaseModelPage"}}{{> "htmMetaBaseModelPage"}}{{> "htmStyleBaseModelPage"}}{{> "htmScriptsBaseModelPage"}}{{> "htmScriptBaseModelPage"}}{{/inline}}
-{{#*inline "htmBodySearchBaseModelPage"}}		<!-- #*inline "htmBodySearchBaseModelPage" -->
-	<div>
-{{#each varsQ}}
-		<div class="w3-padding ">
-			<label for="fqBaseModel_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<input id="fqBaseModel_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
-			<div class="pageSearchVal w3-tiny "></div>
-		</div>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyFiltersBaseModelPage"}}		<!-- #*inline "htmBodyFiltersBaseModelPage" -->
-	<div>
-{{#each varsFq }}
-		<div class="w3-padding ">
-			<label for="fqBaseModel_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<div class="w3-cell-row ">
-				<div class="w3-cell w3-cell-top ">
-					<button id="buttonFacetBaseModel_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
-				</div>
-				<div class="w3-cell w3-cell-top ">
-					<input id="fqBaseModel_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
-				</div>
-			</div>
-		</div>
-		<div class="w3-padding w3-tiny ">
-			<div class="pageSearchVal " id="pageSearchVal-fqBaseModel_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
-			<div class="pageSearchVal " id="pageSearchVal-buttonFacetBaseModel_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
-		</div>
-		<ol class="pageFacetField " id="pageFacetFieldBaseModel_{{ @key }}">
-{{#each facetField.counts }}
-			<li class="">{{ @key }}: {{ this }}</li>
-{{/each}}
-		</ol>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyRangeBaseModelPage"}}		<!-- #*inline "htmBodyRangeBaseModelPage" -->
-	<table class="w3-padding ">
-		<tr>			<td class="w3-padding w3-tiny " colspan="2">
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-BaseModel">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-BaseModel">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-BaseModel">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-BaseModel">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-		<tr class="">
-			<td class="">
-			<span>Range Gap</span>
-			</td>
-			<td class="">
-				<select
- name="facet.range.gap" id="pageFacetRangeGap-BaseModel" onchange="facetRangeChange(this, 'BaseModel'); ">
-					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
-					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
-					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
-					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
-					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
-					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
-					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
-				</select>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range Start</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-BaseModel" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'BaseModel'); "/></span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range End</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2"
-			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-BaseModel" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'BaseModel'); "/></span>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-{{#each varsRange }}
-		<tr class="">
-			<td class="">
-				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeBaseModel_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'BaseModel'); "/></span>
-			</td>
-			<td class="">
-			<label for="pageFacetRangeBaseModel_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{#*inline "htmBodyPivotBaseModelPage"}}		<!-- #*inline "htmBodyPivotBaseModelPage" -->
-		<div class="w3-padding w3-tiny " id="pageSearchVal-pivotBaseModel">
-{{#if defaultPivotVars }}
-			<div class="pageSearchVal " id="pageSearchVal-pivotBaseModel">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
-{{/if}}
-		</div>
-		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenBaseModel">
-{{#each defaultPivotVars }}
-			<div class="pageSearchVal pageSearchVal-hiddenBaseModel " id="pageSearchVal-hiddenBaseModel_{{ this }}">{{ this }}</div>
-{{/each}}
-		</div>
-	<table class="w3-table ">
-{{#each varsFq }}
-		<tr class="">
-			<td class="">
-				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotBaseModel_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'BaseModel'); "/></span>
-			</td>
-			<td class="w3-cell ">
-			<label for="pageFacetPivotBaseModel_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{/inline}}
-{{/inline}}
-{{#*inline "htmBodyMenuBaseModelPage"}}		<!-- #*inline "htmBodyMenuBaseModelPage" -->
-{{> "htmBodyMenuPageLayout"}}{{/inline}}
-{{#*inline "htmBodyGraphBaseModelPage"}}		<!-- #*inline "htmBodyGraphBaseModelPage" -->
-<div id="htmBodyGraphPageLayout" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0BaseModelPage"}}		<!-- #*inline "htmBodyCount0BaseModelPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+					<i class="contextIconCssClasses site-menu-icon "></i>
 				{{/if}}
 				<span class=""></span>
 			</a>
@@ -172,7 +43,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
+					<i class="contextIconCssClasses + " site-menu-icon "></i>
 				{{/if}}
 				<span class=""></span>
 			</span>
@@ -182,7 +53,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3- w3-hover-">
 			{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses site-menu-icon "></i>
 			{{/if}}
 				<span class=""></span>
 			</a>
@@ -192,12 +63,13 @@
 				<span class="">{{baseModel_.objectTitle}}</span>
 			</span>
 		</h2>
+{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1BaseModelPage"}}		<!-- #*inline "htmBodyCount1BaseModelPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class=""></span>
 			</a>
@@ -235,7 +107,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3- w3-hover-">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class=""></span>
 			</a>
@@ -271,18 +143,14 @@
 {{> "table1BaseModelPage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormBaseModelPage"}}
+{{#*inline "htmFormBaseModelPage"}}	{{#if pk}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="BaseModelForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
-{{#if id}}
+		<form action="" id="BaseModelForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
-{{/if}}
 			<input name="focusId" type="hidden"/>
-			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
-{{#if id}}
 {{#block "htmForm_searchpageBaseModel"}}{{/block}}
-{{/if}}
+	{{/if}}
 {{/inline}}
 {{#*inline "htmBodyStartBaseModelPage"}}
 {{> "htmBodyStartPageLayout"}}
@@ -292,47 +160,6 @@
 {{/inline}}
 {{#*inline "htmBodyBaseModelPage"}}
 {{#block "htmBodyStart"}}{{/block}}
-	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
-			<span title="Filters" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3- " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
-		</div>
-<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
-	<div class="w3-bar w3- ">
-		<span class="w3-bar-item w3-padding ">Search</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodySearch"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
-	<div class="w3-bar w3- ">
-		<span class="w3-bar-item w3-padding ">Filters</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyFilters"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
-	<div class="w3-bar w3- ">
-		<span class="w3-bar-item w3-padding ">Range</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyRange"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
-	<div class="w3-bar w3- ">
-		<span class="w3-bar-item w3-padding ">Pivot</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyPivot"}}{{/block}}
-	</div>
-</div>
-	</div>
-<div class="pageContent w3-content ">
-{{#block "htmBodyMenu"}}{{/block}}
-{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq baseModelCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -346,10 +173,8 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
-{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
-</div>
 {{/inline}}
 {{#*inline "table1BaseModelPage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -451,7 +276,7 @@
 					name="suggestBaseModel"
 					id="suggestBaseModel{{id}}"
 					autocomplete="off"
-					oninput="suggestBaseModelObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListBaseModel{{id}}'), {{pk}}; "
+					oninput="suggestBaseModelObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListBaseModel{{id}}'), {{pk}}; "
 					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = 'null?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listBaseModel}}
 					value="{{query2}}"
@@ -507,83 +332,32 @@
 	{{/eq}}
 {{/inline}}
 
-{{#*inline "htmInheritPk"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelInheritPk">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputInheritPk"}}
-													</div>
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3- "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_inheritPk')); $('#{{classApiMethodMethod}}_inheritPk').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#BaseModelForm :input[name=pk]').val() }], 'setInheritPk', null, function() { addGlow($('#{{classApiMethodMethod}}_inheritPk')); }, function() { addError($('#{{classApiMethodMethod}}_inheritPk')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputInheritPk"}}
-														<input
-															type="text"
-															title="An optional inherited primary key from a legacy system for this object in the database"
-															id="{{classApiMethodMethod}}_inheritPk"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setInheritPk classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
-																name="setInheritPk"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setInheritPk classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
-																name="setInheritPk"
-		{{else}}
-																class="valueInheritPk w3-input w3-border classBaseModel inputBaseModel{{pk}}InheritPk w3-input w3-border "
-																name="inheritPk"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInheritPk', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_inheritPk')); }, function() { addError($('#{{classApiMethodMethod}}_inheritPk')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{baseModel_.inheritPk}}"
-	{{/eq}}
-														/>
-
-{{/inline}}
-
 {{#*inline "htmCreated"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelCreated">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label for="{{classApiMethodMethod}}_created">created</label>
+													<label>created</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputCreated"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputCreated"}}
+															</span>
+														</div>
 													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputCreated"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Created " title="{{formatZonedDateTime baseModel_.created 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' defaultLocaleId defaultZoneId}}">{{formatZonedDateTime baseModel_.created 'EEE MMM d yyyy h:mm a zz' defaultLocaleId defaultZoneId}}</span>
+														<span class="varBaseModel{{pk}}Created " title="{{formatZonedDateTime baseModel_.created 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime baseModel_.created 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
 	{{/eq}}
 {{/inline}}
 
@@ -612,169 +386,65 @@
 
 {{#*inline "inputModified"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}Modified " title="{{formatZonedDateTime baseModel_.modified 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' defaultLocaleId defaultZoneId}}">{{formatZonedDateTime baseModel_.modified 'EEE MMM d yyyy h:mm a zz' defaultLocaleId defaultZoneId}}</span>
+														<span class="varBaseModel{{pk}}Modified " title="{{formatZonedDateTime baseModel_.modified 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime baseModel_.modified 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
 	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmArchived"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelArchived">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label for="{{classApiMethodMethod}}_archived">archived</label>
+													<label>archived</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputArchived"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputArchived"}}
+															</span>
+														</div>
 													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputArchived"}}
 	{{#eq 'Page' classApiMethodMethod}}
-															<input
-																type="checkbox"
-																id="{{classApiMethodMethod}}_archived"
-																value="true"
-	{{else}}
-														<select
-															id="{{classApiMethodMethod}}_archived"
+														<span class="varBaseModel{{pk}}Archived ">{{baseModel_.archived}}</span>
 	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															class="classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
-															name="setArchived"
-	{{else}}
-		{{#eq 'Page' classApiMethodMethod}}
-																class="classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
-																name="setArchived"
-		{{else}}
-																class="setArchived valueArchived classBaseModel inputBaseModel{{pk}}Archived w3-input w3-border "
-																name="setArchived"
-		{{/eq}}
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setArchived', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_archived')); }, function() { addError($('#{{classApiMethodMethod}}_archived')); }); "
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-		{{#if baseModel_.archived}}
-																checked="checked"
-		{{/if}}
-																/>
-	{{else}}
-															>
-															<option value="" selected="selected"></option>
-															<option value="true">true</option>
-															<option value="false">false</option>
-														</select>
-	{{/eq}}
-
 {{/inline}}
 
 {{#*inline "htmDeleted"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelDeleted">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-">
-													<label for="{{classApiMethodMethod}}_deleted">deleted</label>
+													<label>deleted</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDeleted"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDeleted"}}
+															</span>
+														</div>
 													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeleted"}}
 	{{#eq 'Page' classApiMethodMethod}}
-															<input
-																type="checkbox"
-																id="{{classApiMethodMethod}}_deleted"
-																value="true"
-	{{else}}
-														<select
-															id="{{classApiMethodMethod}}_deleted"
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															class="classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
-															name="setDeleted"
-	{{else}}
-		{{#eq 'Page' classApiMethodMethod}}
-																class="classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
-																name="setDeleted"
-		{{else}}
-																class="setDeleted valueDeleted classBaseModel inputBaseModel{{pk}}Deleted w3-input w3-border "
-																name="setDeleted"
-		{{/eq}}
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeleted', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_deleted')); }, function() { addError($('#{{classApiMethodMethod}}_deleted')); }); "
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-		{{#if baseModel_.deleted}}
-																checked="checked"
-		{{/if}}
-																/>
-	{{else}}
-															>
-															<option value="" selected="selected"></option>
-															<option value="true">true</option>
-															<option value="false">false</option>
-														</select>
-	{{/eq}}
-
-{{/inline}}
-
-{{#*inline "htmSessionId"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelSessionId">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputSessionId"}}
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputSessionId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}SessionId ">{{baseModel_.sessionId}}</span>
-	{{/eq}}
-{{/inline}}
-
-{{#*inline "htmUserKey"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}BaseModelUserKey">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserKey"}}
-													</div>
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserKey"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varBaseModel{{pk}}UserKey ">{{baseModel_.userKey}}</span>
+														<span class="varBaseModel{{pk}}Deleted ">{{baseModel_.deleted}}</span>
 	{{/eq}}
 {{/inline}}
 

--- a/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
+++ b/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
@@ -26,16 +26,145 @@
 				if(pk != null) {
 				}
 				websocketCurrikiResource(websocketCurrikiResourceInner);
+				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
+				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlCurrikiResource"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadCurrikiResourcePage"}}{{> "htmTitleCurrikiResourcePage"}}{{> "htmMetaCurrikiResourcePage"}}{{> "htmStyleCurrikiResourcePage"}}{{> "htmScriptsCurrikiResourcePage"}}{{> "htmScriptCurrikiResourcePage"}}{{/inline}}
+{{#*inline "htmBodySearchCurrikiResourcePage"}}		<!-- #*inline "htmBodySearchCurrikiResourcePage" -->
+	<div>
+{{#each varsQ}}
+		<div class="w3-padding ">
+			<label for="fqCurrikiResource_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<input id="fqCurrikiResource_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
+			<div class="pageSearchVal w3-tiny "></div>
+		</div>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyFiltersCurrikiResourcePage"}}		<!-- #*inline "htmBodyFiltersCurrikiResourcePage" -->
+	<div>
+{{#each varsFq }}
+		<div class="w3-padding ">
+			<label for="fqCurrikiResource_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<div class="w3-cell-row ">
+				<div class="w3-cell w3-cell-top ">
+					<button id="buttonFacetCurrikiResource_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
+				</div>
+				<div class="w3-cell w3-cell-top ">
+					<input id="fqCurrikiResource_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
+				</div>
+			</div>
+		</div>
+		<div class="w3-padding w3-tiny ">
+			<div class="pageSearchVal " id="pageSearchVal-fqCurrikiResource_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
+			<div class="pageSearchVal " id="pageSearchVal-buttonFacetCurrikiResource_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
+		</div>
+		<ol class="pageFacetField " id="pageFacetFieldCurrikiResource_{{ @key }}">
+{{#each facetField.counts }}
+			<li class="">{{ @key }}: {{ this }}</li>
+{{/each}}
+		</ol>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyRangeCurrikiResourcePage"}}		<!-- #*inline "htmBodyRangeCurrikiResourcePage" -->
+	<table class="w3-padding ">
+		<tr>			<td class="w3-padding w3-tiny " colspan="2">
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-CurrikiResource">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-CurrikiResource">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-CurrikiResource">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-CurrikiResource">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+		<tr class="">
+			<td class="">
+			<span>Range Gap</span>
+			</td>
+			<td class="">
+				<select
+ name="facet.range.gap" id="pageFacetRangeGap-CurrikiResource" onchange="facetRangeChange(this, 'CurrikiResource'); ">
+					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
+					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
+					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
+					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
+					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
+					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
+					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
+				</select>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range Start</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-CurrikiResource" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range End</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2"
+			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-CurrikiResource" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+{{#each varsRange }}
+		<tr class="">
+			<td class="">
+				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeCurrikiResource_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
+			</td>
+			<td class="">
+			<label for="pageFacetRangeCurrikiResource_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{#*inline "htmBodyPivotCurrikiResourcePage"}}		<!-- #*inline "htmBodyPivotCurrikiResourcePage" -->
+		<div class="w3-padding w3-tiny pageSearchVal " id="pageSearchVal-pivotCurrikiResource">
+{{#if defaultPivotVars }}
+			<div class="pageSearchVal " id="pageSearchVal-pivotCurrikiResource">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
+{{/if}}
+		</div>
+		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenCurrikiResource">
+{{#each defaultPivotVars }}
+			<div class="pageSearchVal pageSearchVal-hiddenCurrikiResource " id="pageSearchVal-hiddenCurrikiResource_{{ this }}">{{ this }}</div>
+{{/each}}
+		</div>
+	<table class="w3-table ">
+{{#each varsFq }}
+		<tr class="">
+			<td class="">
+				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotCurrikiResource_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'CurrikiResource'); "/></span>
+			</td>
+			<td class="w3-cell ">
+			<label for="pageFacetPivotCurrikiResource_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{/inline}}
+{{/inline}}
+{{#*inline "htmBodyMenuCurrikiResourcePage"}}		<!-- #*inline "htmBodyMenuCurrikiResourcePage" -->
+{{> "htmBodyMenuBaseModelPage"}}{{/inline}}
+{{#*inline "htmBodyGraphCurrikiResourcePage"}}		<!-- #*inline "htmBodyGraphCurrikiResourcePage" -->
+<div id="htmBodyGraphBaseModelPage" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0CurrikiResourcePage"}}		<!-- #*inline "htmBodyCount0CurrikiResourcePage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 				{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -43,7 +172,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-blue">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses + " site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
 				{{/if}}
 				<span class="">no resource found</span>
 			</span>
@@ -53,7 +182,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3-blue w3-hover-blue">
 			{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 			{{/if}}
 				<span class="">resource</span>
 			</a>
@@ -63,13 +192,12 @@
 				<span class="">{{currikiResource_.objectTitle}}</span>
 			</span>
 		</h2>
-{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1CurrikiResourcePage"}}		<!-- #*inline "htmBodyCount1CurrikiResourcePage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -107,7 +235,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -143,14 +271,18 @@
 {{> "table1CurrikiResourcePage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormCurrikiResourcePage"}}	{{#if pk}}
+{{#*inline "htmFormCurrikiResourcePage"}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="CurrikiResourceForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
+		<form action="" id="CurrikiResourceForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
+{{#if id}}
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
+{{/if}}
 			<input name="focusId" type="hidden"/>
+			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
+{{#if id}}
 {{#block "htmForm_searchpageCurrikiResource"}}{{/block}}
-	{{/if}}
+{{/if}}
 {{/inline}}
 {{#*inline "htmFormCurrikiResourcePage_patchCurrikiResource"}}
 		<button
@@ -160,7 +292,7 @@
 			<i class="fas fa-edit "></i>
 			Modify resources
 		</button>
-		<div id="patchCurrikiResourceModal" class="w3-modal w3-padding-32 ">
+		<div id="patchCurrikiResourceModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -176,6 +308,170 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="PATCH"}}
 {{> "htmDeleted" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceId" classApiMethodMethod="PATCH"}}
+{{> "htmLicenseId" classApiMethodMethod="PATCH"}}
+{{> "htmContributorId" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmContributionDate" classApiMethodMethod="PATCH"}}
+{{> "htmDescription" classApiMethodMethod="PATCH"}}
+{{> "htmTitle" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmKeywordsStr" classApiMethodMethod="PATCH"}}
+{{> "htmGeneratedKeywordsStr" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLanguage" classApiMethodMethod="PATCH"}}
+{{> "htmLastEditorId" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLastEditDate" classApiMethodMethod="PATCH"}}
+{{> "htmCurrikiLicense" classApiMethodMethod="PATCH"}}
+{{> "htmExternalUrl" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceChecked" classApiMethodMethod="PATCH"}}
+{{> "htmContent" classApiMethodMethod="PATCH"}}
+{{> "htmResourceCheckRequestNote" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceCheckDate" classApiMethodMethod="PATCH"}}
+{{> "htmResourceCheckId" classApiMethodMethod="PATCH"}}
+{{> "htmResourceCheckNote" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmStudentFacing" classApiMethodMethod="PATCH"}}
+{{> "htmSource" classApiMethodMethod="PATCH"}}
+{{> "htmReviewStatus" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLastReviewDate" classApiMethodMethod="PATCH"}}
+{{> "htmReviewByID" classApiMethodMethod="PATCH"}}
+{{> "htmReviewRating" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTechnicalCompleteness" classApiMethodMethod="PATCH"}}
+{{> "htmContentAccuracy" classApiMethodMethod="PATCH"}}
+{{> "htmPedagogy" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRatingComment" classApiMethodMethod="PATCH"}}
+{{> "htmStandardsAlignment" classApiMethodMethod="PATCH"}}
+{{> "htmStandardsAlignmentComment" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSubjectMatter" classApiMethodMethod="PATCH"}}
+{{> "htmSubjectMatterComment" classApiMethodMethod="PATCH"}}
+{{> "htmSupportsTeaching" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSupportsTeachingComment" classApiMethodMethod="PATCH"}}
+{{> "htmAssessmentsQuality" classApiMethodMethod="PATCH"}}
+{{> "htmAssessmentsQualityComment" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmInteractivityQuality" classApiMethodMethod="PATCH"}}
+{{> "htmInteractivityQualityComment" classApiMethodMethod="PATCH"}}
+{{> "htmInstructionalQuality" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmInstructionalQualityComment" classApiMethodMethod="PATCH"}}
+{{> "htmDeeperLearning" classApiMethodMethod="PATCH"}}
+{{> "htmDeeperLearningComment" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPartner" classApiMethodMethod="PATCH"}}
+{{> "htmCreateDate" classApiMethodMethod="PATCH"}}
+{{> "htmType" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmFeatured" classApiMethodMethod="PATCH"}}
+{{> "htmPage" classApiMethodMethod="PATCH"}}
+{{> "htmActive" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPublic" classApiMethodMethod="PATCH"}}
+{{> "htmXwd_id" classApiMethodMethod="PATCH"}}
+{{> "htmMediaType" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmAccess" classApiMethodMethod="PATCH"}}
+{{> "htmMemberRating" classApiMethodMethod="PATCH"}}
+{{> "htmAligned" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPageUrl" classApiMethodMethod="PATCH"}}
+{{> "htmIndexed" classApiMethodMethod="PATCH"}}
+{{> "htmLastIndexDate" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmIndexRequired" classApiMethodMethod="PATCH"}}
+{{> "htmIndexRequiredDate" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRescrape" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmGoButton" classApiMethodMethod="PATCH"}}
+{{> "htmDownloadButton" classApiMethodMethod="PATCH"}}
+{{> "htmTopOfSearch" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRemove" classApiMethodMethod="PATCH"}}
+{{> "htmSpam" classApiMethodMethod="PATCH"}}
+{{> "htmTopOfSearchInt" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPartnerInt" classApiMethodMethod="PATCH"}}
+{{> "htmReviewResource" classApiMethodMethod="PATCH"}}
+{{> "htmOldUrl" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmContentDisplayOk" classApiMethodMethod="PATCH"}}
+{{> "htmMetadata" classApiMethodMethod="PATCH"}}
+{{> "htmApprovalStatus" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmApprovalStatusDate" classApiMethodMethod="PATCH"}}
+{{> "htmSpamUser" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmUrl" classApiMethodMethod="PATCH"}}
+{{> "htmDisplaySeqNo" classApiMethodMethod="PATCH"}}
+{{> "htmFileId" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmFileName" classApiMethodMethod="PATCH"}}
+{{> "htmUploadDate" classApiMethodMethod="PATCH"}}
+{{> "htmSequence" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmUniqueName" classApiMethodMethod="PATCH"}}
+{{> "htmExt" classApiMethodMethod="PATCH"}}
+{{> "htmResourceFilesActive" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTempactive" classApiMethodMethod="PATCH"}}
+{{> "htmS3path" classApiMethodMethod="PATCH"}}
+{{> "htmSdfStatus" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTranscoded" classApiMethodMethod="PATCH"}}
+{{> "htmLodestar" classApiMethodMethod="PATCH"}}
+{{> "htmArchive" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmIdentifier" classApiMethodMethod="PATCH"}}
+{{> "htmEducationLevelDisplayName" classApiMethodMethod="PATCH"}}
+{{> "htmSubjectArea" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSubjectAreaDisplayName" classApiMethodMethod="PATCH"}}
+{{> "htmInstructionTypeDisplayName" classApiMethodMethod="PATCH"}}
+{{> "htmName" classApiMethodMethod="PATCH"}}
 							</div>
 						<button
 							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-blue "
@@ -194,7 +490,7 @@
 			<i class="fas fa-file-plus "></i>
 			Create a resource
 		</button>
-		<div id="postCurrikiResourceModal" class="w3-modal w3-padding-32 ">
+		<div id="postCurrikiResourceModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -211,6 +507,170 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="POST"}}
 {{> "htmDeleted" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceId" classApiMethodMethod="POST"}}
+{{> "htmLicenseId" classApiMethodMethod="POST"}}
+{{> "htmContributorId" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmContributionDate" classApiMethodMethod="POST"}}
+{{> "htmDescription" classApiMethodMethod="POST"}}
+{{> "htmTitle" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmKeywordsStr" classApiMethodMethod="POST"}}
+{{> "htmGeneratedKeywordsStr" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLanguage" classApiMethodMethod="POST"}}
+{{> "htmLastEditorId" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLastEditDate" classApiMethodMethod="POST"}}
+{{> "htmCurrikiLicense" classApiMethodMethod="POST"}}
+{{> "htmExternalUrl" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceChecked" classApiMethodMethod="POST"}}
+{{> "htmContent" classApiMethodMethod="POST"}}
+{{> "htmResourceCheckRequestNote" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmResourceCheckDate" classApiMethodMethod="POST"}}
+{{> "htmResourceCheckId" classApiMethodMethod="POST"}}
+{{> "htmResourceCheckNote" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmStudentFacing" classApiMethodMethod="POST"}}
+{{> "htmSource" classApiMethodMethod="POST"}}
+{{> "htmReviewStatus" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmLastReviewDate" classApiMethodMethod="POST"}}
+{{> "htmReviewByID" classApiMethodMethod="POST"}}
+{{> "htmReviewRating" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTechnicalCompleteness" classApiMethodMethod="POST"}}
+{{> "htmContentAccuracy" classApiMethodMethod="POST"}}
+{{> "htmPedagogy" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRatingComment" classApiMethodMethod="POST"}}
+{{> "htmStandardsAlignment" classApiMethodMethod="POST"}}
+{{> "htmStandardsAlignmentComment" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSubjectMatter" classApiMethodMethod="POST"}}
+{{> "htmSubjectMatterComment" classApiMethodMethod="POST"}}
+{{> "htmSupportsTeaching" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSupportsTeachingComment" classApiMethodMethod="POST"}}
+{{> "htmAssessmentsQuality" classApiMethodMethod="POST"}}
+{{> "htmAssessmentsQualityComment" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmInteractivityQuality" classApiMethodMethod="POST"}}
+{{> "htmInteractivityQualityComment" classApiMethodMethod="POST"}}
+{{> "htmInstructionalQuality" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmInstructionalQualityComment" classApiMethodMethod="POST"}}
+{{> "htmDeeperLearning" classApiMethodMethod="POST"}}
+{{> "htmDeeperLearningComment" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPartner" classApiMethodMethod="POST"}}
+{{> "htmCreateDate" classApiMethodMethod="POST"}}
+{{> "htmType" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmFeatured" classApiMethodMethod="POST"}}
+{{> "htmPage" classApiMethodMethod="POST"}}
+{{> "htmActive" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPublic" classApiMethodMethod="POST"}}
+{{> "htmXwd_id" classApiMethodMethod="POST"}}
+{{> "htmMediaType" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmAccess" classApiMethodMethod="POST"}}
+{{> "htmMemberRating" classApiMethodMethod="POST"}}
+{{> "htmAligned" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPageUrl" classApiMethodMethod="POST"}}
+{{> "htmIndexed" classApiMethodMethod="POST"}}
+{{> "htmLastIndexDate" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmIndexRequired" classApiMethodMethod="POST"}}
+{{> "htmIndexRequiredDate" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRescrape" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmGoButton" classApiMethodMethod="POST"}}
+{{> "htmDownloadButton" classApiMethodMethod="POST"}}
+{{> "htmTopOfSearch" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmRemove" classApiMethodMethod="POST"}}
+{{> "htmSpam" classApiMethodMethod="POST"}}
+{{> "htmTopOfSearchInt" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmPartnerInt" classApiMethodMethod="POST"}}
+{{> "htmReviewResource" classApiMethodMethod="POST"}}
+{{> "htmOldUrl" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmContentDisplayOk" classApiMethodMethod="POST"}}
+{{> "htmMetadata" classApiMethodMethod="POST"}}
+{{> "htmApprovalStatus" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmApprovalStatusDate" classApiMethodMethod="POST"}}
+{{> "htmSpamUser" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmUrl" classApiMethodMethod="POST"}}
+{{> "htmDisplaySeqNo" classApiMethodMethod="POST"}}
+{{> "htmFileId" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmFileName" classApiMethodMethod="POST"}}
+{{> "htmUploadDate" classApiMethodMethod="POST"}}
+{{> "htmSequence" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmUniqueName" classApiMethodMethod="POST"}}
+{{> "htmExt" classApiMethodMethod="POST"}}
+{{> "htmResourceFilesActive" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTempactive" classApiMethodMethod="POST"}}
+{{> "htmS3path" classApiMethodMethod="POST"}}
+{{> "htmSdfStatus" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTranscoded" classApiMethodMethod="POST"}}
+{{> "htmLodestar" classApiMethodMethod="POST"}}
+{{> "htmArchive" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmIdentifier" classApiMethodMethod="POST"}}
+{{> "htmEducationLevelDisplayName" classApiMethodMethod="POST"}}
+{{> "htmSubjectArea" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSubjectAreaDisplayName" classApiMethodMethod="POST"}}
+{{> "htmInstructionTypeDisplayName" classApiMethodMethod="POST"}}
+{{> "htmName" classApiMethodMethod="POST"}}
 							</div>
 						</div>
 						<button
@@ -230,7 +690,7 @@
 			<i class="fas fa-file-import "></i>
 			Import resources
 		</button>
-		<div id="putimportCurrikiResourceModal" class="w3-modal w3-padding-32 ">
+		<div id="putimportCurrikiResourceModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -243,7 +703,7 @@
 						<div class="w3-cell-row ">
 							<textarea
 								class="PUTImport_searchList w3-input w3-border "
-								style="height: 400px; "
+								style="height: 300px; "
 								placeholder="{ 'searchList': [ { 'pk': ... , 'saves': [ ... ] }, ... ] }"
 								></textarea>
 						</div>
@@ -257,15 +717,9 @@
 		</div>
 {{/inline}}
 {{#*inline "htmFormCurrikiResourcePage_searchpageCurrikiResource"}}
-		<div id="searchpageCurrikiResourceModal" class="w3-padding-32 ">
+		<div id="searchpageCurrikiResourceModal" class="">
 			<div class="">
 				<div class="w3-card-4 ">
-					<header class="w3-container w3-blue">
-	{{#eq "Page" classApiMethodMethod}}
-						<span class="w3-button w3-display-topright " onclick="$('#searchpageCurrikiResourceModal').hide(); ">×</span>
-	{{/eq}}
-						<h2 class="w3-padding "></h2>
-					</header>
 					<div class="" id="searchpageCurrikiResourceFormValues">
 						<div id="searchpageCurrikiResourceForm">
 							<div class="w3-cell-row ">
@@ -445,10 +899,6 @@
 {{> "htmName" classApiMethodMethod="Page"}}
 							</div>
 						</div>
-						<button
-							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-blue "
-							onclick="searchpageCurrikiResource(); "
-							></button>
 					</div>
 				</div>
 			</div>
@@ -462,6 +912,47 @@
 {{/inline}}
 {{#*inline "htmBodyCurrikiResourcePage"}}
 {{#block "htmBodyStart"}}{{/block}}
+	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
+			<span title="Filters" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
+		</div>
+<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
+	<div class="w3-bar w3-blue ">
+		<span class="w3-bar-item w3-padding ">Search</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodySearch"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
+	<div class="w3-bar w3-blue ">
+		<span class="w3-bar-item w3-padding ">Filters</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyFilters"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
+	<div class="w3-bar w3-blue ">
+		<span class="w3-bar-item w3-padding ">Range</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyRange"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
+	<div class="w3-bar w3-blue ">
+		<span class="w3-bar-item w3-padding ">Pivot</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyPivot"}}{{/block}}
+	</div>
+</div>
+	</div>
+<div class="pageContent w3-content ">
+{{#block "htmBodyMenu"}}{{/block}}
+{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq currikiResourceCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -475,8 +966,10 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
+{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
+</div>
 {{/inline}}
 {{#*inline "table1CurrikiResourcePage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -509,7 +1002,7 @@
 			<tr>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "yyyy-MM-dd'T'HH:mm:ss.SSS'['VV']'" siteLocale}}</span>
+							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "MMM d, yyyy h:mm:ss a" siteLocale}}</span>
 						</a>
 					</td>
 					<td>
@@ -582,7 +1075,7 @@
 					name="suggestCurrikiResource"
 					id="suggestCurrikiResource{{id}}"
 					autocomplete="off"
-					oninput="suggestCurrikiResourceObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListCurrikiResource{{id}}'), {{pk}}; "
+					oninput="suggestCurrikiResourceObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListCurrikiResource{{id}}'), {{pk}}; "
 					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/api/resource?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listCurrikiResource}}
 					value="{{query2}}"
@@ -612,205 +1105,451 @@
 
 {{#*inline "htmResourceId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>resource ID</label>
+													<label for="{{classApiMethodMethod}}_resourceId">resource ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceId"}}
-															</span>
-														</div>
+														{{> "inputResourceId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceId')); $('#{{classApiMethodMethod}}_resourceId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceId', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceId ">{{currikiResource_.resourceId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="resource ID"
+															id="{{classApiMethodMethod}}_resourceId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceId classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
+																name="setResourceId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceId classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
+																name="setResourceId"
+		{{else}}
+																class="valueResourceId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
+																name="resourceId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceId ">{{currikiResource_.resourceId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLicenseId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLicenseId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>license ID</label>
+													<label for="{{classApiMethodMethod}}_licenseId">license ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLicenseId"}}
-															</span>
-														</div>
+														{{> "inputLicenseId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_licenseId')); $('#{{classApiMethodMethod}}_licenseId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLicenseId', null, function() { addGlow($('#{{classApiMethodMethod}}_licenseId')); }, function() { addError($('#{{classApiMethodMethod}}_licenseId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLicenseId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}LicenseId ">{{currikiResource_.licenseId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="license ID"
+															id="{{classApiMethodMethod}}_licenseId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setLicenseId classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
+																name="setLicenseId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setLicenseId classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
+																name="setLicenseId"
+		{{else}}
+																class="valueLicenseId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
+																name="licenseId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLicenseId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_licenseId')); }, function() { addError($('#{{classApiMethodMethod}}_licenseId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.licenseId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}LicenseId ">{{currikiResource_.licenseId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContributorId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContributorId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>contributor ID</label>
+													<label for="{{classApiMethodMethod}}_contributorId">contributor ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputContributorId"}}
-															</span>
-														</div>
+														{{> "inputContributorId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_contributorId')); $('#{{classApiMethodMethod}}_contributorId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContributorId', null, function() { addGlow($('#{{classApiMethodMethod}}_contributorId')); }, function() { addError($('#{{classApiMethodMethod}}_contributorId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputContributorId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ContributorId ">{{currikiResource_.contributorId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="contributor ID"
+															id="{{classApiMethodMethod}}_contributorId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setContributorId classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
+																name="setContributorId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setContributorId classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
+																name="setContributorId"
+		{{else}}
+																class="valueContributorId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
+																name="contributorId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContributorId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contributorId')); }, function() { addError($('#{{classApiMethodMethod}}_contributorId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.contributorId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ContributorId ">{{currikiResource_.contributorId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContributionDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContributionDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>contribution Date</label>
+													<label for="{{classApiMethodMethod}}_contributionDate">contribution Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputContributionDate"}}
-															</span>
-														</div>
+														{{> "inputContributionDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_contributionDate')); $('#{{classApiMethodMethod}}_contributionDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContributionDate', null, function() { addGlow($('#{{classApiMethodMethod}}_contributionDate')); }, function() { addError($('#{{classApiMethodMethod}}_contributionDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputContributionDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ContributionDate " title="{{formatZonedDateTime currikiResource_.contributionDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.contributionDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setContributionDate classCurrikiResource inputCurrikiResource{{pk}}ContributionDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_contributionDate"
+																value="{{currikiResource_.contributionDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContributionDate', s, function() { addGlow($('#{{classApiMethodMethod}}_contributionDate')); }, function() { addError($('#{{classApiMethodMethod}}_contributionDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ContributionDate ">{{currikiResource_.contributionDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDescription"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDescription">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>description</label>
+													<label for="{{classApiMethodMethod}}_description">description</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDescription"}}
-															</span>
-														</div>
+														{{> "inputDescription"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_description')); $('#{{classApiMethodMethod}}_description').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDescription', null, function() { addGlow($('#{{classApiMethodMethod}}_description')); }, function() { addError($('#{{classApiMethodMethod}}_description')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDescription"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Description ">{{currikiResource_.description}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="description"
+															id="{{classApiMethodMethod}}_description"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setDescription classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
+																name="setDescription"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setDescription classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
+																name="setDescription"
+		{{else}}
+																class="valueDescription w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
+																name="description"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDescription', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_description')); }, function() { addError($('#{{classApiMethodMethod}}_description')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.description}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Description ">{{currikiResource_.description}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTitle"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTitle">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>title</label>
+													<label for="{{classApiMethodMethod}}_title">title</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTitle"}}
-															</span>
-														</div>
+														{{> "inputTitle"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_title')); $('#{{classApiMethodMethod}}_title').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTitle', null, function() { addGlow($('#{{classApiMethodMethod}}_title')); }, function() { addError($('#{{classApiMethodMethod}}_title')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTitle"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Title ">{{currikiResource_.title}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="title"
+															id="{{classApiMethodMethod}}_title"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTitle classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
+																name="setTitle"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTitle classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
+																name="setTitle"
+		{{else}}
+																class="valueTitle w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
+																name="title"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTitle', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_title')); }, function() { addError($('#{{classApiMethodMethod}}_title')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.title}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Title ">{{currikiResource_.title}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmKeywordsStr"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceKeywordsStr">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Keywords String</label>
+													<label for="{{classApiMethodMethod}}_keywordsStr">Keywords String</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputKeywordsStr"}}
-															</span>
-														</div>
+														{{> "inputKeywordsStr"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_keywordsStr')); $('#{{classApiMethodMethod}}_keywordsStr').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setKeywordsStr', null, function() { addGlow($('#{{classApiMethodMethod}}_keywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_keywordsStr')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputKeywordsStr"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}KeywordsStr ">{{currikiResource_.keywordsStr}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Keywords String"
+															id="{{classApiMethodMethod}}_keywordsStr"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
+																name="setKeywordsStr"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
+																name="setKeywordsStr"
+		{{else}}
+																class="valueKeywordsStr w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
+																name="keywordsStr"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setKeywordsStr', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_keywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_keywordsStr')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.keywordsStr}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}KeywordsStr ">{{currikiResource_.keywordsStr}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmKeywords"}}
@@ -844,31 +1583,68 @@
 
 {{#*inline "htmGeneratedKeywordsStr"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceGeneratedKeywordsStr">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Generated Keywords String</label>
+													<label for="{{classApiMethodMethod}}_generatedKeywordsStr">Generated Keywords String</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputGeneratedKeywordsStr"}}
-															</span>
-														</div>
+														{{> "inputGeneratedKeywordsStr"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); $('#{{classApiMethodMethod}}_generatedKeywordsStr').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setGeneratedKeywordsStr', null, function() { addGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputGeneratedKeywordsStr"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}GeneratedKeywordsStr ">{{currikiResource_.generatedKeywordsStr}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Generated Keywords String"
+															id="{{classApiMethodMethod}}_generatedKeywordsStr"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setGeneratedKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
+																name="setGeneratedKeywordsStr"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setGeneratedKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
+																name="setGeneratedKeywordsStr"
+		{{else}}
+																class="valueGeneratedKeywordsStr w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
+																name="generatedKeywordsStr"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setGeneratedKeywordsStr', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.generatedKeywordsStr}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}GeneratedKeywordsStr ">{{currikiResource_.generatedKeywordsStr}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmGeneratedKeywords"}}
@@ -902,2552 +1678,5717 @@
 
 {{#*inline "htmLanguage"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLanguage">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Language</label>
+													<label for="{{classApiMethodMethod}}_language">Language</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLanguage"}}
-															</span>
-														</div>
+														{{> "inputLanguage"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_language')); $('#{{classApiMethodMethod}}_language').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLanguage', null, function() { addGlow($('#{{classApiMethodMethod}}_language')); }, function() { addError($('#{{classApiMethodMethod}}_language')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLanguage"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Language ">{{currikiResource_.language}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Language"
+															id="{{classApiMethodMethod}}_language"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setLanguage classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
+																name="setLanguage"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setLanguage classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
+																name="setLanguage"
+		{{else}}
+																class="valueLanguage w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
+																name="language"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLanguage', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_language')); }, function() { addError($('#{{classApiMethodMethod}}_language')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.language}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Language ">{{currikiResource_.language}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastEditorId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastEditorId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Last Editor ID</label>
+													<label for="{{classApiMethodMethod}}_lastEditorId">Last Editor ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLastEditorId"}}
-															</span>
-														</div>
+														{{> "inputLastEditorId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastEditorId')); $('#{{classApiMethodMethod}}_lastEditorId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastEditorId', null, function() { addGlow($('#{{classApiMethodMethod}}_lastEditorId')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditorId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastEditorId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}LastEditorId ">{{currikiResource_.lastEditorId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Last Editor ID"
+															id="{{classApiMethodMethod}}_lastEditorId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setLastEditorId classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
+																name="setLastEditorId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setLastEditorId classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
+																name="setLastEditorId"
+		{{else}}
+																class="valueLastEditorId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
+																name="lastEditorId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastEditorId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_lastEditorId')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditorId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.lastEditorId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}LastEditorId ">{{currikiResource_.lastEditorId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastEditDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastEditDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Last Edit Date</label>
+													<label for="{{classApiMethodMethod}}_lastEditDate">Last Edit Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLastEditDate"}}
-															</span>
-														</div>
+														{{> "inputLastEditDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastEditDate')); $('#{{classApiMethodMethod}}_lastEditDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastEditDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastEditDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastEditDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}LastEditDate " title="{{formatZonedDateTime currikiResource_.lastEditDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastEditDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setLastEditDate classCurrikiResource inputCurrikiResource{{pk}}LastEditDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_lastEditDate"
+																value="{{currikiResource_.lastEditDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastEditDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastEditDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}LastEditDate ">{{currikiResource_.lastEditDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmCurrikiLicense"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceCurrikiLicense">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Curriki License</label>
+													<label for="{{classApiMethodMethod}}_currikiLicense">Curriki License</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputCurrikiLicense"}}
-															</span>
-														</div>
+														{{> "inputCurrikiLicense"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_currikiLicense')); $('#{{classApiMethodMethod}}_currikiLicense').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setCurrikiLicense', null, function() { addGlow($('#{{classApiMethodMethod}}_currikiLicense')); }, function() { addError($('#{{classApiMethodMethod}}_currikiLicense')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputCurrikiLicense"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}CurrikiLicense ">{{currikiResource_.currikiLicense}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Curriki License"
+															id="{{classApiMethodMethod}}_currikiLicense"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setCurrikiLicense classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
+																name="setCurrikiLicense"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setCurrikiLicense classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
+																name="setCurrikiLicense"
+		{{else}}
+																class="valueCurrikiLicense w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
+																name="currikiLicense"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setCurrikiLicense', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_currikiLicense')); }, function() { addError($('#{{classApiMethodMethod}}_currikiLicense')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.currikiLicense}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}CurrikiLicense ">{{currikiResource_.currikiLicense}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmExternalUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceExternalUrl">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>External URL</label>
+													<label for="{{classApiMethodMethod}}_externalUrl">External URL</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputExternalUrl"}}
-															</span>
-														</div>
+														{{> "inputExternalUrl"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_externalUrl')); $('#{{classApiMethodMethod}}_externalUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setExternalUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_externalUrl')); }, function() { addError($('#{{classApiMethodMethod}}_externalUrl')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputExternalUrl"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ExternalUrl ">{{currikiResource_.externalUrl}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="External URL"
+															id="{{classApiMethodMethod}}_externalUrl"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setExternalUrl classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
+																name="setExternalUrl"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setExternalUrl classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
+																name="setExternalUrl"
+		{{else}}
+																class="valueExternalUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
+																name="externalUrl"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setExternalUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_externalUrl')); }, function() { addError($('#{{classApiMethodMethod}}_externalUrl')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.externalUrl}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ExternalUrl ">{{currikiResource_.externalUrl}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceChecked"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceChecked">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Checked</label>
+													<label for="{{classApiMethodMethod}}_resourceChecked">Resource Checked</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceChecked"}}
-															</span>
-														</div>
+														{{> "inputResourceChecked"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceChecked')); $('#{{classApiMethodMethod}}_resourceChecked').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceChecked', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceChecked')); }, function() { addError($('#{{classApiMethodMethod}}_resourceChecked')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceChecked"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceChecked ">{{currikiResource_.resourceChecked}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Resource Checked"
+															id="{{classApiMethodMethod}}_resourceChecked"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceChecked classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
+																name="setResourceChecked"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceChecked classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
+																name="setResourceChecked"
+		{{else}}
+																class="valueResourceChecked w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
+																name="resourceChecked"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceChecked', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceChecked')); }, function() { addError($('#{{classApiMethodMethod}}_resourceChecked')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceChecked}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceChecked ">{{currikiResource_.resourceChecked}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContent"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContent">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>External URL</label>
+													<label for="{{classApiMethodMethod}}_content">External URL</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputContent"}}
-															</span>
-														</div>
+														{{> "inputContent"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_content')); $('#{{classApiMethodMethod}}_content').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContent', null, function() { addGlow($('#{{classApiMethodMethod}}_content')); }, function() { addError($('#{{classApiMethodMethod}}_content')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputContent"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Content ">{{currikiResource_.content}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="External URL"
+															id="{{classApiMethodMethod}}_content"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setContent classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
+																name="setContent"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setContent classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
+																name="setContent"
+		{{else}}
+																class="valueContent w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
+																name="content"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContent', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_content')); }, function() { addError($('#{{classApiMethodMethod}}_content')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.content}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Content ">{{currikiResource_.content}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckRequestNote"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckRequestNote">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Check Request Note</label>
+													<label for="{{classApiMethodMethod}}_resourceCheckRequestNote">Resource Check Request Note</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceCheckRequestNote"}}
-															</span>
-														</div>
+														{{> "inputResourceCheckRequestNote"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); $('#{{classApiMethodMethod}}_resourceCheckRequestNote').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckRequestNote', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckRequestNote"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceCheckRequestNote ">{{currikiResource_.resourceCheckRequestNote}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Resource Check Request Note"
+															id="{{classApiMethodMethod}}_resourceCheckRequestNote"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceCheckRequestNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
+																name="setResourceCheckRequestNote"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceCheckRequestNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
+																name="setResourceCheckRequestNote"
+		{{else}}
+																class="valueResourceCheckRequestNote w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
+																name="resourceCheckRequestNote"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckRequestNote', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceCheckRequestNote}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceCheckRequestNote ">{{currikiResource_.resourceCheckRequestNote}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Check Date</label>
+													<label for="{{classApiMethodMethod}}_resourceCheckDate">Resource Check Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceCheckDate"}}
-															</span>
-														</div>
+														{{> "inputResourceCheckDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); $('#{{classApiMethodMethod}}_resourceCheckDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckDate', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceCheckDate " title="{{formatZonedDateTime currikiResource_.resourceCheckDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.resourceCheckDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setResourceCheckDate classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_resourceCheckDate"
+																value="{{currikiResource_.resourceCheckDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckDate', s, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceCheckDate ">{{currikiResource_.resourceCheckDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Check ID</label>
+													<label for="{{classApiMethodMethod}}_resourceCheckId">Resource Check ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceCheckId"}}
-															</span>
-														</div>
+														{{> "inputResourceCheckId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckId')); $('#{{classApiMethodMethod}}_resourceCheckId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckId', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceCheckId ">{{currikiResource_.resourceCheckId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Resource Check ID"
+															id="{{classApiMethodMethod}}_resourceCheckId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceCheckId classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
+																name="setResourceCheckId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceCheckId classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
+																name="setResourceCheckId"
+		{{else}}
+																class="valueResourceCheckId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
+																name="resourceCheckId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceCheckId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceCheckId ">{{currikiResource_.resourceCheckId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckNote"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckNote">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Check Note</label>
+													<label for="{{classApiMethodMethod}}_resourceCheckNote">Resource Check Note</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceCheckNote"}}
-															</span>
-														</div>
+														{{> "inputResourceCheckNote"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); $('#{{classApiMethodMethod}}_resourceCheckNote').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckNote', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckNote')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckNote"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceCheckNote ">{{currikiResource_.resourceCheckNote}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Resource Check Note"
+															id="{{classApiMethodMethod}}_resourceCheckNote"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceCheckNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
+																name="setResourceCheckNote"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceCheckNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
+																name="setResourceCheckNote"
+		{{else}}
+																class="valueResourceCheckNote w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
+																name="resourceCheckNote"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckNote', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckNote')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceCheckNote}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceCheckNote ">{{currikiResource_.resourceCheckNote}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStudentFacing"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStudentFacing">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Student Facing</label>
+													<label for="{{classApiMethodMethod}}_studentFacing">Student Facing</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputStudentFacing"}}
-															</span>
-														</div>
+														{{> "inputStudentFacing"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_studentFacing')); $('#{{classApiMethodMethod}}_studentFacing').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStudentFacing', null, function() { addGlow($('#{{classApiMethodMethod}}_studentFacing')); }, function() { addError($('#{{classApiMethodMethod}}_studentFacing')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputStudentFacing"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}StudentFacing ">{{currikiResource_.studentFacing}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Student Facing"
+															id="{{classApiMethodMethod}}_studentFacing"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setStudentFacing classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
+																name="setStudentFacing"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setStudentFacing classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
+																name="setStudentFacing"
+		{{else}}
+																class="valueStudentFacing w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
+																name="studentFacing"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStudentFacing', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_studentFacing')); }, function() { addError($('#{{classApiMethodMethod}}_studentFacing')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.studentFacing}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}StudentFacing ">{{currikiResource_.studentFacing}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSource"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSource">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Source</label>
+													<label for="{{classApiMethodMethod}}_source">Source</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSource"}}
-															</span>
-														</div>
+														{{> "inputSource"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_source')); $('#{{classApiMethodMethod}}_source').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSource', null, function() { addGlow($('#{{classApiMethodMethod}}_source')); }, function() { addError($('#{{classApiMethodMethod}}_source')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSource"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Source ">{{currikiResource_.source}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Source"
+															id="{{classApiMethodMethod}}_source"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSource classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
+																name="setSource"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSource classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
+																name="setSource"
+		{{else}}
+																class="valueSource w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
+																name="source"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSource', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_source')); }, function() { addError($('#{{classApiMethodMethod}}_source')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.source}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Source ">{{currikiResource_.source}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewStatus"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewStatus">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Review Status</label>
+													<label for="{{classApiMethodMethod}}_reviewStatus">Review Status</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputReviewStatus"}}
-															</span>
-														</div>
+														{{> "inputReviewStatus"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewStatus')); $('#{{classApiMethodMethod}}_reviewStatus').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewStatus', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewStatus')); }, function() { addError($('#{{classApiMethodMethod}}_reviewStatus')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewStatus"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ReviewStatus ">{{currikiResource_.reviewStatus}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Review Status"
+															id="{{classApiMethodMethod}}_reviewStatus"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setReviewStatus classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
+																name="setReviewStatus"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setReviewStatus classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
+																name="setReviewStatus"
+		{{else}}
+																class="valueReviewStatus w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
+																name="reviewStatus"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewStatus', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewStatus')); }, function() { addError($('#{{classApiMethodMethod}}_reviewStatus')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.reviewStatus}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ReviewStatus ">{{currikiResource_.reviewStatus}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastReviewDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastReviewDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Last Review Date</label>
+													<label for="{{classApiMethodMethod}}_lastReviewDate">Last Review Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLastReviewDate"}}
-															</span>
-														</div>
+														{{> "inputLastReviewDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastReviewDate')); $('#{{classApiMethodMethod}}_lastReviewDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastReviewDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastReviewDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastReviewDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastReviewDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}LastReviewDate " title="{{formatZonedDateTime currikiResource_.lastReviewDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastReviewDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setLastReviewDate classCurrikiResource inputCurrikiResource{{pk}}LastReviewDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_lastReviewDate"
+																value="{{currikiResource_.lastReviewDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastReviewDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastReviewDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastReviewDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}LastReviewDate ">{{currikiResource_.lastReviewDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewByID"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewByID">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Review By ID</label>
+													<label for="{{classApiMethodMethod}}_reviewByID">Review By ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputReviewByID"}}
-															</span>
-														</div>
+														{{> "inputReviewByID"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewByID')); $('#{{classApiMethodMethod}}_reviewByID').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewByID', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewByID')); }, function() { addError($('#{{classApiMethodMethod}}_reviewByID')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewByID"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ReviewByID ">{{currikiResource_.reviewByID}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Review By ID"
+															id="{{classApiMethodMethod}}_reviewByID"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setReviewByID classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
+																name="setReviewByID"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setReviewByID classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
+																name="setReviewByID"
+		{{else}}
+																class="valueReviewByID w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
+																name="reviewByID"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewByID', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewByID')); }, function() { addError($('#{{classApiMethodMethod}}_reviewByID')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.reviewByID}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ReviewByID ">{{currikiResource_.reviewByID}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewRating"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewRating">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Review Rating</label>
+													<label for="{{classApiMethodMethod}}_reviewRating">Review Rating</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputReviewRating"}}
-															</span>
-														</div>
+														{{> "inputReviewRating"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewRating')); $('#{{classApiMethodMethod}}_reviewRating').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewRating', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewRating')); }, function() { addError($('#{{classApiMethodMethod}}_reviewRating')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewRating"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ReviewRating ">{{currikiResource_.reviewRating}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Review Rating"
+															id="{{classApiMethodMethod}}_reviewRating"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setReviewRating classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
+																name="setReviewRating"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setReviewRating classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
+																name="setReviewRating"
+		{{else}}
+																class="valueReviewRating w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
+																name="reviewRating"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewRating', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewRating')); }, function() { addError($('#{{classApiMethodMethod}}_reviewRating')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.reviewRating}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ReviewRating ">{{currikiResource_.reviewRating}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTechnicalCompleteness"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTechnicalCompleteness">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Technical Completeness</label>
+													<label for="{{classApiMethodMethod}}_technicalCompleteness">Technical Completeness</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTechnicalCompleteness"}}
-															</span>
-														</div>
+														{{> "inputTechnicalCompleteness"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); $('#{{classApiMethodMethod}}_technicalCompleteness').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTechnicalCompleteness', null, function() { addGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); }, function() { addError($('#{{classApiMethodMethod}}_technicalCompleteness')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTechnicalCompleteness"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}TechnicalCompleteness ">{{currikiResource_.technicalCompleteness}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Technical Completeness"
+															id="{{classApiMethodMethod}}_technicalCompleteness"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTechnicalCompleteness classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
+																name="setTechnicalCompleteness"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTechnicalCompleteness classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
+																name="setTechnicalCompleteness"
+		{{else}}
+																class="valueTechnicalCompleteness w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
+																name="technicalCompleteness"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTechnicalCompleteness', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); }, function() { addError($('#{{classApiMethodMethod}}_technicalCompleteness')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.technicalCompleteness}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}TechnicalCompleteness ">{{currikiResource_.technicalCompleteness}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContentAccuracy"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContentAccuracy">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Content Accuracy</label>
+													<label for="{{classApiMethodMethod}}_contentAccuracy">Content Accuracy</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputContentAccuracy"}}
-															</span>
-														</div>
+														{{> "inputContentAccuracy"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_contentAccuracy')); $('#{{classApiMethodMethod}}_contentAccuracy').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContentAccuracy', null, function() { addGlow($('#{{classApiMethodMethod}}_contentAccuracy')); }, function() { addError($('#{{classApiMethodMethod}}_contentAccuracy')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputContentAccuracy"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ContentAccuracy ">{{currikiResource_.contentAccuracy}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Content Accuracy"
+															id="{{classApiMethodMethod}}_contentAccuracy"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setContentAccuracy classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
+																name="setContentAccuracy"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setContentAccuracy classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
+																name="setContentAccuracy"
+		{{else}}
+																class="valueContentAccuracy w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
+																name="contentAccuracy"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContentAccuracy', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contentAccuracy')); }, function() { addError($('#{{classApiMethodMethod}}_contentAccuracy')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.contentAccuracy}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ContentAccuracy ">{{currikiResource_.contentAccuracy}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPedagogy"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePedagogy">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Pedagogy</label>
+													<label for="{{classApiMethodMethod}}_pedagogy">Pedagogy</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPedagogy"}}
-															</span>
-														</div>
+														{{> "inputPedagogy"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_pedagogy')); $('#{{classApiMethodMethod}}_pedagogy').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPedagogy', null, function() { addGlow($('#{{classApiMethodMethod}}_pedagogy')); }, function() { addError($('#{{classApiMethodMethod}}_pedagogy')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPedagogy"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Pedagogy ">{{currikiResource_.pedagogy}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Pedagogy"
+															id="{{classApiMethodMethod}}_pedagogy"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPedagogy classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
+																name="setPedagogy"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPedagogy classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
+																name="setPedagogy"
+		{{else}}
+																class="valuePedagogy w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
+																name="pedagogy"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPedagogy', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_pedagogy')); }, function() { addError($('#{{classApiMethodMethod}}_pedagogy')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.pedagogy}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Pedagogy ">{{currikiResource_.pedagogy}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmRatingComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRatingComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Rating Comment</label>
+													<label for="{{classApiMethodMethod}}_ratingComment">Rating Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputRatingComment"}}
-															</span>
-														</div>
+														{{> "inputRatingComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_ratingComment')); $('#{{classApiMethodMethod}}_ratingComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRatingComment', null, function() { addGlow($('#{{classApiMethodMethod}}_ratingComment')); }, function() { addError($('#{{classApiMethodMethod}}_ratingComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputRatingComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}RatingComment ">{{currikiResource_.ratingComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Rating Comment"
+															id="{{classApiMethodMethod}}_ratingComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setRatingComment classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
+																name="setRatingComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setRatingComment classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
+																name="setRatingComment"
+		{{else}}
+																class="valueRatingComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
+																name="ratingComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRatingComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_ratingComment')); }, function() { addError($('#{{classApiMethodMethod}}_ratingComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.ratingComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}RatingComment ">{{currikiResource_.ratingComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStandardsAlignment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStandardsAlignment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Standards Alignment</label>
+													<label for="{{classApiMethodMethod}}_standardsAlignment">Standards Alignment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputStandardsAlignment"}}
-															</span>
-														</div>
+														{{> "inputStandardsAlignment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_standardsAlignment')); $('#{{classApiMethodMethod}}_standardsAlignment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStandardsAlignment', null, function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputStandardsAlignment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}StandardsAlignment ">{{currikiResource_.standardsAlignment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Standards Alignment"
+															id="{{classApiMethodMethod}}_standardsAlignment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setStandardsAlignment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
+																name="setStandardsAlignment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setStandardsAlignment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
+																name="setStandardsAlignment"
+		{{else}}
+																class="valueStandardsAlignment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
+																name="standardsAlignment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStandardsAlignment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.standardsAlignment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}StandardsAlignment ">{{currikiResource_.standardsAlignment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStandardsAlignmentComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStandardsAlignmentComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Standards Alignment Comment</label>
+													<label for="{{classApiMethodMethod}}_standardsAlignmentComment">Standards Alignment Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputStandardsAlignmentComment"}}
-															</span>
-														</div>
+														{{> "inputStandardsAlignmentComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); $('#{{classApiMethodMethod}}_standardsAlignmentComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStandardsAlignmentComment', null, function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputStandardsAlignmentComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}StandardsAlignmentComment ">{{currikiResource_.standardsAlignmentComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Standards Alignment Comment"
+															id="{{classApiMethodMethod}}_standardsAlignmentComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setStandardsAlignmentComment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
+																name="setStandardsAlignmentComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setStandardsAlignmentComment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
+																name="setStandardsAlignmentComment"
+		{{else}}
+																class="valueStandardsAlignmentComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
+																name="standardsAlignmentComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStandardsAlignmentComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.standardsAlignmentComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}StandardsAlignmentComment ">{{currikiResource_.standardsAlignmentComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectMatter"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectMatter">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Subject Matter</label>
+													<label for="{{classApiMethodMethod}}_subjectMatter">Subject Matter</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSubjectMatter"}}
-															</span>
-														</div>
+														{{> "inputSubjectMatter"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectMatter')); $('#{{classApiMethodMethod}}_subjectMatter').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectMatter', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectMatter')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatter')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectMatter"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SubjectMatter ">{{currikiResource_.subjectMatter}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Subject Matter"
+															id="{{classApiMethodMethod}}_subjectMatter"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSubjectMatter classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
+																name="setSubjectMatter"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSubjectMatter classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
+																name="setSubjectMatter"
+		{{else}}
+																class="valueSubjectMatter w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
+																name="subjectMatter"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectMatter', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectMatter')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatter')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.subjectMatter}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SubjectMatter ">{{currikiResource_.subjectMatter}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectMatterComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectMatterComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Subject Matter Comment</label>
+													<label for="{{classApiMethodMethod}}_subjectMatterComment">Subject Matter Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSubjectMatterComment"}}
-															</span>
-														</div>
+														{{> "inputSubjectMatterComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); $('#{{classApiMethodMethod}}_subjectMatterComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectMatterComment', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatterComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectMatterComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SubjectMatterComment ">{{currikiResource_.subjectMatterComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Subject Matter Comment"
+															id="{{classApiMethodMethod}}_subjectMatterComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSubjectMatterComment classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
+																name="setSubjectMatterComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSubjectMatterComment classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
+																name="setSubjectMatterComment"
+		{{else}}
+																class="valueSubjectMatterComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
+																name="subjectMatterComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectMatterComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatterComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.subjectMatterComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SubjectMatterComment ">{{currikiResource_.subjectMatterComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSupportsTeaching"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSupportsTeaching">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Supports Teaching</label>
+													<label for="{{classApiMethodMethod}}_supportsTeaching">Supports Teaching</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSupportsTeaching"}}
-															</span>
-														</div>
+														{{> "inputSupportsTeaching"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_supportsTeaching')); $('#{{classApiMethodMethod}}_supportsTeaching').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSupportsTeaching', null, function() { addGlow($('#{{classApiMethodMethod}}_supportsTeaching')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeaching')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSupportsTeaching"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SupportsTeaching ">{{currikiResource_.supportsTeaching}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Supports Teaching"
+															id="{{classApiMethodMethod}}_supportsTeaching"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSupportsTeaching classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
+																name="setSupportsTeaching"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSupportsTeaching classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
+																name="setSupportsTeaching"
+		{{else}}
+																class="valueSupportsTeaching w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
+																name="supportsTeaching"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSupportsTeaching', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_supportsTeaching')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeaching')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.supportsTeaching}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SupportsTeaching ">{{currikiResource_.supportsTeaching}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSupportsTeachingComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSupportsTeachingComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Supports Teaching Comment</label>
+													<label for="{{classApiMethodMethod}}_supportsTeachingComment">Supports Teaching Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSupportsTeachingComment"}}
-															</span>
-														</div>
+														{{> "inputSupportsTeachingComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); $('#{{classApiMethodMethod}}_supportsTeachingComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSupportsTeachingComment', null, function() { addGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeachingComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSupportsTeachingComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SupportsTeachingComment ">{{currikiResource_.supportsTeachingComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Supports Teaching Comment"
+															id="{{classApiMethodMethod}}_supportsTeachingComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSupportsTeachingComment classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
+																name="setSupportsTeachingComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSupportsTeachingComment classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
+																name="setSupportsTeachingComment"
+		{{else}}
+																class="valueSupportsTeachingComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
+																name="supportsTeachingComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSupportsTeachingComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeachingComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.supportsTeachingComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SupportsTeachingComment ">{{currikiResource_.supportsTeachingComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAssessmentsQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAssessmentsQuality">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Assessments Quality</label>
+													<label for="{{classApiMethodMethod}}_assessmentsQuality">Assessments Quality</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputAssessmentsQuality"}}
-															</span>
-														</div>
+														{{> "inputAssessmentsQuality"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); $('#{{classApiMethodMethod}}_assessmentsQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAssessmentsQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQuality')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputAssessmentsQuality"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}AssessmentsQuality ">{{currikiResource_.assessmentsQuality}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Assessments Quality"
+															id="{{classApiMethodMethod}}_assessmentsQuality"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setAssessmentsQuality classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
+																name="setAssessmentsQuality"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setAssessmentsQuality classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
+																name="setAssessmentsQuality"
+		{{else}}
+																class="valueAssessmentsQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
+																name="assessmentsQuality"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAssessmentsQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQuality')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.assessmentsQuality}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}AssessmentsQuality ">{{currikiResource_.assessmentsQuality}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAssessmentsQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAssessmentsQualityComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Assessments Quality Comment</label>
+													<label for="{{classApiMethodMethod}}_assessmentsQualityComment">Assessments Quality Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputAssessmentsQualityComment"}}
-															</span>
-														</div>
+														{{> "inputAssessmentsQualityComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); $('#{{classApiMethodMethod}}_assessmentsQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAssessmentsQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputAssessmentsQualityComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}AssessmentsQualityComment ">{{currikiResource_.assessmentsQualityComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Assessments Quality Comment"
+															id="{{classApiMethodMethod}}_assessmentsQualityComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setAssessmentsQualityComment classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
+																name="setAssessmentsQualityComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setAssessmentsQualityComment classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
+																name="setAssessmentsQualityComment"
+		{{else}}
+																class="valueAssessmentsQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
+																name="assessmentsQualityComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAssessmentsQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.assessmentsQualityComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}AssessmentsQualityComment ">{{currikiResource_.assessmentsQualityComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInteractivityQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInteractivityQuality">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Interactivity Quality</label>
+													<label for="{{classApiMethodMethod}}_interactivityQuality">Interactivity Quality</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputInteractivityQuality"}}
-															</span>
-														</div>
+														{{> "inputInteractivityQuality"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_interactivityQuality')); $('#{{classApiMethodMethod}}_interactivityQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInteractivityQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_interactivityQuality')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQuality')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputInteractivityQuality"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}InteractivityQuality ">{{currikiResource_.interactivityQuality}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Interactivity Quality"
+															id="{{classApiMethodMethod}}_interactivityQuality"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInteractivityQuality classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
+																name="setInteractivityQuality"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInteractivityQuality classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
+																name="setInteractivityQuality"
+		{{else}}
+																class="valueInteractivityQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
+																name="interactivityQuality"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInteractivityQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_interactivityQuality')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQuality')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.interactivityQuality}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}InteractivityQuality ">{{currikiResource_.interactivityQuality}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInteractivityQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInteractivityQualityComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Interactivity Quality Comment</label>
+													<label for="{{classApiMethodMethod}}_interactivityQualityComment">Interactivity Quality Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputInteractivityQualityComment"}}
-															</span>
-														</div>
+														{{> "inputInteractivityQualityComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); $('#{{classApiMethodMethod}}_interactivityQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInteractivityQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQualityComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputInteractivityQualityComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}InteractivityQualityComment ">{{currikiResource_.interactivityQualityComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Interactivity Quality Comment"
+															id="{{classApiMethodMethod}}_interactivityQualityComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInteractivityQualityComment classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
+																name="setInteractivityQualityComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInteractivityQualityComment classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
+																name="setInteractivityQualityComment"
+		{{else}}
+																class="valueInteractivityQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
+																name="interactivityQualityComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInteractivityQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQualityComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.interactivityQualityComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}InteractivityQualityComment ">{{currikiResource_.interactivityQualityComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInstructionalQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInstructionalQuality">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Instructional Quality</label>
+													<label for="{{classApiMethodMethod}}_instructionalQuality">Instructional Quality</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputInstructionalQuality"}}
-															</span>
-														</div>
+														{{> "inputInstructionalQuality"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_instructionalQuality')); $('#{{classApiMethodMethod}}_instructionalQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInstructionalQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_instructionalQuality')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQuality')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputInstructionalQuality"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}InstructionalQuality ">{{currikiResource_.instructionalQuality}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Instructional Quality"
+															id="{{classApiMethodMethod}}_instructionalQuality"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInstructionalQuality classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
+																name="setInstructionalQuality"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInstructionalQuality classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
+																name="setInstructionalQuality"
+		{{else}}
+																class="valueInstructionalQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
+																name="instructionalQuality"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInstructionalQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_instructionalQuality')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQuality')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.instructionalQuality}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}InstructionalQuality ">{{currikiResource_.instructionalQuality}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInstructionalQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInstructionalQualityComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Instructional Quality Comment</label>
+													<label for="{{classApiMethodMethod}}_instructionalQualityComment">Instructional Quality Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputInstructionalQualityComment"}}
-															</span>
-														</div>
+														{{> "inputInstructionalQualityComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); $('#{{classApiMethodMethod}}_instructionalQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInstructionalQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQualityComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputInstructionalQualityComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}InstructionalQualityComment ">{{currikiResource_.instructionalQualityComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Instructional Quality Comment"
+															id="{{classApiMethodMethod}}_instructionalQualityComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInstructionalQualityComment classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
+																name="setInstructionalQualityComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInstructionalQualityComment classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
+																name="setInstructionalQualityComment"
+		{{else}}
+																class="valueInstructionalQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
+																name="instructionalQualityComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInstructionalQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQualityComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.instructionalQualityComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}InstructionalQualityComment ">{{currikiResource_.instructionalQualityComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDeeperLearning"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDeeperLearning">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Deeper Learning</label>
+													<label for="{{classApiMethodMethod}}_deeperLearning">Deeper Learning</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDeeperLearning"}}
-															</span>
-														</div>
+														{{> "inputDeeperLearning"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_deeperLearning')); $('#{{classApiMethodMethod}}_deeperLearning').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDeeperLearning', null, function() { addGlow($('#{{classApiMethodMethod}}_deeperLearning')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearning')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeeperLearning"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}DeeperLearning ">{{currikiResource_.deeperLearning}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Deeper Learning"
+															id="{{classApiMethodMethod}}_deeperLearning"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setDeeperLearning classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
+																name="setDeeperLearning"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setDeeperLearning classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
+																name="setDeeperLearning"
+		{{else}}
+																class="valueDeeperLearning w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
+																name="deeperLearning"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeeperLearning', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_deeperLearning')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearning')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.deeperLearning}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}DeeperLearning ">{{currikiResource_.deeperLearning}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDeeperLearningComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDeeperLearningComment">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Deeper Learning Comment</label>
+													<label for="{{classApiMethodMethod}}_deeperLearningComment">Deeper Learning Comment</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDeeperLearningComment"}}
-															</span>
-														</div>
+														{{> "inputDeeperLearningComment"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); $('#{{classApiMethodMethod}}_deeperLearningComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDeeperLearningComment', null, function() { addGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearningComment')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeeperLearningComment"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}DeeperLearningComment ">{{currikiResource_.deeperLearningComment}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Deeper Learning Comment"
+															id="{{classApiMethodMethod}}_deeperLearningComment"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setDeeperLearningComment classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
+																name="setDeeperLearningComment"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setDeeperLearningComment classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
+																name="setDeeperLearningComment"
+		{{else}}
+																class="valueDeeperLearningComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
+																name="deeperLearningComment"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeeperLearningComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearningComment')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.deeperLearningComment}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}DeeperLearningComment ">{{currikiResource_.deeperLearningComment}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPartner"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePartner">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Partner</label>
+													<label for="{{classApiMethodMethod}}_partner">Partner</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPartner"}}
-															</span>
-														</div>
+														{{> "inputPartner"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_partner')); $('#{{classApiMethodMethod}}_partner').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPartner', null, function() { addGlow($('#{{classApiMethodMethod}}_partner')); }, function() { addError($('#{{classApiMethodMethod}}_partner')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPartner"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Partner ">{{currikiResource_.partner}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Partner"
+															id="{{classApiMethodMethod}}_partner"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPartner classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
+																name="setPartner"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPartner classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
+																name="setPartner"
+		{{else}}
+																class="valuePartner w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
+																name="partner"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPartner', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_partner')); }, function() { addError($('#{{classApiMethodMethod}}_partner')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.partner}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Partner ">{{currikiResource_.partner}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmCreateDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceCreateDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Create Date</label>
+													<label for="{{classApiMethodMethod}}_createDate">Create Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputCreateDate"}}
-															</span>
-														</div>
+														{{> "inputCreateDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_createDate')); $('#{{classApiMethodMethod}}_createDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setCreateDate', null, function() { addGlow($('#{{classApiMethodMethod}}_createDate')); }, function() { addError($('#{{classApiMethodMethod}}_createDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputCreateDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}CreateDate " title="{{formatZonedDateTime currikiResource_.createDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.createDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setCreateDate classCurrikiResource inputCurrikiResource{{pk}}CreateDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_createDate"
+																value="{{currikiResource_.createDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setCreateDate', s, function() { addGlow($('#{{classApiMethodMethod}}_createDate')); }, function() { addError($('#{{classApiMethodMethod}}_createDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}CreateDate ">{{currikiResource_.createDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmType"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceType">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Type</label>
+													<label for="{{classApiMethodMethod}}_type">Type</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputType"}}
-															</span>
-														</div>
+														{{> "inputType"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_type')); $('#{{classApiMethodMethod}}_type').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setType', null, function() { addGlow($('#{{classApiMethodMethod}}_type')); }, function() { addError($('#{{classApiMethodMethod}}_type')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputType"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Type ">{{currikiResource_.type}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Type"
+															id="{{classApiMethodMethod}}_type"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setType classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
+																name="setType"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setType classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
+																name="setType"
+		{{else}}
+																class="valueType w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
+																name="type"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setType', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_type')); }, function() { addError($('#{{classApiMethodMethod}}_type')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.type}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Type ">{{currikiResource_.type}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmFeatured"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceFeatured">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Featured</label>
+													<label for="{{classApiMethodMethod}}_featured">Featured</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputFeatured"}}
-															</span>
-														</div>
+														{{> "inputFeatured"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_featured')); $('#{{classApiMethodMethod}}_featured').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setFeatured', null, function() { addGlow($('#{{classApiMethodMethod}}_featured')); }, function() { addError($('#{{classApiMethodMethod}}_featured')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputFeatured"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Featured ">{{currikiResource_.featured}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Featured"
+															id="{{classApiMethodMethod}}_featured"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setFeatured classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
+																name="setFeatured"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setFeatured classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
+																name="setFeatured"
+		{{else}}
+																class="valueFeatured w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
+																name="featured"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setFeatured', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_featured')); }, function() { addError($('#{{classApiMethodMethod}}_featured')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.featured}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Featured ">{{currikiResource_.featured}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPage"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePage">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Page</label>
+													<label for="{{classApiMethodMethod}}_page">Page</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPage"}}
-															</span>
-														</div>
+														{{> "inputPage"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_page')); $('#{{classApiMethodMethod}}_page').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPage', null, function() { addGlow($('#{{classApiMethodMethod}}_page')); }, function() { addError($('#{{classApiMethodMethod}}_page')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPage"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Page ">{{currikiResource_.page}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Page"
+															id="{{classApiMethodMethod}}_page"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPage classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
+																name="setPage"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPage classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
+																name="setPage"
+		{{else}}
+																class="valuePage w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
+																name="page"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPage', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_page')); }, function() { addError($('#{{classApiMethodMethod}}_page')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.page}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Page ">{{currikiResource_.page}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmActive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceActive">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Active</label>
+													<label for="{{classApiMethodMethod}}_active">Active</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputActive"}}
-															</span>
-														</div>
+														{{> "inputActive"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_active')); $('#{{classApiMethodMethod}}_active').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setActive', null, function() { addGlow($('#{{classApiMethodMethod}}_active')); }, function() { addError($('#{{classApiMethodMethod}}_active')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputActive"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Active ">{{currikiResource_.active}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Active"
+															id="{{classApiMethodMethod}}_active"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setActive classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
+																name="setActive"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setActive classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
+																name="setActive"
+		{{else}}
+																class="valueActive w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
+																name="active"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setActive', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_active')); }, function() { addError($('#{{classApiMethodMethod}}_active')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.active}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Active ">{{currikiResource_.active}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPublic"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePublic">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Public</label>
+													<label for="{{classApiMethodMethod}}_Public">Public</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPublic"}}
-															</span>
-														</div>
+														{{> "inputPublic"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_Public')); $('#{{classApiMethodMethod}}_Public').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPublic', null, function() { addGlow($('#{{classApiMethodMethod}}_Public')); }, function() { addError($('#{{classApiMethodMethod}}_Public')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPublic"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Public ">{{currikiResource_.Public}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Public"
+															id="{{classApiMethodMethod}}_Public"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPublic classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
+																name="setPublic"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPublic classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
+																name="setPublic"
+		{{else}}
+																class="valuePublic w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
+																name="Public"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPublic', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_Public')); }, function() { addError($('#{{classApiMethodMethod}}_Public')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.Public}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Public ">{{currikiResource_.Public}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmXwd_id"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceXwd_id">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>xwd ID</label>
+													<label for="{{classApiMethodMethod}}_xwd_id">xwd ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputXwd_id"}}
-															</span>
-														</div>
+														{{> "inputXwd_id"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_xwd_id')); $('#{{classApiMethodMethod}}_xwd_id').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setXwd_id', null, function() { addGlow($('#{{classApiMethodMethod}}_xwd_id')); }, function() { addError($('#{{classApiMethodMethod}}_xwd_id')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputXwd_id"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Xwd_id ">{{currikiResource_.xwd_id}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="xwd ID"
+															id="{{classApiMethodMethod}}_xwd_id"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setXwd_id classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
+																name="setXwd_id"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setXwd_id classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
+																name="setXwd_id"
+		{{else}}
+																class="valueXwd_id w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
+																name="xwd_id"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setXwd_id', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_xwd_id')); }, function() { addError($('#{{classApiMethodMethod}}_xwd_id')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.xwd_id}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Xwd_id ">{{currikiResource_.xwd_id}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMediaType"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMediaType">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Media Type</label>
+													<label for="{{classApiMethodMethod}}_mediaType">Media Type</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputMediaType"}}
-															</span>
-														</div>
+														{{> "inputMediaType"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_mediaType')); $('#{{classApiMethodMethod}}_mediaType').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMediaType', null, function() { addGlow($('#{{classApiMethodMethod}}_mediaType')); }, function() { addError($('#{{classApiMethodMethod}}_mediaType')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputMediaType"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}MediaType ">{{currikiResource_.mediaType}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Media Type"
+															id="{{classApiMethodMethod}}_mediaType"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setMediaType classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
+																name="setMediaType"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setMediaType classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
+																name="setMediaType"
+		{{else}}
+																class="valueMediaType w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
+																name="mediaType"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMediaType', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_mediaType')); }, function() { addError($('#{{classApiMethodMethod}}_mediaType')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.mediaType}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}MediaType ">{{currikiResource_.mediaType}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAccess"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAccess">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Access</label>
+													<label for="{{classApiMethodMethod}}_access">Access</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputAccess"}}
-															</span>
-														</div>
+														{{> "inputAccess"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_access')); $('#{{classApiMethodMethod}}_access').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAccess', null, function() { addGlow($('#{{classApiMethodMethod}}_access')); }, function() { addError($('#{{classApiMethodMethod}}_access')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputAccess"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Access ">{{currikiResource_.access}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Access"
+															id="{{classApiMethodMethod}}_access"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setAccess classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
+																name="setAccess"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setAccess classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
+																name="setAccess"
+		{{else}}
+																class="valueAccess w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
+																name="access"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAccess', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_access')); }, function() { addError($('#{{classApiMethodMethod}}_access')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.access}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Access ">{{currikiResource_.access}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMemberRating"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMemberRating">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Member Rating</label>
+													<label for="{{classApiMethodMethod}}_memberRating">Member Rating</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputMemberRating"}}
-															</span>
-														</div>
+														{{> "inputMemberRating"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_memberRating')); $('#{{classApiMethodMethod}}_memberRating').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMemberRating', null, function() { addGlow($('#{{classApiMethodMethod}}_memberRating')); }, function() { addError($('#{{classApiMethodMethod}}_memberRating')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputMemberRating"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}MemberRating ">{{currikiResource_.memberRating}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Member Rating"
+															id="{{classApiMethodMethod}}_memberRating"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setMemberRating classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
+																name="setMemberRating"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setMemberRating classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
+																name="setMemberRating"
+		{{else}}
+																class="valueMemberRating w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
+																name="memberRating"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMemberRating', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_memberRating')); }, function() { addError($('#{{classApiMethodMethod}}_memberRating')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.memberRating}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}MemberRating ">{{currikiResource_.memberRating}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAligned"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAligned">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Aligned</label>
+													<label for="{{classApiMethodMethod}}_aligned">Aligned</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputAligned"}}
-															</span>
-														</div>
+														{{> "inputAligned"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_aligned')); $('#{{classApiMethodMethod}}_aligned').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAligned', null, function() { addGlow($('#{{classApiMethodMethod}}_aligned')); }, function() { addError($('#{{classApiMethodMethod}}_aligned')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputAligned"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Aligned ">{{currikiResource_.aligned}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Aligned"
+															id="{{classApiMethodMethod}}_aligned"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setAligned classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
+																name="setAligned"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setAligned classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
+																name="setAligned"
+		{{else}}
+																class="valueAligned w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
+																name="aligned"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAligned', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_aligned')); }, function() { addError($('#{{classApiMethodMethod}}_aligned')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.aligned}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Aligned ">{{currikiResource_.aligned}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPageUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePageUrl">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Page URL</label>
+													<label for="{{classApiMethodMethod}}_pageUrl">Page URL</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPageUrl"}}
-															</span>
-														</div>
+														{{> "inputPageUrl"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_pageUrl')); $('#{{classApiMethodMethod}}_pageUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPageUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_pageUrl')); }, function() { addError($('#{{classApiMethodMethod}}_pageUrl')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPageUrl"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}PageUrl ">{{currikiResource_.pageUrl}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Page URL"
+															id="{{classApiMethodMethod}}_pageUrl"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPageUrl classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
+																name="setPageUrl"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPageUrl classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
+																name="setPageUrl"
+		{{else}}
+																class="valuePageUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
+																name="pageUrl"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPageUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_pageUrl')); }, function() { addError($('#{{classApiMethodMethod}}_pageUrl')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.pageUrl}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}PageUrl ">{{currikiResource_.pageUrl}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIndexed"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexed">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Indexed</label>
+													<label for="{{classApiMethodMethod}}_indexed">Indexed</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputIndexed"}}
-															</span>
-														</div>
+														{{> "inputIndexed"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexed')); $('#{{classApiMethodMethod}}_indexed').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexed', null, function() { addGlow($('#{{classApiMethodMethod}}_indexed')); }, function() { addError($('#{{classApiMethodMethod}}_indexed')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexed"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Indexed ">{{currikiResource_.indexed}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Indexed"
+															id="{{classApiMethodMethod}}_indexed"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setIndexed classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
+																name="setIndexed"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setIndexed classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
+																name="setIndexed"
+		{{else}}
+																class="valueIndexed w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
+																name="indexed"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexed', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_indexed')); }, function() { addError($('#{{classApiMethodMethod}}_indexed')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.indexed}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Indexed ">{{currikiResource_.indexed}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastIndexDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastIndexDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Last Index Date</label>
+													<label for="{{classApiMethodMethod}}_lastIndexDate">Last Index Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLastIndexDate"}}
-															</span>
-														</div>
+														{{> "inputLastIndexDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastIndexDate')); $('#{{classApiMethodMethod}}_lastIndexDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastIndexDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastIndexDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastIndexDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastIndexDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}LastIndexDate " title="{{formatZonedDateTime currikiResource_.lastIndexDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastIndexDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setLastIndexDate classCurrikiResource inputCurrikiResource{{pk}}LastIndexDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_lastIndexDate"
+																value="{{currikiResource_.lastIndexDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastIndexDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastIndexDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastIndexDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}LastIndexDate ">{{currikiResource_.lastIndexDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIndexRequired"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexRequired">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Index Required</label>
+													<label for="{{classApiMethodMethod}}_indexRequired">Index Required</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputIndexRequired"}}
-															</span>
-														</div>
+														{{> "inputIndexRequired"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexRequired')); $('#{{classApiMethodMethod}}_indexRequired').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexRequired', null, function() { addGlow($('#{{classApiMethodMethod}}_indexRequired')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequired')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexRequired"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}IndexRequired ">{{currikiResource_.indexRequired}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Index Required"
+															id="{{classApiMethodMethod}}_indexRequired"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setIndexRequired classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
+																name="setIndexRequired"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setIndexRequired classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
+																name="setIndexRequired"
+		{{else}}
+																class="valueIndexRequired w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
+																name="indexRequired"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexRequired', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_indexRequired')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequired')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.indexRequired}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}IndexRequired ">{{currikiResource_.indexRequired}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIndexRequiredDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexRequiredDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>IndexRequiredDate</label>
+													<label for="{{classApiMethodMethod}}_indexRequiredDate">IndexRequiredDate</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputIndexRequiredDate"}}
-															</span>
-														</div>
+														{{> "inputIndexRequiredDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); $('#{{classApiMethodMethod}}_indexRequiredDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexRequiredDate', null, function() { addGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequiredDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexRequiredDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}IndexRequiredDate " title="{{formatZonedDateTime currikiResource_.indexRequiredDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.indexRequiredDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setIndexRequiredDate classCurrikiResource inputCurrikiResource{{pk}}IndexRequiredDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_indexRequiredDate"
+																value="{{currikiResource_.indexRequiredDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexRequiredDate', s, function() { addGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequiredDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}IndexRequiredDate ">{{currikiResource_.indexRequiredDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmRescrape"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRescrape">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>rescrape</label>
+													<label for="{{classApiMethodMethod}}_rescrape">rescrape</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputRescrape"}}
-															</span>
-														</div>
+														{{> "inputRescrape"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_rescrape')); $('#{{classApiMethodMethod}}_rescrape').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRescrape', null, function() { addGlow($('#{{classApiMethodMethod}}_rescrape')); }, function() { addError($('#{{classApiMethodMethod}}_rescrape')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputRescrape"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Rescrape ">{{currikiResource_.rescrape}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="rescrape"
+															id="{{classApiMethodMethod}}_rescrape"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setRescrape classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
+																name="setRescrape"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setRescrape classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
+																name="setRescrape"
+		{{else}}
+																class="valueRescrape w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
+																name="rescrape"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRescrape', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_rescrape')); }, function() { addError($('#{{classApiMethodMethod}}_rescrape')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.rescrape}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Rescrape ">{{currikiResource_.rescrape}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmGoButton"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceGoButton">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Go Button</label>
+													<label for="{{classApiMethodMethod}}_goButton">Go Button</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputGoButton"}}
-															</span>
-														</div>
+														{{> "inputGoButton"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_goButton')); $('#{{classApiMethodMethod}}_goButton').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setGoButton', null, function() { addGlow($('#{{classApiMethodMethod}}_goButton')); }, function() { addError($('#{{classApiMethodMethod}}_goButton')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputGoButton"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}GoButton ">{{currikiResource_.goButton}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Go Button"
+															id="{{classApiMethodMethod}}_goButton"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setGoButton classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
+																name="setGoButton"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setGoButton classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
+																name="setGoButton"
+		{{else}}
+																class="valueGoButton w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
+																name="goButton"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setGoButton', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_goButton')); }, function() { addError($('#{{classApiMethodMethod}}_goButton')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.goButton}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}GoButton ">{{currikiResource_.goButton}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDownloadButton"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDownloadButton">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Download Button</label>
+													<label for="{{classApiMethodMethod}}_downloadButton">Download Button</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDownloadButton"}}
-															</span>
-														</div>
+														{{> "inputDownloadButton"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_downloadButton')); $('#{{classApiMethodMethod}}_downloadButton').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDownloadButton', null, function() { addGlow($('#{{classApiMethodMethod}}_downloadButton')); }, function() { addError($('#{{classApiMethodMethod}}_downloadButton')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDownloadButton"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}DownloadButton ">{{currikiResource_.downloadButton}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Download Button"
+															id="{{classApiMethodMethod}}_downloadButton"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setDownloadButton classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
+																name="setDownloadButton"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setDownloadButton classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
+																name="setDownloadButton"
+		{{else}}
+																class="valueDownloadButton w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
+																name="downloadButton"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDownloadButton', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_downloadButton')); }, function() { addError($('#{{classApiMethodMethod}}_downloadButton')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.downloadButton}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}DownloadButton ">{{currikiResource_.downloadButton}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTopOfSearch"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTopOfSearch">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Top of Search</label>
+													<label for="{{classApiMethodMethod}}_topOfSearch">Top of Search</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTopOfSearch"}}
-															</span>
-														</div>
+														{{> "inputTopOfSearch"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_topOfSearch')); $('#{{classApiMethodMethod}}_topOfSearch').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTopOfSearch', null, function() { addGlow($('#{{classApiMethodMethod}}_topOfSearch')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearch')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTopOfSearch"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}TopOfSearch ">{{currikiResource_.topOfSearch}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Top of Search"
+															id="{{classApiMethodMethod}}_topOfSearch"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTopOfSearch classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
+																name="setTopOfSearch"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTopOfSearch classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
+																name="setTopOfSearch"
+		{{else}}
+																class="valueTopOfSearch w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
+																name="topOfSearch"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTopOfSearch', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_topOfSearch')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearch')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.topOfSearch}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}TopOfSearch ">{{currikiResource_.topOfSearch}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmRemove"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRemove">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Remove</label>
+													<label for="{{classApiMethodMethod}}_remove">Remove</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputRemove"}}
-															</span>
-														</div>
+														{{> "inputRemove"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_remove')); $('#{{classApiMethodMethod}}_remove').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRemove', null, function() { addGlow($('#{{classApiMethodMethod}}_remove')); }, function() { addError($('#{{classApiMethodMethod}}_remove')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputRemove"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Remove ">{{currikiResource_.remove}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Remove"
+															id="{{classApiMethodMethod}}_remove"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setRemove classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
+																name="setRemove"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setRemove classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
+																name="setRemove"
+		{{else}}
+																class="valueRemove w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
+																name="remove"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRemove', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_remove')); }, function() { addError($('#{{classApiMethodMethod}}_remove')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.remove}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Remove ">{{currikiResource_.remove}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSpam"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSpam">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Spam</label>
+													<label for="{{classApiMethodMethod}}_spam">Spam</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSpam"}}
-															</span>
-														</div>
+														{{> "inputSpam"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_spam')); $('#{{classApiMethodMethod}}_spam').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSpam', null, function() { addGlow($('#{{classApiMethodMethod}}_spam')); }, function() { addError($('#{{classApiMethodMethod}}_spam')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSpam"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Spam ">{{currikiResource_.spam}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Spam"
+															id="{{classApiMethodMethod}}_spam"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSpam classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
+																name="setSpam"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSpam classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
+																name="setSpam"
+		{{else}}
+																class="valueSpam w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
+																name="spam"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSpam', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_spam')); }, function() { addError($('#{{classApiMethodMethod}}_spam')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.spam}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Spam ">{{currikiResource_.spam}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTopOfSearchInt"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTopOfSearchInt">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Top of search int</label>
+													<label for="{{classApiMethodMethod}}_topOfSearchInt">Top of search int</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTopOfSearchInt"}}
-															</span>
-														</div>
+														{{> "inputTopOfSearchInt"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); $('#{{classApiMethodMethod}}_topOfSearchInt').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTopOfSearchInt', null, function() { addGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearchInt')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTopOfSearchInt"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}TopOfSearchInt ">{{currikiResource_.topOfSearchInt}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Top of search int"
+															id="{{classApiMethodMethod}}_topOfSearchInt"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTopOfSearchInt classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
+																name="setTopOfSearchInt"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTopOfSearchInt classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
+																name="setTopOfSearchInt"
+		{{else}}
+																class="valueTopOfSearchInt w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
+																name="topOfSearchInt"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTopOfSearchInt', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearchInt')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.topOfSearchInt}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}TopOfSearchInt ">{{currikiResource_.topOfSearchInt}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPartnerInt"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePartnerInt">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Partner Int</label>
+													<label for="{{classApiMethodMethod}}_partnerInt">Partner Int</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputPartnerInt"}}
-															</span>
-														</div>
+														{{> "inputPartnerInt"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_partnerInt')); $('#{{classApiMethodMethod}}_partnerInt').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPartnerInt', null, function() { addGlow($('#{{classApiMethodMethod}}_partnerInt')); }, function() { addError($('#{{classApiMethodMethod}}_partnerInt')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputPartnerInt"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}PartnerInt ">{{currikiResource_.partnerInt}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Partner Int"
+															id="{{classApiMethodMethod}}_partnerInt"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setPartnerInt classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
+																name="setPartnerInt"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setPartnerInt classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
+																name="setPartnerInt"
+		{{else}}
+																class="valuePartnerInt w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
+																name="partnerInt"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPartnerInt', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_partnerInt')); }, function() { addError($('#{{classApiMethodMethod}}_partnerInt')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.partnerInt}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}PartnerInt ">{{currikiResource_.partnerInt}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewResource"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewResource">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Review Resource</label>
+													<label for="{{classApiMethodMethod}}_reviewResource">Review Resource</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputReviewResource"}}
-															</span>
-														</div>
+														{{> "inputReviewResource"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewResource')); $('#{{classApiMethodMethod}}_reviewResource').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewResource', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewResource')); }, function() { addError($('#{{classApiMethodMethod}}_reviewResource')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewResource"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ReviewResource ">{{currikiResource_.reviewResource}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Review Resource"
+															id="{{classApiMethodMethod}}_reviewResource"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setReviewResource classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
+																name="setReviewResource"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setReviewResource classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
+																name="setReviewResource"
+		{{else}}
+																class="valueReviewResource w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
+																name="reviewResource"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewResource', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewResource')); }, function() { addError($('#{{classApiMethodMethod}}_reviewResource')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.reviewResource}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ReviewResource ">{{currikiResource_.reviewResource}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmOldUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceOldUrl">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Old URL</label>
+													<label for="{{classApiMethodMethod}}_oldUrl">Old URL</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputOldUrl"}}
-															</span>
-														</div>
+														{{> "inputOldUrl"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_oldUrl')); $('#{{classApiMethodMethod}}_oldUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setOldUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_oldUrl')); }, function() { addError($('#{{classApiMethodMethod}}_oldUrl')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputOldUrl"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}OldUrl ">{{currikiResource_.oldUrl}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Old URL"
+															id="{{classApiMethodMethod}}_oldUrl"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setOldUrl classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
+																name="setOldUrl"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setOldUrl classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
+																name="setOldUrl"
+		{{else}}
+																class="valueOldUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
+																name="oldUrl"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setOldUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_oldUrl')); }, function() { addError($('#{{classApiMethodMethod}}_oldUrl')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.oldUrl}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}OldUrl ">{{currikiResource_.oldUrl}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContentDisplayOk"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContentDisplayOk">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Content Display OK</label>
+													<label for="{{classApiMethodMethod}}_contentDisplayOk">Content Display OK</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputContentDisplayOk"}}
-															</span>
-														</div>
+														{{> "inputContentDisplayOk"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); $('#{{classApiMethodMethod}}_contentDisplayOk').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContentDisplayOk', null, function() { addGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); }, function() { addError($('#{{classApiMethodMethod}}_contentDisplayOk')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputContentDisplayOk"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ContentDisplayOk ">{{currikiResource_.contentDisplayOk}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Content Display OK"
+															id="{{classApiMethodMethod}}_contentDisplayOk"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setContentDisplayOk classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
+																name="setContentDisplayOk"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setContentDisplayOk classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
+																name="setContentDisplayOk"
+		{{else}}
+																class="valueContentDisplayOk w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
+																name="contentDisplayOk"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContentDisplayOk', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); }, function() { addError($('#{{classApiMethodMethod}}_contentDisplayOk')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.contentDisplayOk}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ContentDisplayOk ">{{currikiResource_.contentDisplayOk}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMetadata"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMetadata">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Metadata</label>
+													<label for="{{classApiMethodMethod}}_metadata">Metadata</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputMetadata"}}
-															</span>
-														</div>
+														{{> "inputMetadata"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_metadata')); $('#{{classApiMethodMethod}}_metadata').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMetadata', null, function() { addGlow($('#{{classApiMethodMethod}}_metadata')); }, function() { addError($('#{{classApiMethodMethod}}_metadata')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputMetadata"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Metadata ">{{currikiResource_.metadata}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Metadata"
+															id="{{classApiMethodMethod}}_metadata"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setMetadata classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
+																name="setMetadata"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setMetadata classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
+																name="setMetadata"
+		{{else}}
+																class="valueMetadata w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
+																name="metadata"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMetadata', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_metadata')); }, function() { addError($('#{{classApiMethodMethod}}_metadata')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.metadata}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Metadata ">{{currikiResource_.metadata}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmApprovalStatus"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceApprovalStatus">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Approval Status</label>
+													<label for="{{classApiMethodMethod}}_approvalStatus">Approval Status</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputApprovalStatus"}}
-															</span>
-														</div>
+														{{> "inputApprovalStatus"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_approvalStatus')); $('#{{classApiMethodMethod}}_approvalStatus').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setApprovalStatus', null, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatus')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatus')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputApprovalStatus"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ApprovalStatus ">{{currikiResource_.approvalStatus}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Approval Status"
+															id="{{classApiMethodMethod}}_approvalStatus"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setApprovalStatus classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
+																name="setApprovalStatus"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setApprovalStatus classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
+																name="setApprovalStatus"
+		{{else}}
+																class="valueApprovalStatus w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
+																name="approvalStatus"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setApprovalStatus', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_approvalStatus')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatus')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.approvalStatus}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ApprovalStatus ">{{currikiResource_.approvalStatus}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmApprovalStatusDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceApprovalStatusDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Approval Status Date</label>
+													<label for="{{classApiMethodMethod}}_approvalStatusDate">Approval Status Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputApprovalStatusDate"}}
-															</span>
-														</div>
+														{{> "inputApprovalStatusDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); $('#{{classApiMethodMethod}}_approvalStatusDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setApprovalStatusDate', null, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatusDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputApprovalStatusDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ApprovalStatusDate " title="{{formatZonedDateTime currikiResource_.approvalStatusDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.approvalStatusDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
-	{{/eq}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+																type="text"
+																class="w3-input w3-border datepicker setApprovalStatusDate classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatusDate w3-input w3-border "
+																placeholder="MM/DD/YYYY HH:MM AM"
+																data-timeformat="MM/dd/yyyy"
+																id="{{classApiMethodMethod}}_approvalStatusDate"
+																value="{{currikiResource_.approvalStatusDate}}"
+														{{#eq 'Page' classApiMethodMethod}}
+															onclick="removeGlow($(this)); ";
+															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setApprovalStatusDate', s, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatusDate')); }); } "
+														{{/eq}}
+														/>
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ApprovalStatusDate ">{{currikiResource_.approvalStatusDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSpamUser"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSpamUser">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Spam User</label>
+													<label for="{{classApiMethodMethod}}_spamUser">Spam User</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSpamUser"}}
-															</span>
-														</div>
+														{{> "inputSpamUser"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_spamUser')); $('#{{classApiMethodMethod}}_spamUser').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSpamUser', null, function() { addGlow($('#{{classApiMethodMethod}}_spamUser')); }, function() { addError($('#{{classApiMethodMethod}}_spamUser')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSpamUser"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SpamUser ">{{currikiResource_.spamUser}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Spam User"
+															id="{{classApiMethodMethod}}_spamUser"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSpamUser classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
+																name="setSpamUser"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSpamUser classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
+																name="setSpamUser"
+		{{else}}
+																class="valueSpamUser w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
+																name="spamUser"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSpamUser', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_spamUser')); }, function() { addError($('#{{classApiMethodMethod}}_spamUser')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.spamUser}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SpamUser ">{{currikiResource_.spamUser}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceUrl">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>URL</label>
+													<label for="{{classApiMethodMethod}}_url">URL</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputUrl"}}
-															</span>
-														</div>
+														{{> "inputUrl"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_url')); $('#{{classApiMethodMethod}}_url').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_url')); }, function() { addError($('#{{classApiMethodMethod}}_url')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputUrl"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Url ">{{currikiResource_.url}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="URL"
+															id="{{classApiMethodMethod}}_url"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUrl classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
+																name="setUrl"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUrl classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
+																name="setUrl"
+		{{else}}
+																class="valueUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
+																name="url"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_url')); }, function() { addError($('#{{classApiMethodMethod}}_url')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.url}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Url ">{{currikiResource_.url}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDisplaySeqNo"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDisplaySeqNo">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Display Sequence Number</label>
+													<label for="{{classApiMethodMethod}}_displaySeqNo">Display Sequence Number</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputDisplaySeqNo"}}
-															</span>
-														</div>
+														{{> "inputDisplaySeqNo"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_displaySeqNo')); $('#{{classApiMethodMethod}}_displaySeqNo').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDisplaySeqNo', null, function() { addGlow($('#{{classApiMethodMethod}}_displaySeqNo')); }, function() { addError($('#{{classApiMethodMethod}}_displaySeqNo')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputDisplaySeqNo"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}DisplaySeqNo ">{{currikiResource_.displaySeqNo}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Display Sequence Number"
+															id="{{classApiMethodMethod}}_displaySeqNo"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setDisplaySeqNo classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
+																name="setDisplaySeqNo"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setDisplaySeqNo classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
+																name="setDisplaySeqNo"
+		{{else}}
+																class="valueDisplaySeqNo w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
+																name="displaySeqNo"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDisplaySeqNo', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_displaySeqNo')); }, function() { addError($('#{{classApiMethodMethod}}_displaySeqNo')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.displaySeqNo}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}DisplaySeqNo ">{{currikiResource_.displaySeqNo}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmFileId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceFileId">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>File ID</label>
+													<label for="{{classApiMethodMethod}}_fileId">File ID</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputFileId"}}
-															</span>
-														</div>
+														{{> "inputFileId"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_fileId')); $('#{{classApiMethodMethod}}_fileId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setFileId', null, function() { addGlow($('#{{classApiMethodMethod}}_fileId')); }, function() { addError($('#{{classApiMethodMethod}}_fileId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputFileId"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}FileId ">{{currikiResource_.fileId}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="File ID"
+															id="{{classApiMethodMethod}}_fileId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setFileId classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
+																name="setFileId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setFileId classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
+																name="setFileId"
+		{{else}}
+																class="valueFileId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
+																name="fileId"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setFileId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_fileId')); }, function() { addError($('#{{classApiMethodMethod}}_fileId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.fileId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}FileId ">{{currikiResource_.fileId}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmFileName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceFileName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Filename</label>
+													<label for="{{classApiMethodMethod}}_fileName">Filename</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputFileName"}}
-															</span>
-														</div>
+														{{> "inputFileName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_fileName')); $('#{{classApiMethodMethod}}_fileName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setFileName', null, function() { addGlow($('#{{classApiMethodMethod}}_fileName')); }, function() { addError($('#{{classApiMethodMethod}}_fileName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputFileName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}FileName ">{{currikiResource_.fileName}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Filename"
+															id="{{classApiMethodMethod}}_fileName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setFileName classCurrikiResource inputCurrikiResource{{pk}}FileName w3-input w3-border "
+																name="setFileName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setFileName classCurrikiResource inputCurrikiResource{{pk}}FileName w3-input w3-border "
+																name="setFileName"
+		{{else}}
+																class="valueFileName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}FileName w3-input w3-border "
+																name="fileName"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setFileName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_fileName')); }, function() { addError($('#{{classApiMethodMethod}}_fileName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.fileName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}FileName ">{{currikiResource_.fileName}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmUploadDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceUploadDate">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Upload Date</label>
+													<label for="{{classApiMethodMethod}}_uploadDate">Upload Date</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputUploadDate"}}
-															</span>
-														</div>
+														{{> "inputUploadDate"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_uploadDate')); $('#{{classApiMethodMethod}}_uploadDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setUploadDate', null, function() { addGlow($('#{{classApiMethodMethod}}_uploadDate')); }, function() { addError($('#{{classApiMethodMethod}}_uploadDate')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputUploadDate"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}UploadDate ">{{currikiResource_.uploadDate}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Upload Date"
+															id="{{classApiMethodMethod}}_uploadDate"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUploadDate classCurrikiResource inputCurrikiResource{{pk}}UploadDate w3-input w3-border "
+																name="setUploadDate"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUploadDate classCurrikiResource inputCurrikiResource{{pk}}UploadDate w3-input w3-border "
+																name="setUploadDate"
+		{{else}}
+																class="valueUploadDate w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}UploadDate w3-input w3-border "
+																name="uploadDate"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUploadDate', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_uploadDate')); }, function() { addError($('#{{classApiMethodMethod}}_uploadDate')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.uploadDate}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}UploadDate ">{{currikiResource_.uploadDate}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSequence"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSequence">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Sequence</label>
+													<label for="{{classApiMethodMethod}}_sequence">Sequence</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSequence"}}
-															</span>
-														</div>
+														{{> "inputSequence"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_sequence')); $('#{{classApiMethodMethod}}_sequence').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSequence', null, function() { addGlow($('#{{classApiMethodMethod}}_sequence')); }, function() { addError($('#{{classApiMethodMethod}}_sequence')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSequence"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Sequence ">{{currikiResource_.sequence}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Sequence"
+															id="{{classApiMethodMethod}}_sequence"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSequence classCurrikiResource inputCurrikiResource{{pk}}Sequence w3-input w3-border "
+																name="setSequence"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSequence classCurrikiResource inputCurrikiResource{{pk}}Sequence w3-input w3-border "
+																name="setSequence"
+		{{else}}
+																class="valueSequence w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Sequence w3-input w3-border "
+																name="sequence"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSequence', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_sequence')); }, function() { addError($('#{{classApiMethodMethod}}_sequence')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.sequence}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Sequence ">{{currikiResource_.sequence}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmUniqueName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceUniqueName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Unique Name</label>
+													<label for="{{classApiMethodMethod}}_uniqueName">Unique Name</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputUniqueName"}}
-															</span>
-														</div>
+														{{> "inputUniqueName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_uniqueName')); $('#{{classApiMethodMethod}}_uniqueName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setUniqueName', null, function() { addGlow($('#{{classApiMethodMethod}}_uniqueName')); }, function() { addError($('#{{classApiMethodMethod}}_uniqueName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputUniqueName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}UniqueName ">{{currikiResource_.uniqueName}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Unique Name"
+															id="{{classApiMethodMethod}}_uniqueName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUniqueName classCurrikiResource inputCurrikiResource{{pk}}UniqueName w3-input w3-border "
+																name="setUniqueName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUniqueName classCurrikiResource inputCurrikiResource{{pk}}UniqueName w3-input w3-border "
+																name="setUniqueName"
+		{{else}}
+																class="valueUniqueName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}UniqueName w3-input w3-border "
+																name="uniqueName"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUniqueName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_uniqueName')); }, function() { addError($('#{{classApiMethodMethod}}_uniqueName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.uniqueName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}UniqueName ">{{currikiResource_.uniqueName}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmExt"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceExt">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Ext</label>
+													<label for="{{classApiMethodMethod}}_ext">Ext</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputExt"}}
-															</span>
-														</div>
+														{{> "inputExt"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_ext')); $('#{{classApiMethodMethod}}_ext').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setExt', null, function() { addGlow($('#{{classApiMethodMethod}}_ext')); }, function() { addError($('#{{classApiMethodMethod}}_ext')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputExt"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Ext ">{{currikiResource_.ext}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Ext"
+															id="{{classApiMethodMethod}}_ext"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setExt classCurrikiResource inputCurrikiResource{{pk}}Ext w3-input w3-border "
+																name="setExt"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setExt classCurrikiResource inputCurrikiResource{{pk}}Ext w3-input w3-border "
+																name="setExt"
+		{{else}}
+																class="valueExt w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Ext w3-input w3-border "
+																name="ext"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setExt', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_ext')); }, function() { addError($('#{{classApiMethodMethod}}_ext')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.ext}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Ext ">{{currikiResource_.ext}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceFilesActive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceFilesActive">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Resource Files Active</label>
+													<label for="{{classApiMethodMethod}}_resourceFilesActive">Resource Files Active</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputResourceFilesActive"}}
-															</span>
-														</div>
+														{{> "inputResourceFilesActive"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceFilesActive')); $('#{{classApiMethodMethod}}_resourceFilesActive').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceFilesActive', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceFilesActive')); }, function() { addError($('#{{classApiMethodMethod}}_resourceFilesActive')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceFilesActive"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}ResourceFilesActive ">{{currikiResource_.resourceFilesActive}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Resource Files Active"
+															id="{{classApiMethodMethod}}_resourceFilesActive"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setResourceFilesActive classCurrikiResource inputCurrikiResource{{pk}}ResourceFilesActive w3-input w3-border "
+																name="setResourceFilesActive"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setResourceFilesActive classCurrikiResource inputCurrikiResource{{pk}}ResourceFilesActive w3-input w3-border "
+																name="setResourceFilesActive"
+		{{else}}
+																class="valueResourceFilesActive w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceFilesActive w3-input w3-border "
+																name="resourceFilesActive"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceFilesActive', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceFilesActive')); }, function() { addError($('#{{classApiMethodMethod}}_resourceFilesActive')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.resourceFilesActive}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}ResourceFilesActive ">{{currikiResource_.resourceFilesActive}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTempactive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTempactive">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Tempactive</label>
+													<label for="{{classApiMethodMethod}}_tempactive">Tempactive</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTempactive"}}
-															</span>
-														</div>
+														{{> "inputTempactive"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_tempactive')); $('#{{classApiMethodMethod}}_tempactive').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTempactive', null, function() { addGlow($('#{{classApiMethodMethod}}_tempactive')); }, function() { addError($('#{{classApiMethodMethod}}_tempactive')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTempactive"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Tempactive ">{{currikiResource_.tempactive}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Tempactive"
+															id="{{classApiMethodMethod}}_tempactive"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTempactive classCurrikiResource inputCurrikiResource{{pk}}Tempactive w3-input w3-border "
+																name="setTempactive"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTempactive classCurrikiResource inputCurrikiResource{{pk}}Tempactive w3-input w3-border "
+																name="setTempactive"
+		{{else}}
+																class="valueTempactive w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Tempactive w3-input w3-border "
+																name="tempactive"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTempactive', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_tempactive')); }, function() { addError($('#{{classApiMethodMethod}}_tempactive')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.tempactive}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Tempactive ">{{currikiResource_.tempactive}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmS3path"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceS3path">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>S3 Path</label>
+													<label for="{{classApiMethodMethod}}_s3path">S3 Path</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputS3path"}}
-															</span>
-														</div>
+														{{> "inputS3path"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_s3path')); $('#{{classApiMethodMethod}}_s3path').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setS3path', null, function() { addGlow($('#{{classApiMethodMethod}}_s3path')); }, function() { addError($('#{{classApiMethodMethod}}_s3path')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputS3path"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}S3path ">{{currikiResource_.s3path}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="S3 Path"
+															id="{{classApiMethodMethod}}_s3path"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setS3path classCurrikiResource inputCurrikiResource{{pk}}S3path w3-input w3-border "
+																name="setS3path"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setS3path classCurrikiResource inputCurrikiResource{{pk}}S3path w3-input w3-border "
+																name="setS3path"
+		{{else}}
+																class="valueS3path w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}S3path w3-input w3-border "
+																name="s3path"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setS3path', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_s3path')); }, function() { addError($('#{{classApiMethodMethod}}_s3path')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.s3path}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}S3path ">{{currikiResource_.s3path}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSdfStatus"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSdfStatus">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>SDF Status</label>
+													<label for="{{classApiMethodMethod}}_sdfStatus">SDF Status</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSdfStatus"}}
-															</span>
-														</div>
+														{{> "inputSdfStatus"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_sdfStatus')); $('#{{classApiMethodMethod}}_sdfStatus').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSdfStatus', null, function() { addGlow($('#{{classApiMethodMethod}}_sdfStatus')); }, function() { addError($('#{{classApiMethodMethod}}_sdfStatus')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSdfStatus"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SdfStatus ">{{currikiResource_.sdfStatus}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="SDF Status"
+															id="{{classApiMethodMethod}}_sdfStatus"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSdfStatus classCurrikiResource inputCurrikiResource{{pk}}SdfStatus w3-input w3-border "
+																name="setSdfStatus"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSdfStatus classCurrikiResource inputCurrikiResource{{pk}}SdfStatus w3-input w3-border "
+																name="setSdfStatus"
+		{{else}}
+																class="valueSdfStatus w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SdfStatus w3-input w3-border "
+																name="sdfStatus"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSdfStatus', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_sdfStatus')); }, function() { addError($('#{{classApiMethodMethod}}_sdfStatus')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.sdfStatus}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SdfStatus ">{{currikiResource_.sdfStatus}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTranscoded"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTranscoded">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Transcoded</label>
+													<label for="{{classApiMethodMethod}}_transcoded">Transcoded</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputTranscoded"}}
-															</span>
-														</div>
+														{{> "inputTranscoded"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_transcoded')); $('#{{classApiMethodMethod}}_transcoded').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTranscoded', null, function() { addGlow($('#{{classApiMethodMethod}}_transcoded')); }, function() { addError($('#{{classApiMethodMethod}}_transcoded')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputTranscoded"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Transcoded ">{{currikiResource_.transcoded}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Transcoded"
+															id="{{classApiMethodMethod}}_transcoded"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setTranscoded classCurrikiResource inputCurrikiResource{{pk}}Transcoded w3-input w3-border "
+																name="setTranscoded"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setTranscoded classCurrikiResource inputCurrikiResource{{pk}}Transcoded w3-input w3-border "
+																name="setTranscoded"
+		{{else}}
+																class="valueTranscoded w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Transcoded w3-input w3-border "
+																name="transcoded"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTranscoded', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_transcoded')); }, function() { addError($('#{{classApiMethodMethod}}_transcoded')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.transcoded}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Transcoded ">{{currikiResource_.transcoded}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLodestar"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLodestar">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Lodestar</label>
+													<label for="{{classApiMethodMethod}}_lodestar">Lodestar</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputLodestar"}}
-															</span>
-														</div>
+														{{> "inputLodestar"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_lodestar')); $('#{{classApiMethodMethod}}_lodestar').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLodestar', null, function() { addGlow($('#{{classApiMethodMethod}}_lodestar')); }, function() { addError($('#{{classApiMethodMethod}}_lodestar')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputLodestar"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Lodestar ">{{currikiResource_.lodestar}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Lodestar"
+															id="{{classApiMethodMethod}}_lodestar"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setLodestar classCurrikiResource inputCurrikiResource{{pk}}Lodestar w3-input w3-border "
+																name="setLodestar"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setLodestar classCurrikiResource inputCurrikiResource{{pk}}Lodestar w3-input w3-border "
+																name="setLodestar"
+		{{else}}
+																class="valueLodestar w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Lodestar w3-input w3-border "
+																name="lodestar"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLodestar', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_lodestar')); }, function() { addError($('#{{classApiMethodMethod}}_lodestar')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.lodestar}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Lodestar ">{{currikiResource_.lodestar}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmArchive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceArchive">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Archive</label>
+													<label for="{{classApiMethodMethod}}_archive">Archive</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputArchive"}}
-															</span>
-														</div>
+														{{> "inputArchive"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_archive')); $('#{{classApiMethodMethod}}_archive').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setArchive', null, function() { addGlow($('#{{classApiMethodMethod}}_archive')); }, function() { addError($('#{{classApiMethodMethod}}_archive')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputArchive"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Archive ">{{currikiResource_.archive}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Archive"
+															id="{{classApiMethodMethod}}_archive"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setArchive classCurrikiResource inputCurrikiResource{{pk}}Archive w3-input w3-border "
+																name="setArchive"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setArchive classCurrikiResource inputCurrikiResource{{pk}}Archive w3-input w3-border "
+																name="setArchive"
+		{{else}}
+																class="valueArchive w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Archive w3-input w3-border "
+																name="archive"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setArchive', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_archive')); }, function() { addError($('#{{classApiMethodMethod}}_archive')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.archive}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Archive ">{{currikiResource_.archive}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIdentifier"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIdentifier">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Identifier</label>
+													<label for="{{classApiMethodMethod}}_identifier">Identifier</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputIdentifier"}}
-															</span>
-														</div>
+														{{> "inputIdentifier"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_identifier')); $('#{{classApiMethodMethod}}_identifier').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIdentifier', null, function() { addGlow($('#{{classApiMethodMethod}}_identifier')); }, function() { addError($('#{{classApiMethodMethod}}_identifier')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputIdentifier"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Identifier ">{{currikiResource_.identifier}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Identifier"
+															id="{{classApiMethodMethod}}_identifier"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setIdentifier classCurrikiResource inputCurrikiResource{{pk}}Identifier w3-input w3-border "
+																name="setIdentifier"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setIdentifier classCurrikiResource inputCurrikiResource{{pk}}Identifier w3-input w3-border "
+																name="setIdentifier"
+		{{else}}
+																class="valueIdentifier w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Identifier w3-input w3-border "
+																name="identifier"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIdentifier', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_identifier')); }, function() { addError($('#{{classApiMethodMethod}}_identifier')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.identifier}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Identifier ">{{currikiResource_.identifier}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmEducationLevelDisplayName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceEducationLevelDisplayName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Education Level Display Name</label>
+													<label for="{{classApiMethodMethod}}_educationLevelDisplayName">Education Level Display Name</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputEducationLevelDisplayName"}}
-															</span>
-														</div>
+														{{> "inputEducationLevelDisplayName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_educationLevelDisplayName')); $('#{{classApiMethodMethod}}_educationLevelDisplayName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setEducationLevelDisplayName', null, function() { addGlow($('#{{classApiMethodMethod}}_educationLevelDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_educationLevelDisplayName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputEducationLevelDisplayName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}EducationLevelDisplayName ">{{currikiResource_.educationLevelDisplayName}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Education Level Display Name"
+															id="{{classApiMethodMethod}}_educationLevelDisplayName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setEducationLevelDisplayName classCurrikiResource inputCurrikiResource{{pk}}EducationLevelDisplayName w3-input w3-border "
+																name="setEducationLevelDisplayName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setEducationLevelDisplayName classCurrikiResource inputCurrikiResource{{pk}}EducationLevelDisplayName w3-input w3-border "
+																name="setEducationLevelDisplayName"
+		{{else}}
+																class="valueEducationLevelDisplayName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}EducationLevelDisplayName w3-input w3-border "
+																name="educationLevelDisplayName"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setEducationLevelDisplayName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_educationLevelDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_educationLevelDisplayName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.educationLevelDisplayName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}EducationLevelDisplayName ">{{currikiResource_.educationLevelDisplayName}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectArea"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectArea">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Subject Area</label>
+													<label for="{{classApiMethodMethod}}_subjectArea">Subject Area</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSubjectArea"}}
-															</span>
-														</div>
+														{{> "inputSubjectArea"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectArea')); $('#{{classApiMethodMethod}}_subjectArea').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectArea', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectArea')); }, function() { addError($('#{{classApiMethodMethod}}_subjectArea')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectArea"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SubjectArea ">{{currikiResource_.subjectArea}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Subject Area"
+															id="{{classApiMethodMethod}}_subjectArea"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSubjectArea classCurrikiResource inputCurrikiResource{{pk}}SubjectArea w3-input w3-border "
+																name="setSubjectArea"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSubjectArea classCurrikiResource inputCurrikiResource{{pk}}SubjectArea w3-input w3-border "
+																name="setSubjectArea"
+		{{else}}
+																class="valueSubjectArea w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectArea w3-input w3-border "
+																name="subjectArea"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectArea', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectArea')); }, function() { addError($('#{{classApiMethodMethod}}_subjectArea')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.subjectArea}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SubjectArea ">{{currikiResource_.subjectArea}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectAreaDisplayName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectAreaDisplayName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Subject Area Display Name</label>
+													<label for="{{classApiMethodMethod}}_subjectAreaDisplayName">Subject Area Display Name</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSubjectAreaDisplayName"}}
-															</span>
-														</div>
+														{{> "inputSubjectAreaDisplayName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectAreaDisplayName')); $('#{{classApiMethodMethod}}_subjectAreaDisplayName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectAreaDisplayName', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectAreaDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_subjectAreaDisplayName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectAreaDisplayName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}SubjectAreaDisplayName ">{{currikiResource_.subjectAreaDisplayName}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Subject Area Display Name"
+															id="{{classApiMethodMethod}}_subjectAreaDisplayName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setSubjectAreaDisplayName classCurrikiResource inputCurrikiResource{{pk}}SubjectAreaDisplayName w3-input w3-border "
+																name="setSubjectAreaDisplayName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setSubjectAreaDisplayName classCurrikiResource inputCurrikiResource{{pk}}SubjectAreaDisplayName w3-input w3-border "
+																name="setSubjectAreaDisplayName"
+		{{else}}
+																class="valueSubjectAreaDisplayName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectAreaDisplayName w3-input w3-border "
+																name="subjectAreaDisplayName"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectAreaDisplayName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectAreaDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_subjectAreaDisplayName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.subjectAreaDisplayName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}SubjectAreaDisplayName ">{{currikiResource_.subjectAreaDisplayName}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInstructionTypeDisplayName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInstructionTypeDisplayName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Instruction Type Display Name</label>
+													<label for="{{classApiMethodMethod}}_instructionTypeDisplayName">Instruction Type Display Name</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputInstructionTypeDisplayName"}}
-															</span>
-														</div>
+														{{> "inputInstructionTypeDisplayName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_instructionTypeDisplayName')); $('#{{classApiMethodMethod}}_instructionTypeDisplayName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInstructionTypeDisplayName', null, function() { addGlow($('#{{classApiMethodMethod}}_instructionTypeDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_instructionTypeDisplayName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputInstructionTypeDisplayName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}InstructionTypeDisplayName ">{{currikiResource_.instructionTypeDisplayName}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Instruction Type Display Name"
+															id="{{classApiMethodMethod}}_instructionTypeDisplayName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setInstructionTypeDisplayName classCurrikiResource inputCurrikiResource{{pk}}InstructionTypeDisplayName w3-input w3-border "
+																name="setInstructionTypeDisplayName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setInstructionTypeDisplayName classCurrikiResource inputCurrikiResource{{pk}}InstructionTypeDisplayName w3-input w3-border "
+																name="setInstructionTypeDisplayName"
+		{{else}}
+																class="valueInstructionTypeDisplayName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InstructionTypeDisplayName w3-input w3-border "
+																name="instructionTypeDisplayName"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInstructionTypeDisplayName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_instructionTypeDisplayName')); }, function() { addError($('#{{classApiMethodMethod}}_instructionTypeDisplayName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.instructionTypeDisplayName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}InstructionTypeDisplayName ">{{currikiResource_.instructionTypeDisplayName}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}CurrikiResourceName">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Name</label>
+													<label for="{{classApiMethodMethod}}_name">Name</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputName"}}
-															</span>
-														</div>
+														{{> "inputName"}}
 													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_name')); $('#{{classApiMethodMethod}}_name').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setName', null, function() { addGlow($('#{{classApiMethodMethod}}_name')); }, function() { addError($('#{{classApiMethodMethod}}_name')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputName"}}
-	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}Name ">{{currikiResource_.name}}</span>
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															placeholder="Name"
+															id="{{classApiMethodMethod}}_name"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setName classCurrikiResource inputCurrikiResource{{pk}}Name w3-input w3-border "
+																name="setName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setName classCurrikiResource inputCurrikiResource{{pk}}Name w3-input w3-border "
+																name="setName"
+		{{else}}
+																class="valueName w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Name w3-input w3-border "
+																name="name"
+		{{/eq}}
 	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_name')); }, function() { addError($('#{{classApiMethodMethod}}_name')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{currikiResource_.name}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+														{{#ifContainsKeys userKeys}}
+															<span class="varCurrikiResource{{pk}}Name ">{{currikiResource_.name}}</span>
+			{{/ifContainsKeys}}
+		{{/ifContainsAnyRoles}}
 {{/inline}}

--- a/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
+++ b/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
@@ -422,6 +422,7 @@
 							<div class="w3-cell-row ">
 {{> "htmUniqueName" classApiMethodMethod="Page"}}
 {{> "htmExt" classApiMethodMethod="Page"}}
+{{> "htmResourceFilesActive" classApiMethodMethod="Page"}}
 							</div>
 							<div class="w3-cell-row ">
 {{> "htmTempactive" classApiMethodMethod="Page"}}
@@ -435,10 +436,12 @@
 							</div>
 							<div class="w3-cell-row ">
 {{> "htmIdentifier" classApiMethodMethod="Page"}}
-{{> "htmDisplayName" classApiMethodMethod="Page"}}
+{{> "htmEducationLevelDisplayName" classApiMethodMethod="Page"}}
 {{> "htmSubjectArea" classApiMethodMethod="Page"}}
 							</div>
 							<div class="w3-cell-row ">
+{{> "htmSubjectAreaDisplayName" classApiMethodMethod="Page"}}
+{{> "htmInstructionTypeDisplayName" classApiMethodMethod="Page"}}
 {{> "htmName" classApiMethodMethod="Page"}}
 							</div>
 						</div>
@@ -3072,6 +3075,35 @@
 	{{/eq}}
 {{/inline}}
 
+{{#*inline "htmResourceFilesActive"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Resource Files Active</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceFilesActive"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputResourceFilesActive"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceFilesActive ">{{currikiResource_.resourceFilesActive}}</span>
+	{{/eq}}
+{{/inline}}
+
 {{#*inline "htmTempactive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
 									{{#eq 'Page' classApiMethodMethod}}
@@ -3275,19 +3307,19 @@
 	{{/eq}}
 {{/inline}}
 
-{{#*inline "htmDisplayName"}}
+{{#*inline "htmEducationLevelDisplayName"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
 									{{#eq 'Page' classApiMethodMethod}}
 										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label>Display Name</label>
+													<label>Education Level Display Name</label>
 												</div>
 												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
 														<div class="w3-rest ">
 															<span class="">
-																{{> "inputDisplayName"}}
+																{{> "inputEducationLevelDisplayName"}}
 															</span>
 														</div>
 													</div>
@@ -3298,9 +3330,9 @@
 								</div>
 {{/inline}}
 
-{{#*inline "inputDisplayName"}}
+{{#*inline "inputEducationLevelDisplayName"}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varCurrikiResource{{pk}}DisplayName ">{{currikiResource_.displayName}}</span>
+														<span class="varCurrikiResource{{pk}}EducationLevelDisplayName ">{{currikiResource_.educationLevelDisplayName}}</span>
 	{{/eq}}
 {{/inline}}
 
@@ -3330,6 +3362,64 @@
 {{#*inline "inputSubjectArea"}}
 	{{#eq 'Page' classApiMethodMethod}}
 														<span class="varCurrikiResource{{pk}}SubjectArea ">{{currikiResource_.subjectArea}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmSubjectAreaDisplayName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Subject Area Display Name</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSubjectAreaDisplayName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputSubjectAreaDisplayName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SubjectAreaDisplayName ">{{currikiResource_.subjectAreaDisplayName}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmInstructionTypeDisplayName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Instruction Type Display Name</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputInstructionTypeDisplayName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputInstructionTypeDisplayName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}InstructionTypeDisplayName ">{{currikiResource_.instructionTypeDisplayName}}</span>
 	{{/eq}}
 {{/inline}}
 

--- a/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
+++ b/src/main/resources/templates/enUS/CurrikiResourceGenPage.hbs
@@ -26,145 +26,16 @@
 				if(pk != null) {
 				}
 				websocketCurrikiResource(websocketCurrikiResourceInner);
-				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
-				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlCurrikiResource"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadCurrikiResourcePage"}}{{> "htmTitleCurrikiResourcePage"}}{{> "htmMetaCurrikiResourcePage"}}{{> "htmStyleCurrikiResourcePage"}}{{> "htmScriptsCurrikiResourcePage"}}{{> "htmScriptCurrikiResourcePage"}}{{/inline}}
-{{#*inline "htmBodySearchCurrikiResourcePage"}}		<!-- #*inline "htmBodySearchCurrikiResourcePage" -->
-	<div>
-{{#each varsQ}}
-		<div class="w3-padding ">
-			<label for="fqCurrikiResource_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<input id="fqCurrikiResource_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
-			<div class="pageSearchVal w3-tiny "></div>
-		</div>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyFiltersCurrikiResourcePage"}}		<!-- #*inline "htmBodyFiltersCurrikiResourcePage" -->
-	<div>
-{{#each varsFq }}
-		<div class="w3-padding ">
-			<label for="fqCurrikiResource_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<div class="w3-cell-row ">
-				<div class="w3-cell w3-cell-top ">
-					<button id="buttonFacetCurrikiResource_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
-				</div>
-				<div class="w3-cell w3-cell-top ">
-					<input id="fqCurrikiResource_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
-				</div>
-			</div>
-		</div>
-		<div class="w3-padding w3-tiny ">
-			<div class="pageSearchVal " id="pageSearchVal-fqCurrikiResource_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
-			<div class="pageSearchVal " id="pageSearchVal-buttonFacetCurrikiResource_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
-		</div>
-		<ol class="pageFacetField " id="pageFacetFieldCurrikiResource_{{ @key }}">
-{{#each facetField.counts }}
-			<li class="">{{ @key }}: {{ this }}</li>
-{{/each}}
-		</ol>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyRangeCurrikiResourcePage"}}		<!-- #*inline "htmBodyRangeCurrikiResourcePage" -->
-	<table class="w3-padding ">
-		<tr>			<td class="w3-padding w3-tiny " colspan="2">
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-CurrikiResource">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-CurrikiResource">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-CurrikiResource">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-CurrikiResource">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-		<tr class="">
-			<td class="">
-			<span>Range Gap</span>
-			</td>
-			<td class="">
-				<select
- name="facet.range.gap" id="pageFacetRangeGap-CurrikiResource" onchange="facetRangeChange(this, 'CurrikiResource'); ">
-					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
-					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
-					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
-					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
-					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
-					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
-					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
-				</select>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range Start</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-CurrikiResource" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range End</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2"
-			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-CurrikiResource" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-{{#each varsRange }}
-		<tr class="">
-			<td class="">
-				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeCurrikiResource_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'CurrikiResource'); "/></span>
-			</td>
-			<td class="">
-			<label for="pageFacetRangeCurrikiResource_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{#*inline "htmBodyPivotCurrikiResourcePage"}}		<!-- #*inline "htmBodyPivotCurrikiResourcePage" -->
-		<div class="w3-padding w3-tiny " id="pageSearchVal-pivotCurrikiResource">
-{{#if defaultPivotVars }}
-			<div class="pageSearchVal " id="pageSearchVal-pivotCurrikiResource">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
-{{/if}}
-		</div>
-		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenCurrikiResource">
-{{#each defaultPivotVars }}
-			<div class="pageSearchVal pageSearchVal-hiddenCurrikiResource " id="pageSearchVal-hiddenCurrikiResource_{{ this }}">{{ this }}</div>
-{{/each}}
-		</div>
-	<table class="w3-table ">
-{{#each varsFq }}
-		<tr class="">
-			<td class="">
-				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotCurrikiResource_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'CurrikiResource'); "/></span>
-			</td>
-			<td class="w3-cell ">
-			<label for="pageFacetPivotCurrikiResource_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{/inline}}
-{{/inline}}
-{{#*inline "htmBodyMenuCurrikiResourcePage"}}		<!-- #*inline "htmBodyMenuCurrikiResourcePage" -->
-{{> "htmBodyMenuBaseModelPage"}}{{/inline}}
-{{#*inline "htmBodyGraphCurrikiResourcePage"}}		<!-- #*inline "htmBodyGraphCurrikiResourcePage" -->
-<div id="htmBodyGraphBaseModelPage" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0CurrikiResourcePage"}}		<!-- #*inline "htmBodyCount0CurrikiResourcePage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+					<i class="contextIconCssClasses site-menu-icon "></i>
 				{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -172,7 +43,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-blue">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
+					<i class="contextIconCssClasses + " site-menu-icon "></i>
 				{{/if}}
 				<span class="">no resource found</span>
 			</span>
@@ -182,7 +53,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3-blue w3-hover-blue">
 			{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses site-menu-icon "></i>
 			{{/if}}
 				<span class="">resource</span>
 			</a>
@@ -192,12 +63,13 @@
 				<span class="">{{currikiResource_.objectTitle}}</span>
 			</span>
 		</h2>
+{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1CurrikiResourcePage"}}		<!-- #*inline "htmBodyCount1CurrikiResourcePage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -235,7 +107,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-blue w3-hover-blue">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class="">resources</span>
 			</a>
@@ -271,18 +143,14 @@
 {{> "table1CurrikiResourcePage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormCurrikiResourcePage"}}
+{{#*inline "htmFormCurrikiResourcePage"}}	{{#if pk}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="CurrikiResourceForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
-{{#if id}}
+		<form action="" id="CurrikiResourceForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
-{{/if}}
 			<input name="focusId" type="hidden"/>
-			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
-{{#if id}}
 {{#block "htmForm_searchpageCurrikiResource"}}{{/block}}
-{{/if}}
+	{{/if}}
 {{/inline}}
 {{#*inline "htmFormCurrikiResourcePage_patchCurrikiResource"}}
 		<button
@@ -292,7 +160,7 @@
 			<i class="fas fa-edit "></i>
 			Modify resources
 		</button>
-		<div id="patchCurrikiResourceModal" class="w3-modal ">
+		<div id="patchCurrikiResourceModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -308,140 +176,6 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="PATCH"}}
 {{> "htmDeleted" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceId" classApiMethodMethod="PATCH"}}
-{{> "htmLicenseId" classApiMethodMethod="PATCH"}}
-{{> "htmContributorId" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmContributionDate" classApiMethodMethod="PATCH"}}
-{{> "htmDescription" classApiMethodMethod="PATCH"}}
-{{> "htmTitle" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmKeywordsStr" classApiMethodMethod="PATCH"}}
-{{> "htmGeneratedKeywordsStr" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLanguage" classApiMethodMethod="PATCH"}}
-{{> "htmLastEditorId" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLastEditDate" classApiMethodMethod="PATCH"}}
-{{> "htmCurrikiLicense" classApiMethodMethod="PATCH"}}
-{{> "htmExternalUrl" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceChecked" classApiMethodMethod="PATCH"}}
-{{> "htmContent" classApiMethodMethod="PATCH"}}
-{{> "htmResourceCheckRequestNote" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceCheckDate" classApiMethodMethod="PATCH"}}
-{{> "htmResourceCheckId" classApiMethodMethod="PATCH"}}
-{{> "htmResourceCheckNote" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmStudentFacing" classApiMethodMethod="PATCH"}}
-{{> "htmSource" classApiMethodMethod="PATCH"}}
-{{> "htmReviewStatus" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLastReviewDate" classApiMethodMethod="PATCH"}}
-{{> "htmReviewByID" classApiMethodMethod="PATCH"}}
-{{> "htmReviewRating" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmTechnicalCompleteness" classApiMethodMethod="PATCH"}}
-{{> "htmContentAccuracy" classApiMethodMethod="PATCH"}}
-{{> "htmPedagogy" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRatingComment" classApiMethodMethod="PATCH"}}
-{{> "htmStandardsAlignment" classApiMethodMethod="PATCH"}}
-{{> "htmStandardsAlignmentComment" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSubjectMatter" classApiMethodMethod="PATCH"}}
-{{> "htmSubjectMatterComment" classApiMethodMethod="PATCH"}}
-{{> "htmSupportsTeaching" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSupportsTeachingComment" classApiMethodMethod="PATCH"}}
-{{> "htmAssessmentsQuality" classApiMethodMethod="PATCH"}}
-{{> "htmAssessmentsQualityComment" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmInteractivityQuality" classApiMethodMethod="PATCH"}}
-{{> "htmInteractivityQualityComment" classApiMethodMethod="PATCH"}}
-{{> "htmInstructionalQuality" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmInstructionalQualityComment" classApiMethodMethod="PATCH"}}
-{{> "htmDeeperLearning" classApiMethodMethod="PATCH"}}
-{{> "htmDeeperLearningComment" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPartner" classApiMethodMethod="PATCH"}}
-{{> "htmCreateDate" classApiMethodMethod="PATCH"}}
-{{> "htmType" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmFeatured" classApiMethodMethod="PATCH"}}
-{{> "htmPage" classApiMethodMethod="PATCH"}}
-{{> "htmActive" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPublic" classApiMethodMethod="PATCH"}}
-{{> "htmXwd_id" classApiMethodMethod="PATCH"}}
-{{> "htmMediaType" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmAccess" classApiMethodMethod="PATCH"}}
-{{> "htmMemberRating" classApiMethodMethod="PATCH"}}
-{{> "htmAligned" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPageUrl" classApiMethodMethod="PATCH"}}
-{{> "htmIndexed" classApiMethodMethod="PATCH"}}
-{{> "htmLastIndexDate" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmIndexRequired" classApiMethodMethod="PATCH"}}
-{{> "htmIndexRequiredDate" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRescrape" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmGoButton" classApiMethodMethod="PATCH"}}
-{{> "htmDownloadButton" classApiMethodMethod="PATCH"}}
-{{> "htmTopOfSearch" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRemove" classApiMethodMethod="PATCH"}}
-{{> "htmSpam" classApiMethodMethod="PATCH"}}
-{{> "htmTopOfSearchInt" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPartnerInt" classApiMethodMethod="PATCH"}}
-{{> "htmReviewResource" classApiMethodMethod="PATCH"}}
-{{> "htmOldUrl" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmContentDisplayOk" classApiMethodMethod="PATCH"}}
-{{> "htmMetadata" classApiMethodMethod="PATCH"}}
-{{> "htmApprovalStatus" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmApprovalStatusDate" classApiMethodMethod="PATCH"}}
-{{> "htmSpamUser" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmUrl" classApiMethodMethod="PATCH"}}
-{{> "htmDisplaySeqNo" classApiMethodMethod="PATCH"}}
-{{> "htmFileId" classApiMethodMethod="PATCH"}}
 							</div>
 						<button
 							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-blue "
@@ -460,7 +194,7 @@
 			<i class="fas fa-file-plus "></i>
 			Create a resource
 		</button>
-		<div id="postCurrikiResourceModal" class="w3-modal ">
+		<div id="postCurrikiResourceModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -477,140 +211,6 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="POST"}}
 {{> "htmDeleted" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceId" classApiMethodMethod="POST"}}
-{{> "htmLicenseId" classApiMethodMethod="POST"}}
-{{> "htmContributorId" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmContributionDate" classApiMethodMethod="POST"}}
-{{> "htmDescription" classApiMethodMethod="POST"}}
-{{> "htmTitle" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmKeywordsStr" classApiMethodMethod="POST"}}
-{{> "htmGeneratedKeywordsStr" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLanguage" classApiMethodMethod="POST"}}
-{{> "htmLastEditorId" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLastEditDate" classApiMethodMethod="POST"}}
-{{> "htmCurrikiLicense" classApiMethodMethod="POST"}}
-{{> "htmExternalUrl" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceChecked" classApiMethodMethod="POST"}}
-{{> "htmContent" classApiMethodMethod="POST"}}
-{{> "htmResourceCheckRequestNote" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmResourceCheckDate" classApiMethodMethod="POST"}}
-{{> "htmResourceCheckId" classApiMethodMethod="POST"}}
-{{> "htmResourceCheckNote" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmStudentFacing" classApiMethodMethod="POST"}}
-{{> "htmSource" classApiMethodMethod="POST"}}
-{{> "htmReviewStatus" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmLastReviewDate" classApiMethodMethod="POST"}}
-{{> "htmReviewByID" classApiMethodMethod="POST"}}
-{{> "htmReviewRating" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmTechnicalCompleteness" classApiMethodMethod="POST"}}
-{{> "htmContentAccuracy" classApiMethodMethod="POST"}}
-{{> "htmPedagogy" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRatingComment" classApiMethodMethod="POST"}}
-{{> "htmStandardsAlignment" classApiMethodMethod="POST"}}
-{{> "htmStandardsAlignmentComment" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSubjectMatter" classApiMethodMethod="POST"}}
-{{> "htmSubjectMatterComment" classApiMethodMethod="POST"}}
-{{> "htmSupportsTeaching" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSupportsTeachingComment" classApiMethodMethod="POST"}}
-{{> "htmAssessmentsQuality" classApiMethodMethod="POST"}}
-{{> "htmAssessmentsQualityComment" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmInteractivityQuality" classApiMethodMethod="POST"}}
-{{> "htmInteractivityQualityComment" classApiMethodMethod="POST"}}
-{{> "htmInstructionalQuality" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmInstructionalQualityComment" classApiMethodMethod="POST"}}
-{{> "htmDeeperLearning" classApiMethodMethod="POST"}}
-{{> "htmDeeperLearningComment" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPartner" classApiMethodMethod="POST"}}
-{{> "htmCreateDate" classApiMethodMethod="POST"}}
-{{> "htmType" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmFeatured" classApiMethodMethod="POST"}}
-{{> "htmPage" classApiMethodMethod="POST"}}
-{{> "htmActive" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPublic" classApiMethodMethod="POST"}}
-{{> "htmXwd_id" classApiMethodMethod="POST"}}
-{{> "htmMediaType" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmAccess" classApiMethodMethod="POST"}}
-{{> "htmMemberRating" classApiMethodMethod="POST"}}
-{{> "htmAligned" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPageUrl" classApiMethodMethod="POST"}}
-{{> "htmIndexed" classApiMethodMethod="POST"}}
-{{> "htmLastIndexDate" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmIndexRequired" classApiMethodMethod="POST"}}
-{{> "htmIndexRequiredDate" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRescrape" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmGoButton" classApiMethodMethod="POST"}}
-{{> "htmDownloadButton" classApiMethodMethod="POST"}}
-{{> "htmTopOfSearch" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmRemove" classApiMethodMethod="POST"}}
-{{> "htmSpam" classApiMethodMethod="POST"}}
-{{> "htmTopOfSearchInt" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmPartnerInt" classApiMethodMethod="POST"}}
-{{> "htmReviewResource" classApiMethodMethod="POST"}}
-{{> "htmOldUrl" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmContentDisplayOk" classApiMethodMethod="POST"}}
-{{> "htmMetadata" classApiMethodMethod="POST"}}
-{{> "htmApprovalStatus" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmApprovalStatusDate" classApiMethodMethod="POST"}}
-{{> "htmSpamUser" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmUrl" classApiMethodMethod="POST"}}
-{{> "htmDisplaySeqNo" classApiMethodMethod="POST"}}
-{{> "htmFileId" classApiMethodMethod="POST"}}
 							</div>
 						</div>
 						<button
@@ -630,7 +230,7 @@
 			<i class="fas fa-file-import "></i>
 			Import resources
 		</button>
-		<div id="putimportCurrikiResourceModal" class="w3-modal ">
+		<div id="putimportCurrikiResourceModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-blue">
@@ -643,7 +243,7 @@
 						<div class="w3-cell-row ">
 							<textarea
 								class="PUTImport_searchList w3-input w3-border "
-								style="height: 300px; "
+								style="height: 400px; "
 								placeholder="{ 'searchList': [ { 'pk': ... , 'saves': [ ... ] }, ... ] }"
 								></textarea>
 						</div>
@@ -657,9 +257,15 @@
 		</div>
 {{/inline}}
 {{#*inline "htmFormCurrikiResourcePage_searchpageCurrikiResource"}}
-		<div id="searchpageCurrikiResourceModal" class="">
+		<div id="searchpageCurrikiResourceModal" class="w3-padding-32 ">
 			<div class="">
 				<div class="w3-card-4 ">
+					<header class="w3-container w3-blue">
+	{{#eq "Page" classApiMethodMethod}}
+						<span class="w3-button w3-display-topright " onclick="$('#searchpageCurrikiResourceModal').hide(); ">×</span>
+	{{/eq}}
+						<h2 class="w3-padding "></h2>
+					</header>
 					<div class="" id="searchpageCurrikiResourceFormValues">
 						<div id="searchpageCurrikiResourceForm">
 							<div class="w3-cell-row ">
@@ -808,7 +414,38 @@
 {{> "htmDisplaySeqNo" classApiMethodMethod="Page"}}
 {{> "htmFileId" classApiMethodMethod="Page"}}
 							</div>
+							<div class="w3-cell-row ">
+{{> "htmFileName" classApiMethodMethod="Page"}}
+{{> "htmUploadDate" classApiMethodMethod="Page"}}
+{{> "htmSequence" classApiMethodMethod="Page"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmUniqueName" classApiMethodMethod="Page"}}
+{{> "htmExt" classApiMethodMethod="Page"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTempactive" classApiMethodMethod="Page"}}
+{{> "htmS3path" classApiMethodMethod="Page"}}
+{{> "htmSdfStatus" classApiMethodMethod="Page"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmTranscoded" classApiMethodMethod="Page"}}
+{{> "htmLodestar" classApiMethodMethod="Page"}}
+{{> "htmArchive" classApiMethodMethod="Page"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmIdentifier" classApiMethodMethod="Page"}}
+{{> "htmDisplayName" classApiMethodMethod="Page"}}
+{{> "htmSubjectArea" classApiMethodMethod="Page"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmName" classApiMethodMethod="Page"}}
+							</div>
 						</div>
+						<button
+							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-blue "
+							onclick="searchpageCurrikiResource(); "
+							></button>
 					</div>
 				</div>
 			</div>
@@ -822,47 +459,6 @@
 {{/inline}}
 {{#*inline "htmBodyCurrikiResourcePage"}}
 {{#block "htmBodyStart"}}{{/block}}
-	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
-			<span title="Filters" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3-blue " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
-		</div>
-<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
-	<div class="w3-bar w3-blue ">
-		<span class="w3-bar-item w3-padding ">Search</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodySearch"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
-	<div class="w3-bar w3-blue ">
-		<span class="w3-bar-item w3-padding ">Filters</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyFilters"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
-	<div class="w3-bar w3-blue ">
-		<span class="w3-bar-item w3-padding ">Range</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyRange"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
-	<div class="w3-bar w3-blue ">
-		<span class="w3-bar-item w3-padding ">Pivot</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyPivot"}}{{/block}}
-	</div>
-</div>
-	</div>
-<div class="pageContent w3-content ">
-{{#block "htmBodyMenu"}}{{/block}}
-{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq currikiResourceCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -876,10 +472,8 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
-{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
-</div>
 {{/inline}}
 {{#*inline "table1CurrikiResourcePage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -898,8 +492,8 @@
 	{{/inline}}
 {{#*inline "thead2CurrikiResourcePage"}}
 			<tr>
-				<th></th>
 				<th>created</th>
+				<th></th>
 			</tr>
 {{/inline}}
 {{#*inline "tbody1CurrikiResourcePage"}}
@@ -912,13 +506,13 @@
 			<tr>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<i class="far fa-file "></i>
-							<span class="white-space-pre-wrap ">{{objectTitle}}</span>
+							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "yyyy-MM-dd'T'HH:mm:ss.SSS'['VV']'" siteLocale}}</span>
 						</a>
 					</td>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "MMM d, yyyy h:mm:ss a" siteLocale}}</span>
+							<i class="far fa-file "></i>
+							<span class="white-space-pre-wrap ">{{objectTitle}}</span>
 						</a>
 					</td>
 			</tr>
@@ -931,11 +525,11 @@
 {{/inline}}
 {{#*inline "tfoot2CurrikiResourcePage"}}
 		<tr>
-			{{#if getColumnObjectTitle}}
+			{{#if getColumnCreated}}
 				<td>
 				</td>
 			{{/if}}
-			{{#if getColumnCreated}}
+			{{#if getColumnObjectTitle}}
 				<td>
 				</td>
 			{{/if}}
@@ -985,15 +579,15 @@
 					name="suggestCurrikiResource"
 					id="suggestCurrikiResource{{id}}"
 					autocomplete="off"
-					oninput="suggestCurrikiResourceObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListCurrikiResource{{id}}'), {{pk}}; "
-					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/resource?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
+					oninput="suggestCurrikiResourceObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListCurrikiResource{{id}}'), {{pk}}; "
+					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/api/resource?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listCurrikiResource}}
 					value="{{query2}}"
 				{{/if}}
 				/>
 				<button
 					class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-					onclick="window.location.href = '/resource?q=&quot;, query1, &quot;:' + encodeURIComponent(this.previousElementSibling.value) + '&quot;, fqs, sorts, &quot;&amp;rows=&quot;, start2, &quot;&amp;rows=&quot;, rows1, &quot;'; "
+					onclick="window.location.href = '/api/resource?q=&quot;, query1, &quot;:' + encodeURIComponent(this.previousElementSibling.value) + '&quot;, fqs, sorts, &quot;&amp;rows=&quot;, start2, &quot;&amp;rows=&quot;, rows1, &quot;'; "
 					>
 					<i class="fas fa-search "></i>
 				</button>
@@ -1005,7 +599,7 @@
 				</div>
 			</div>
 			<div class="">
-				<a href="/resource" class="">
+				<a href="/api/resource" class="">
 					<i class="far fa-file"></i>
 					see all the resources
 				</a>
@@ -1015,451 +609,205 @@
 
 {{#*inline "htmResourceId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceId">resource ID</label>
+													<label>resource ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceId')); $('#{{classApiMethodMethod}}_resourceId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceId', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="resource ID"
-															id="{{classApiMethodMethod}}_resourceId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setResourceId classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
-																name="setResourceId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setResourceId classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
-																name="setResourceId"
-		{{else}}
-																class="valueResourceId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceId w3-input w3-border "
-																name="resourceId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceId ">{{currikiResource_.resourceId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.resourceId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceId ">{{currikiResource_.resourceId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLicenseId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLicenseId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_licenseId">license ID</label>
+													<label>license ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLicenseId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLicenseId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_licenseId')); $('#{{classApiMethodMethod}}_licenseId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLicenseId', null, function() { addGlow($('#{{classApiMethodMethod}}_licenseId')); }, function() { addError($('#{{classApiMethodMethod}}_licenseId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLicenseId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="license ID"
-															id="{{classApiMethodMethod}}_licenseId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setLicenseId classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
-																name="setLicenseId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setLicenseId classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
-																name="setLicenseId"
-		{{else}}
-																class="valueLicenseId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}LicenseId w3-input w3-border "
-																name="licenseId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}LicenseId ">{{currikiResource_.licenseId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLicenseId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_licenseId')); }, function() { addError($('#{{classApiMethodMethod}}_licenseId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.licenseId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}LicenseId ">{{currikiResource_.licenseId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContributorId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContributorId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_contributorId">contributor ID</label>
+													<label>contributor ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputContributorId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputContributorId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_contributorId')); $('#{{classApiMethodMethod}}_contributorId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContributorId', null, function() { addGlow($('#{{classApiMethodMethod}}_contributorId')); }, function() { addError($('#{{classApiMethodMethod}}_contributorId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputContributorId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="contributor ID"
-															id="{{classApiMethodMethod}}_contributorId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setContributorId classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
-																name="setContributorId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setContributorId classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
-																name="setContributorId"
-		{{else}}
-																class="valueContributorId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContributorId w3-input w3-border "
-																name="contributorId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ContributorId ">{{currikiResource_.contributorId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContributorId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contributorId')); }, function() { addError($('#{{classApiMethodMethod}}_contributorId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.contributorId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ContributorId ">{{currikiResource_.contributorId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContributionDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContributionDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_contributionDate">contribution Date</label>
+													<label>contribution Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputContributionDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputContributionDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_contributionDate')); $('#{{classApiMethodMethod}}_contributionDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContributionDate', null, function() { addGlow($('#{{classApiMethodMethod}}_contributionDate')); }, function() { addError($('#{{classApiMethodMethod}}_contributionDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputContributionDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setContributionDate classCurrikiResource inputCurrikiResource{{pk}}ContributionDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_contributionDate"
-																value="{{currikiResource_.contributionDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContributionDate', s, function() { addGlow($('#{{classApiMethodMethod}}_contributionDate')); }, function() { addError($('#{{classApiMethodMethod}}_contributionDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ContributionDate ">{{currikiResource_.contributionDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ContributionDate " title="{{formatZonedDateTime currikiResource_.contributionDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.contributionDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmDescription"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDescription">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_description">description</label>
+													<label>description</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDescription"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDescription"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_description')); $('#{{classApiMethodMethod}}_description').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDescription', null, function() { addGlow($('#{{classApiMethodMethod}}_description')); }, function() { addError($('#{{classApiMethodMethod}}_description')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDescription"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="description"
-															id="{{classApiMethodMethod}}_description"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setDescription classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
-																name="setDescription"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setDescription classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
-																name="setDescription"
-		{{else}}
-																class="valueDescription w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Description w3-input w3-border "
-																name="description"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Description ">{{currikiResource_.description}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDescription', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_description')); }, function() { addError($('#{{classApiMethodMethod}}_description')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.description}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Description ">{{currikiResource_.description}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTitle"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTitle">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_title">title</label>
+													<label>title</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputTitle"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTitle"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_title')); $('#{{classApiMethodMethod}}_title').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTitle', null, function() { addGlow($('#{{classApiMethodMethod}}_title')); }, function() { addError($('#{{classApiMethodMethod}}_title')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputTitle"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="title"
-															id="{{classApiMethodMethod}}_title"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setTitle classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
-																name="setTitle"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setTitle classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
-																name="setTitle"
-		{{else}}
-																class="valueTitle w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Title w3-input w3-border "
-																name="title"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Title ">{{currikiResource_.title}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTitle', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_title')); }, function() { addError($('#{{classApiMethodMethod}}_title')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.title}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Title ">{{currikiResource_.title}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmKeywordsStr"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceKeywordsStr">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_keywordsStr">Keywords String</label>
+													<label>Keywords String</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputKeywordsStr"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputKeywordsStr"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_keywordsStr')); $('#{{classApiMethodMethod}}_keywordsStr').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setKeywordsStr', null, function() { addGlow($('#{{classApiMethodMethod}}_keywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_keywordsStr')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputKeywordsStr"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Keywords String"
-															id="{{classApiMethodMethod}}_keywordsStr"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
-																name="setKeywordsStr"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
-																name="setKeywordsStr"
-		{{else}}
-																class="valueKeywordsStr w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}KeywordsStr w3-input w3-border "
-																name="keywordsStr"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}KeywordsStr ">{{currikiResource_.keywordsStr}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setKeywordsStr', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_keywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_keywordsStr')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.keywordsStr}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}KeywordsStr ">{{currikiResource_.keywordsStr}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmKeywords"}}
@@ -1493,68 +841,31 @@
 
 {{#*inline "htmGeneratedKeywordsStr"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceGeneratedKeywordsStr">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_generatedKeywordsStr">Generated Keywords String</label>
+													<label>Generated Keywords String</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputGeneratedKeywordsStr"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputGeneratedKeywordsStr"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); $('#{{classApiMethodMethod}}_generatedKeywordsStr').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setGeneratedKeywordsStr', null, function() { addGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputGeneratedKeywordsStr"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Generated Keywords String"
-															id="{{classApiMethodMethod}}_generatedKeywordsStr"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setGeneratedKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
-																name="setGeneratedKeywordsStr"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setGeneratedKeywordsStr classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
-																name="setGeneratedKeywordsStr"
-		{{else}}
-																class="valueGeneratedKeywordsStr w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}GeneratedKeywordsStr w3-input w3-border "
-																name="generatedKeywordsStr"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}GeneratedKeywordsStr ">{{currikiResource_.generatedKeywordsStr}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setGeneratedKeywordsStr', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }, function() { addError($('#{{classApiMethodMethod}}_generatedKeywordsStr')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.generatedKeywordsStr}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}GeneratedKeywordsStr ">{{currikiResource_.generatedKeywordsStr}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmGeneratedKeywords"}}
@@ -1588,4529 +899,2465 @@
 
 {{#*inline "htmLanguage"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLanguage">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_language">Language</label>
+													<label>Language</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLanguage"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLanguage"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_language')); $('#{{classApiMethodMethod}}_language').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLanguage', null, function() { addGlow($('#{{classApiMethodMethod}}_language')); }, function() { addError($('#{{classApiMethodMethod}}_language')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLanguage"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Language"
-															id="{{classApiMethodMethod}}_language"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setLanguage classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
-																name="setLanguage"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setLanguage classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
-																name="setLanguage"
-		{{else}}
-																class="valueLanguage w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Language w3-input w3-border "
-																name="language"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Language ">{{currikiResource_.language}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLanguage', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_language')); }, function() { addError($('#{{classApiMethodMethod}}_language')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.language}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Language ">{{currikiResource_.language}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastEditorId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastEditorId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_lastEditorId">Last Editor ID</label>
+													<label>Last Editor ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLastEditorId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLastEditorId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastEditorId')); $('#{{classApiMethodMethod}}_lastEditorId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastEditorId', null, function() { addGlow($('#{{classApiMethodMethod}}_lastEditorId')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditorId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastEditorId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Last Editor ID"
-															id="{{classApiMethodMethod}}_lastEditorId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setLastEditorId classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
-																name="setLastEditorId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setLastEditorId classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
-																name="setLastEditorId"
-		{{else}}
-																class="valueLastEditorId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}LastEditorId w3-input w3-border "
-																name="lastEditorId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}LastEditorId ">{{currikiResource_.lastEditorId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastEditorId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_lastEditorId')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditorId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.lastEditorId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}LastEditorId ">{{currikiResource_.lastEditorId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastEditDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastEditDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_lastEditDate">Last Edit Date</label>
+													<label>Last Edit Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLastEditDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLastEditDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastEditDate')); $('#{{classApiMethodMethod}}_lastEditDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastEditDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastEditDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastEditDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setLastEditDate classCurrikiResource inputCurrikiResource{{pk}}LastEditDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_lastEditDate"
-																value="{{currikiResource_.lastEditDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastEditDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastEditDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastEditDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}LastEditDate ">{{currikiResource_.lastEditDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}LastEditDate " title="{{formatZonedDateTime currikiResource_.lastEditDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastEditDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmCurrikiLicense"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceCurrikiLicense">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_currikiLicense">Curriki License</label>
+													<label>Curriki License</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputCurrikiLicense"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputCurrikiLicense"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_currikiLicense')); $('#{{classApiMethodMethod}}_currikiLicense').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setCurrikiLicense', null, function() { addGlow($('#{{classApiMethodMethod}}_currikiLicense')); }, function() { addError($('#{{classApiMethodMethod}}_currikiLicense')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputCurrikiLicense"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Curriki License"
-															id="{{classApiMethodMethod}}_currikiLicense"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setCurrikiLicense classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
-																name="setCurrikiLicense"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setCurrikiLicense classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
-																name="setCurrikiLicense"
-		{{else}}
-																class="valueCurrikiLicense w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}CurrikiLicense w3-input w3-border "
-																name="currikiLicense"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}CurrikiLicense ">{{currikiResource_.currikiLicense}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setCurrikiLicense', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_currikiLicense')); }, function() { addError($('#{{classApiMethodMethod}}_currikiLicense')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.currikiLicense}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}CurrikiLicense ">{{currikiResource_.currikiLicense}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmExternalUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceExternalUrl">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_externalUrl">External URL</label>
+													<label>External URL</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputExternalUrl"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputExternalUrl"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_externalUrl')); $('#{{classApiMethodMethod}}_externalUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setExternalUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_externalUrl')); }, function() { addError($('#{{classApiMethodMethod}}_externalUrl')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputExternalUrl"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="External URL"
-															id="{{classApiMethodMethod}}_externalUrl"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setExternalUrl classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
-																name="setExternalUrl"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setExternalUrl classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
-																name="setExternalUrl"
-		{{else}}
-																class="valueExternalUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ExternalUrl w3-input w3-border "
-																name="externalUrl"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ExternalUrl ">{{currikiResource_.externalUrl}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setExternalUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_externalUrl')); }, function() { addError($('#{{classApiMethodMethod}}_externalUrl')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.externalUrl}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ExternalUrl ">{{currikiResource_.externalUrl}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceChecked"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceChecked">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceChecked">Resource Checked</label>
+													<label>Resource Checked</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceChecked"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceChecked"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceChecked')); $('#{{classApiMethodMethod}}_resourceChecked').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceChecked', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceChecked')); }, function() { addError($('#{{classApiMethodMethod}}_resourceChecked')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceChecked"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Resource Checked"
-															id="{{classApiMethodMethod}}_resourceChecked"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setResourceChecked classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
-																name="setResourceChecked"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setResourceChecked classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
-																name="setResourceChecked"
-		{{else}}
-																class="valueResourceChecked w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceChecked w3-input w3-border "
-																name="resourceChecked"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceChecked ">{{currikiResource_.resourceChecked}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceChecked', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceChecked')); }, function() { addError($('#{{classApiMethodMethod}}_resourceChecked')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.resourceChecked}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceChecked ">{{currikiResource_.resourceChecked}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContent"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContent">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_content">External URL</label>
+													<label>External URL</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputContent"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputContent"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_content')); $('#{{classApiMethodMethod}}_content').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContent', null, function() { addGlow($('#{{classApiMethodMethod}}_content')); }, function() { addError($('#{{classApiMethodMethod}}_content')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputContent"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="External URL"
-															id="{{classApiMethodMethod}}_content"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setContent classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
-																name="setContent"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setContent classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
-																name="setContent"
-		{{else}}
-																class="valueContent w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Content w3-input w3-border "
-																name="content"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Content ">{{currikiResource_.content}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContent', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_content')); }, function() { addError($('#{{classApiMethodMethod}}_content')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.content}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Content ">{{currikiResource_.content}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckRequestNote"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckRequestNote">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceCheckRequestNote">Resource Check Request Note</label>
+													<label>Resource Check Request Note</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceCheckRequestNote"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceCheckRequestNote"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); $('#{{classApiMethodMethod}}_resourceCheckRequestNote').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckRequestNote', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckRequestNote"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Resource Check Request Note"
-															id="{{classApiMethodMethod}}_resourceCheckRequestNote"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setResourceCheckRequestNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
-																name="setResourceCheckRequestNote"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setResourceCheckRequestNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
-																name="setResourceCheckRequestNote"
-		{{else}}
-																class="valueResourceCheckRequestNote w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckRequestNote w3-input w3-border "
-																name="resourceCheckRequestNote"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceCheckRequestNote ">{{currikiResource_.resourceCheckRequestNote}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckRequestNote', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckRequestNote')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.resourceCheckRequestNote}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceCheckRequestNote ">{{currikiResource_.resourceCheckRequestNote}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceCheckDate">Resource Check Date</label>
+													<label>Resource Check Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceCheckDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceCheckDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); $('#{{classApiMethodMethod}}_resourceCheckDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckDate', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setResourceCheckDate classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_resourceCheckDate"
-																value="{{currikiResource_.resourceCheckDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckDate', s, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckDate')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceCheckDate ">{{currikiResource_.resourceCheckDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceCheckDate " title="{{formatZonedDateTime currikiResource_.resourceCheckDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.resourceCheckDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceCheckId">Resource Check ID</label>
+													<label>Resource Check ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceCheckId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceCheckId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckId')); $('#{{classApiMethodMethod}}_resourceCheckId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckId', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Resource Check ID"
-															id="{{classApiMethodMethod}}_resourceCheckId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setResourceCheckId classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
-																name="setResourceCheckId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setResourceCheckId classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
-																name="setResourceCheckId"
-		{{else}}
-																class="valueResourceCheckId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckId w3-input w3-border "
-																name="resourceCheckId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceCheckId ">{{currikiResource_.resourceCheckId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckId')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.resourceCheckId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceCheckId ">{{currikiResource_.resourceCheckId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmResourceCheckNote"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceResourceCheckNote">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_resourceCheckNote">Resource Check Note</label>
+													<label>Resource Check Note</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputResourceCheckNote"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputResourceCheckNote"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); $('#{{classApiMethodMethod}}_resourceCheckNote').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setResourceCheckNote', null, function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckNote')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputResourceCheckNote"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Resource Check Note"
-															id="{{classApiMethodMethod}}_resourceCheckNote"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setResourceCheckNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
-																name="setResourceCheckNote"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setResourceCheckNote classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
-																name="setResourceCheckNote"
-		{{else}}
-																class="valueResourceCheckNote w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ResourceCheckNote w3-input w3-border "
-																name="resourceCheckNote"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ResourceCheckNote ">{{currikiResource_.resourceCheckNote}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setResourceCheckNote', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_resourceCheckNote')); }, function() { addError($('#{{classApiMethodMethod}}_resourceCheckNote')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.resourceCheckNote}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ResourceCheckNote ">{{currikiResource_.resourceCheckNote}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStudentFacing"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStudentFacing">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_studentFacing">Student Facing</label>
+													<label>Student Facing</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputStudentFacing"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputStudentFacing"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_studentFacing')); $('#{{classApiMethodMethod}}_studentFacing').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStudentFacing', null, function() { addGlow($('#{{classApiMethodMethod}}_studentFacing')); }, function() { addError($('#{{classApiMethodMethod}}_studentFacing')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputStudentFacing"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Student Facing"
-															id="{{classApiMethodMethod}}_studentFacing"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setStudentFacing classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
-																name="setStudentFacing"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setStudentFacing classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
-																name="setStudentFacing"
-		{{else}}
-																class="valueStudentFacing w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StudentFacing w3-input w3-border "
-																name="studentFacing"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}StudentFacing ">{{currikiResource_.studentFacing}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStudentFacing', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_studentFacing')); }, function() { addError($('#{{classApiMethodMethod}}_studentFacing')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.studentFacing}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}StudentFacing ">{{currikiResource_.studentFacing}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSource"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSource">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_source">Source</label>
+													<label>Source</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSource"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSource"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_source')); $('#{{classApiMethodMethod}}_source').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSource', null, function() { addGlow($('#{{classApiMethodMethod}}_source')); }, function() { addError($('#{{classApiMethodMethod}}_source')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSource"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Source"
-															id="{{classApiMethodMethod}}_source"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSource classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
-																name="setSource"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSource classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
-																name="setSource"
-		{{else}}
-																class="valueSource w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Source w3-input w3-border "
-																name="source"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Source ">{{currikiResource_.source}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSource', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_source')); }, function() { addError($('#{{classApiMethodMethod}}_source')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.source}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Source ">{{currikiResource_.source}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewStatus"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewStatus">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_reviewStatus">Review Status</label>
+													<label>Review Status</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputReviewStatus"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputReviewStatus"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewStatus')); $('#{{classApiMethodMethod}}_reviewStatus').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewStatus', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewStatus')); }, function() { addError($('#{{classApiMethodMethod}}_reviewStatus')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewStatus"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Review Status"
-															id="{{classApiMethodMethod}}_reviewStatus"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setReviewStatus classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
-																name="setReviewStatus"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setReviewStatus classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
-																name="setReviewStatus"
-		{{else}}
-																class="valueReviewStatus w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewStatus w3-input w3-border "
-																name="reviewStatus"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ReviewStatus ">{{currikiResource_.reviewStatus}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewStatus', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewStatus')); }, function() { addError($('#{{classApiMethodMethod}}_reviewStatus')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.reviewStatus}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ReviewStatus ">{{currikiResource_.reviewStatus}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastReviewDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastReviewDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_lastReviewDate">Last Review Date</label>
+													<label>Last Review Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLastReviewDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLastReviewDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastReviewDate')); $('#{{classApiMethodMethod}}_lastReviewDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastReviewDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastReviewDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastReviewDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastReviewDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setLastReviewDate classCurrikiResource inputCurrikiResource{{pk}}LastReviewDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_lastReviewDate"
-																value="{{currikiResource_.lastReviewDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastReviewDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastReviewDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastReviewDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}LastReviewDate ">{{currikiResource_.lastReviewDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}LastReviewDate " title="{{formatZonedDateTime currikiResource_.lastReviewDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastReviewDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmReviewByID"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewByID">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_reviewByID">Review By ID</label>
+													<label>Review By ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputReviewByID"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputReviewByID"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewByID')); $('#{{classApiMethodMethod}}_reviewByID').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewByID', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewByID')); }, function() { addError($('#{{classApiMethodMethod}}_reviewByID')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewByID"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Review By ID"
-															id="{{classApiMethodMethod}}_reviewByID"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setReviewByID classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
-																name="setReviewByID"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setReviewByID classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
-																name="setReviewByID"
-		{{else}}
-																class="valueReviewByID w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewByID w3-input w3-border "
-																name="reviewByID"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ReviewByID ">{{currikiResource_.reviewByID}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewByID', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewByID')); }, function() { addError($('#{{classApiMethodMethod}}_reviewByID')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.reviewByID}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ReviewByID ">{{currikiResource_.reviewByID}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewRating"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewRating">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_reviewRating">Review Rating</label>
+													<label>Review Rating</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputReviewRating"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputReviewRating"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewRating')); $('#{{classApiMethodMethod}}_reviewRating').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewRating', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewRating')); }, function() { addError($('#{{classApiMethodMethod}}_reviewRating')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewRating"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Review Rating"
-															id="{{classApiMethodMethod}}_reviewRating"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setReviewRating classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
-																name="setReviewRating"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setReviewRating classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
-																name="setReviewRating"
-		{{else}}
-																class="valueReviewRating w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewRating w3-input w3-border "
-																name="reviewRating"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ReviewRating ">{{currikiResource_.reviewRating}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewRating', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewRating')); }, function() { addError($('#{{classApiMethodMethod}}_reviewRating')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.reviewRating}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ReviewRating ">{{currikiResource_.reviewRating}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTechnicalCompleteness"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTechnicalCompleteness">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_technicalCompleteness">Technical Completeness</label>
+													<label>Technical Completeness</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputTechnicalCompleteness"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTechnicalCompleteness"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); $('#{{classApiMethodMethod}}_technicalCompleteness').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTechnicalCompleteness', null, function() { addGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); }, function() { addError($('#{{classApiMethodMethod}}_technicalCompleteness')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputTechnicalCompleteness"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Technical Completeness"
-															id="{{classApiMethodMethod}}_technicalCompleteness"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setTechnicalCompleteness classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
-																name="setTechnicalCompleteness"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setTechnicalCompleteness classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
-																name="setTechnicalCompleteness"
-		{{else}}
-																class="valueTechnicalCompleteness w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TechnicalCompleteness w3-input w3-border "
-																name="technicalCompleteness"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}TechnicalCompleteness ">{{currikiResource_.technicalCompleteness}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTechnicalCompleteness', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_technicalCompleteness')); }, function() { addError($('#{{classApiMethodMethod}}_technicalCompleteness')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.technicalCompleteness}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}TechnicalCompleteness ">{{currikiResource_.technicalCompleteness}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContentAccuracy"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContentAccuracy">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_contentAccuracy">Content Accuracy</label>
+													<label>Content Accuracy</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputContentAccuracy"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputContentAccuracy"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_contentAccuracy')); $('#{{classApiMethodMethod}}_contentAccuracy').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContentAccuracy', null, function() { addGlow($('#{{classApiMethodMethod}}_contentAccuracy')); }, function() { addError($('#{{classApiMethodMethod}}_contentAccuracy')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputContentAccuracy"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Content Accuracy"
-															id="{{classApiMethodMethod}}_contentAccuracy"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setContentAccuracy classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
-																name="setContentAccuracy"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setContentAccuracy classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
-																name="setContentAccuracy"
-		{{else}}
-																class="valueContentAccuracy w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContentAccuracy w3-input w3-border "
-																name="contentAccuracy"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ContentAccuracy ">{{currikiResource_.contentAccuracy}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContentAccuracy', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contentAccuracy')); }, function() { addError($('#{{classApiMethodMethod}}_contentAccuracy')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.contentAccuracy}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ContentAccuracy ">{{currikiResource_.contentAccuracy}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPedagogy"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePedagogy">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_pedagogy">Pedagogy</label>
+													<label>Pedagogy</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPedagogy"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPedagogy"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_pedagogy')); $('#{{classApiMethodMethod}}_pedagogy').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPedagogy', null, function() { addGlow($('#{{classApiMethodMethod}}_pedagogy')); }, function() { addError($('#{{classApiMethodMethod}}_pedagogy')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPedagogy"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Pedagogy"
-															id="{{classApiMethodMethod}}_pedagogy"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPedagogy classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
-																name="setPedagogy"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPedagogy classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
-																name="setPedagogy"
-		{{else}}
-																class="valuePedagogy w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Pedagogy w3-input w3-border "
-																name="pedagogy"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Pedagogy ">{{currikiResource_.pedagogy}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPedagogy', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_pedagogy')); }, function() { addError($('#{{classApiMethodMethod}}_pedagogy')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.pedagogy}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Pedagogy ">{{currikiResource_.pedagogy}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmRatingComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRatingComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_ratingComment">Rating Comment</label>
+													<label>Rating Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputRatingComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputRatingComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_ratingComment')); $('#{{classApiMethodMethod}}_ratingComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRatingComment', null, function() { addGlow($('#{{classApiMethodMethod}}_ratingComment')); }, function() { addError($('#{{classApiMethodMethod}}_ratingComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputRatingComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Rating Comment"
-															id="{{classApiMethodMethod}}_ratingComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setRatingComment classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
-																name="setRatingComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setRatingComment classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
-																name="setRatingComment"
-		{{else}}
-																class="valueRatingComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}RatingComment w3-input w3-border "
-																name="ratingComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}RatingComment ">{{currikiResource_.ratingComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRatingComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_ratingComment')); }, function() { addError($('#{{classApiMethodMethod}}_ratingComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.ratingComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}RatingComment ">{{currikiResource_.ratingComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStandardsAlignment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStandardsAlignment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_standardsAlignment">Standards Alignment</label>
+													<label>Standards Alignment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputStandardsAlignment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputStandardsAlignment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_standardsAlignment')); $('#{{classApiMethodMethod}}_standardsAlignment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStandardsAlignment', null, function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputStandardsAlignment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Standards Alignment"
-															id="{{classApiMethodMethod}}_standardsAlignment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setStandardsAlignment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
-																name="setStandardsAlignment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setStandardsAlignment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
-																name="setStandardsAlignment"
-		{{else}}
-																class="valueStandardsAlignment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignment w3-input w3-border "
-																name="standardsAlignment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}StandardsAlignment ">{{currikiResource_.standardsAlignment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStandardsAlignment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.standardsAlignment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}StandardsAlignment ">{{currikiResource_.standardsAlignment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmStandardsAlignmentComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceStandardsAlignmentComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_standardsAlignmentComment">Standards Alignment Comment</label>
+													<label>Standards Alignment Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputStandardsAlignmentComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputStandardsAlignmentComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); $('#{{classApiMethodMethod}}_standardsAlignmentComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setStandardsAlignmentComment', null, function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputStandardsAlignmentComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Standards Alignment Comment"
-															id="{{classApiMethodMethod}}_standardsAlignmentComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setStandardsAlignmentComment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
-																name="setStandardsAlignmentComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setStandardsAlignmentComment classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
-																name="setStandardsAlignmentComment"
-		{{else}}
-																class="valueStandardsAlignmentComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}StandardsAlignmentComment w3-input w3-border "
-																name="standardsAlignmentComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}StandardsAlignmentComment ">{{currikiResource_.standardsAlignmentComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setStandardsAlignmentComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }, function() { addError($('#{{classApiMethodMethod}}_standardsAlignmentComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.standardsAlignmentComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}StandardsAlignmentComment ">{{currikiResource_.standardsAlignmentComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectMatter"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectMatter">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_subjectMatter">Subject Matter</label>
+													<label>Subject Matter</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSubjectMatter"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSubjectMatter"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectMatter')); $('#{{classApiMethodMethod}}_subjectMatter').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectMatter', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectMatter')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatter')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectMatter"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Subject Matter"
-															id="{{classApiMethodMethod}}_subjectMatter"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSubjectMatter classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
-																name="setSubjectMatter"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSubjectMatter classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
-																name="setSubjectMatter"
-		{{else}}
-																class="valueSubjectMatter w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectMatter w3-input w3-border "
-																name="subjectMatter"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SubjectMatter ">{{currikiResource_.subjectMatter}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectMatter', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectMatter')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatter')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.subjectMatter}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}SubjectMatter ">{{currikiResource_.subjectMatter}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSubjectMatterComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSubjectMatterComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_subjectMatterComment">Subject Matter Comment</label>
+													<label>Subject Matter Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSubjectMatterComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSubjectMatterComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); $('#{{classApiMethodMethod}}_subjectMatterComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSubjectMatterComment', null, function() { addGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatterComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSubjectMatterComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Subject Matter Comment"
-															id="{{classApiMethodMethod}}_subjectMatterComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSubjectMatterComment classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
-																name="setSubjectMatterComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSubjectMatterComment classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
-																name="setSubjectMatterComment"
-		{{else}}
-																class="valueSubjectMatterComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SubjectMatterComment w3-input w3-border "
-																name="subjectMatterComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SubjectMatterComment ">{{currikiResource_.subjectMatterComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSubjectMatterComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_subjectMatterComment')); }, function() { addError($('#{{classApiMethodMethod}}_subjectMatterComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.subjectMatterComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}SubjectMatterComment ">{{currikiResource_.subjectMatterComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSupportsTeaching"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSupportsTeaching">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_supportsTeaching">Supports Teaching</label>
+													<label>Supports Teaching</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSupportsTeaching"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSupportsTeaching"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_supportsTeaching')); $('#{{classApiMethodMethod}}_supportsTeaching').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSupportsTeaching', null, function() { addGlow($('#{{classApiMethodMethod}}_supportsTeaching')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeaching')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSupportsTeaching"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Supports Teaching"
-															id="{{classApiMethodMethod}}_supportsTeaching"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSupportsTeaching classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
-																name="setSupportsTeaching"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSupportsTeaching classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
-																name="setSupportsTeaching"
-		{{else}}
-																class="valueSupportsTeaching w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SupportsTeaching w3-input w3-border "
-																name="supportsTeaching"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SupportsTeaching ">{{currikiResource_.supportsTeaching}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSupportsTeaching', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_supportsTeaching')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeaching')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.supportsTeaching}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}SupportsTeaching ">{{currikiResource_.supportsTeaching}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSupportsTeachingComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSupportsTeachingComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_supportsTeachingComment">Supports Teaching Comment</label>
+													<label>Supports Teaching Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSupportsTeachingComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSupportsTeachingComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); $('#{{classApiMethodMethod}}_supportsTeachingComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSupportsTeachingComment', null, function() { addGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeachingComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSupportsTeachingComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Supports Teaching Comment"
-															id="{{classApiMethodMethod}}_supportsTeachingComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSupportsTeachingComment classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
-																name="setSupportsTeachingComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSupportsTeachingComment classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
-																name="setSupportsTeachingComment"
-		{{else}}
-																class="valueSupportsTeachingComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SupportsTeachingComment w3-input w3-border "
-																name="supportsTeachingComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SupportsTeachingComment ">{{currikiResource_.supportsTeachingComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSupportsTeachingComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_supportsTeachingComment')); }, function() { addError($('#{{classApiMethodMethod}}_supportsTeachingComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.supportsTeachingComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}SupportsTeachingComment ">{{currikiResource_.supportsTeachingComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAssessmentsQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAssessmentsQuality">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_assessmentsQuality">Assessments Quality</label>
+													<label>Assessments Quality</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputAssessmentsQuality"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputAssessmentsQuality"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); $('#{{classApiMethodMethod}}_assessmentsQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAssessmentsQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQuality')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputAssessmentsQuality"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Assessments Quality"
-															id="{{classApiMethodMethod}}_assessmentsQuality"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setAssessmentsQuality classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
-																name="setAssessmentsQuality"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setAssessmentsQuality classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
-																name="setAssessmentsQuality"
-		{{else}}
-																class="valueAssessmentsQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQuality w3-input w3-border "
-																name="assessmentsQuality"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}AssessmentsQuality ">{{currikiResource_.assessmentsQuality}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAssessmentsQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQuality')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQuality')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.assessmentsQuality}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}AssessmentsQuality ">{{currikiResource_.assessmentsQuality}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAssessmentsQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAssessmentsQualityComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_assessmentsQualityComment">Assessments Quality Comment</label>
+													<label>Assessments Quality Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputAssessmentsQualityComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputAssessmentsQualityComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); $('#{{classApiMethodMethod}}_assessmentsQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAssessmentsQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputAssessmentsQualityComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Assessments Quality Comment"
-															id="{{classApiMethodMethod}}_assessmentsQualityComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setAssessmentsQualityComment classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
-																name="setAssessmentsQualityComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setAssessmentsQualityComment classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
-																name="setAssessmentsQualityComment"
-		{{else}}
-																class="valueAssessmentsQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}AssessmentsQualityComment w3-input w3-border "
-																name="assessmentsQualityComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}AssessmentsQualityComment ">{{currikiResource_.assessmentsQualityComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAssessmentsQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_assessmentsQualityComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.assessmentsQualityComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}AssessmentsQualityComment ">{{currikiResource_.assessmentsQualityComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInteractivityQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInteractivityQuality">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_interactivityQuality">Interactivity Quality</label>
+													<label>Interactivity Quality</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputInteractivityQuality"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputInteractivityQuality"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_interactivityQuality')); $('#{{classApiMethodMethod}}_interactivityQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInteractivityQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_interactivityQuality')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQuality')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputInteractivityQuality"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Interactivity Quality"
-															id="{{classApiMethodMethod}}_interactivityQuality"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setInteractivityQuality classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
-																name="setInteractivityQuality"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setInteractivityQuality classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
-																name="setInteractivityQuality"
-		{{else}}
-																class="valueInteractivityQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InteractivityQuality w3-input w3-border "
-																name="interactivityQuality"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}InteractivityQuality ">{{currikiResource_.interactivityQuality}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInteractivityQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_interactivityQuality')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQuality')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.interactivityQuality}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}InteractivityQuality ">{{currikiResource_.interactivityQuality}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInteractivityQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInteractivityQualityComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_interactivityQualityComment">Interactivity Quality Comment</label>
+													<label>Interactivity Quality Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputInteractivityQualityComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputInteractivityQualityComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); $('#{{classApiMethodMethod}}_interactivityQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInteractivityQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQualityComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputInteractivityQualityComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Interactivity Quality Comment"
-															id="{{classApiMethodMethod}}_interactivityQualityComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setInteractivityQualityComment classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
-																name="setInteractivityQualityComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setInteractivityQualityComment classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
-																name="setInteractivityQualityComment"
-		{{else}}
-																class="valueInteractivityQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InteractivityQualityComment w3-input w3-border "
-																name="interactivityQualityComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}InteractivityQualityComment ">{{currikiResource_.interactivityQualityComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInteractivityQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_interactivityQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_interactivityQualityComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.interactivityQualityComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}InteractivityQualityComment ">{{currikiResource_.interactivityQualityComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInstructionalQuality"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInstructionalQuality">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_instructionalQuality">Instructional Quality</label>
+													<label>Instructional Quality</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputInstructionalQuality"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputInstructionalQuality"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_instructionalQuality')); $('#{{classApiMethodMethod}}_instructionalQuality').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInstructionalQuality', null, function() { addGlow($('#{{classApiMethodMethod}}_instructionalQuality')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQuality')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputInstructionalQuality"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Instructional Quality"
-															id="{{classApiMethodMethod}}_instructionalQuality"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setInstructionalQuality classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
-																name="setInstructionalQuality"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setInstructionalQuality classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
-																name="setInstructionalQuality"
-		{{else}}
-																class="valueInstructionalQuality w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InstructionalQuality w3-input w3-border "
-																name="instructionalQuality"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}InstructionalQuality ">{{currikiResource_.instructionalQuality}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInstructionalQuality', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_instructionalQuality')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQuality')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.instructionalQuality}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}InstructionalQuality ">{{currikiResource_.instructionalQuality}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmInstructionalQualityComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceInstructionalQualityComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_instructionalQualityComment">Instructional Quality Comment</label>
+													<label>Instructional Quality Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputInstructionalQualityComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputInstructionalQualityComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); $('#{{classApiMethodMethod}}_instructionalQualityComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setInstructionalQualityComment', null, function() { addGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQualityComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputInstructionalQualityComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Instructional Quality Comment"
-															id="{{classApiMethodMethod}}_instructionalQualityComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setInstructionalQualityComment classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
-																name="setInstructionalQualityComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setInstructionalQualityComment classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
-																name="setInstructionalQualityComment"
-		{{else}}
-																class="valueInstructionalQualityComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}InstructionalQualityComment w3-input w3-border "
-																name="instructionalQualityComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}InstructionalQualityComment ">{{currikiResource_.instructionalQualityComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setInstructionalQualityComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_instructionalQualityComment')); }, function() { addError($('#{{classApiMethodMethod}}_instructionalQualityComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.instructionalQualityComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}InstructionalQualityComment ">{{currikiResource_.instructionalQualityComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDeeperLearning"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDeeperLearning">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_deeperLearning">Deeper Learning</label>
+													<label>Deeper Learning</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDeeperLearning"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDeeperLearning"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_deeperLearning')); $('#{{classApiMethodMethod}}_deeperLearning').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDeeperLearning', null, function() { addGlow($('#{{classApiMethodMethod}}_deeperLearning')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearning')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeeperLearning"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Deeper Learning"
-															id="{{classApiMethodMethod}}_deeperLearning"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setDeeperLearning classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
-																name="setDeeperLearning"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setDeeperLearning classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
-																name="setDeeperLearning"
-		{{else}}
-																class="valueDeeperLearning w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DeeperLearning w3-input w3-border "
-																name="deeperLearning"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}DeeperLearning ">{{currikiResource_.deeperLearning}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeeperLearning', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_deeperLearning')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearning')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.deeperLearning}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}DeeperLearning ">{{currikiResource_.deeperLearning}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDeeperLearningComment"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDeeperLearningComment">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_deeperLearningComment">Deeper Learning Comment</label>
+													<label>Deeper Learning Comment</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDeeperLearningComment"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDeeperLearningComment"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); $('#{{classApiMethodMethod}}_deeperLearningComment').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDeeperLearningComment', null, function() { addGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearningComment')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDeeperLearningComment"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Deeper Learning Comment"
-															id="{{classApiMethodMethod}}_deeperLearningComment"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setDeeperLearningComment classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
-																name="setDeeperLearningComment"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setDeeperLearningComment classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
-																name="setDeeperLearningComment"
-		{{else}}
-																class="valueDeeperLearningComment w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DeeperLearningComment w3-input w3-border "
-																name="deeperLearningComment"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}DeeperLearningComment ">{{currikiResource_.deeperLearningComment}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDeeperLearningComment', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_deeperLearningComment')); }, function() { addError($('#{{classApiMethodMethod}}_deeperLearningComment')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.deeperLearningComment}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}DeeperLearningComment ">{{currikiResource_.deeperLearningComment}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPartner"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePartner">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_partner">Partner</label>
+													<label>Partner</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPartner"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPartner"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_partner')); $('#{{classApiMethodMethod}}_partner').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPartner', null, function() { addGlow($('#{{classApiMethodMethod}}_partner')); }, function() { addError($('#{{classApiMethodMethod}}_partner')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPartner"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Partner"
-															id="{{classApiMethodMethod}}_partner"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPartner classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
-																name="setPartner"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPartner classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
-																name="setPartner"
-		{{else}}
-																class="valuePartner w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Partner w3-input w3-border "
-																name="partner"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Partner ">{{currikiResource_.partner}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPartner', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_partner')); }, function() { addError($('#{{classApiMethodMethod}}_partner')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.partner}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Partner ">{{currikiResource_.partner}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmCreateDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceCreateDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_createDate">Create Date</label>
+													<label>Create Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputCreateDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputCreateDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_createDate')); $('#{{classApiMethodMethod}}_createDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setCreateDate', null, function() { addGlow($('#{{classApiMethodMethod}}_createDate')); }, function() { addError($('#{{classApiMethodMethod}}_createDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputCreateDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setCreateDate classCurrikiResource inputCurrikiResource{{pk}}CreateDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_createDate"
-																value="{{currikiResource_.createDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setCreateDate', s, function() { addGlow($('#{{classApiMethodMethod}}_createDate')); }, function() { addError($('#{{classApiMethodMethod}}_createDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}CreateDate ">{{currikiResource_.createDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}CreateDate " title="{{formatZonedDateTime currikiResource_.createDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.createDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmType"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceType">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_type">Type</label>
+													<label>Type</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputType"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputType"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_type')); $('#{{classApiMethodMethod}}_type').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setType', null, function() { addGlow($('#{{classApiMethodMethod}}_type')); }, function() { addError($('#{{classApiMethodMethod}}_type')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputType"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Type"
-															id="{{classApiMethodMethod}}_type"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setType classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
-																name="setType"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setType classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
-																name="setType"
-		{{else}}
-																class="valueType w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Type w3-input w3-border "
-																name="type"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Type ">{{currikiResource_.type}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setType', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_type')); }, function() { addError($('#{{classApiMethodMethod}}_type')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.type}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Type ">{{currikiResource_.type}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmFeatured"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceFeatured">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_featured">Featured</label>
+													<label>Featured</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputFeatured"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputFeatured"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_featured')); $('#{{classApiMethodMethod}}_featured').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setFeatured', null, function() { addGlow($('#{{classApiMethodMethod}}_featured')); }, function() { addError($('#{{classApiMethodMethod}}_featured')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputFeatured"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Featured"
-															id="{{classApiMethodMethod}}_featured"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setFeatured classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
-																name="setFeatured"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setFeatured classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
-																name="setFeatured"
-		{{else}}
-																class="valueFeatured w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Featured w3-input w3-border "
-																name="featured"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Featured ">{{currikiResource_.featured}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setFeatured', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_featured')); }, function() { addError($('#{{classApiMethodMethod}}_featured')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.featured}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Featured ">{{currikiResource_.featured}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPage"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePage">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_page">Page</label>
+													<label>Page</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPage"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPage"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_page')); $('#{{classApiMethodMethod}}_page').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPage', null, function() { addGlow($('#{{classApiMethodMethod}}_page')); }, function() { addError($('#{{classApiMethodMethod}}_page')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPage"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Page"
-															id="{{classApiMethodMethod}}_page"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPage classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
-																name="setPage"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPage classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
-																name="setPage"
-		{{else}}
-																class="valuePage w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Page w3-input w3-border "
-																name="page"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Page ">{{currikiResource_.page}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPage', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_page')); }, function() { addError($('#{{classApiMethodMethod}}_page')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.page}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Page ">{{currikiResource_.page}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmActive"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceActive">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_active">Active</label>
+													<label>Active</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputActive"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputActive"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_active')); $('#{{classApiMethodMethod}}_active').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setActive', null, function() { addGlow($('#{{classApiMethodMethod}}_active')); }, function() { addError($('#{{classApiMethodMethod}}_active')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputActive"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Active"
-															id="{{classApiMethodMethod}}_active"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setActive classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
-																name="setActive"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setActive classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
-																name="setActive"
-		{{else}}
-																class="valueActive w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Active w3-input w3-border "
-																name="active"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Active ">{{currikiResource_.active}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setActive', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_active')); }, function() { addError($('#{{classApiMethodMethod}}_active')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.active}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Active ">{{currikiResource_.active}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPublic"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePublic">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_Public">Public</label>
+													<label>Public</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPublic"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPublic"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_Public')); $('#{{classApiMethodMethod}}_Public').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPublic', null, function() { addGlow($('#{{classApiMethodMethod}}_Public')); }, function() { addError($('#{{classApiMethodMethod}}_Public')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPublic"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Public"
-															id="{{classApiMethodMethod}}_Public"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPublic classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
-																name="setPublic"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPublic classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
-																name="setPublic"
-		{{else}}
-																class="valuePublic w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Public w3-input w3-border "
-																name="Public"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Public ">{{currikiResource_.Public}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPublic', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_Public')); }, function() { addError($('#{{classApiMethodMethod}}_Public')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.Public}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Public ">{{currikiResource_.Public}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmXwd_id"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceXwd_id">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_xwd_id">xwd ID</label>
+													<label>xwd ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputXwd_id"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputXwd_id"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_xwd_id')); $('#{{classApiMethodMethod}}_xwd_id').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setXwd_id', null, function() { addGlow($('#{{classApiMethodMethod}}_xwd_id')); }, function() { addError($('#{{classApiMethodMethod}}_xwd_id')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputXwd_id"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="xwd ID"
-															id="{{classApiMethodMethod}}_xwd_id"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setXwd_id classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
-																name="setXwd_id"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setXwd_id classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
-																name="setXwd_id"
-		{{else}}
-																class="valueXwd_id w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Xwd_id w3-input w3-border "
-																name="xwd_id"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Xwd_id ">{{currikiResource_.xwd_id}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setXwd_id', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_xwd_id')); }, function() { addError($('#{{classApiMethodMethod}}_xwd_id')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.xwd_id}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Xwd_id ">{{currikiResource_.xwd_id}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMediaType"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMediaType">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_mediaType">Media Type</label>
+													<label>Media Type</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputMediaType"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputMediaType"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_mediaType')); $('#{{classApiMethodMethod}}_mediaType').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMediaType', null, function() { addGlow($('#{{classApiMethodMethod}}_mediaType')); }, function() { addError($('#{{classApiMethodMethod}}_mediaType')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputMediaType"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Media Type"
-															id="{{classApiMethodMethod}}_mediaType"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setMediaType classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
-																name="setMediaType"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setMediaType classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
-																name="setMediaType"
-		{{else}}
-																class="valueMediaType w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}MediaType w3-input w3-border "
-																name="mediaType"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}MediaType ">{{currikiResource_.mediaType}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMediaType', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_mediaType')); }, function() { addError($('#{{classApiMethodMethod}}_mediaType')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.mediaType}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}MediaType ">{{currikiResource_.mediaType}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAccess"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAccess">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_access">Access</label>
+													<label>Access</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputAccess"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputAccess"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_access')); $('#{{classApiMethodMethod}}_access').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAccess', null, function() { addGlow($('#{{classApiMethodMethod}}_access')); }, function() { addError($('#{{classApiMethodMethod}}_access')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputAccess"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Access"
-															id="{{classApiMethodMethod}}_access"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setAccess classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
-																name="setAccess"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setAccess classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
-																name="setAccess"
-		{{else}}
-																class="valueAccess w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Access w3-input w3-border "
-																name="access"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Access ">{{currikiResource_.access}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAccess', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_access')); }, function() { addError($('#{{classApiMethodMethod}}_access')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.access}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Access ">{{currikiResource_.access}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMemberRating"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMemberRating">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_memberRating">Member Rating</label>
+													<label>Member Rating</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputMemberRating"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputMemberRating"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_memberRating')); $('#{{classApiMethodMethod}}_memberRating').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMemberRating', null, function() { addGlow($('#{{classApiMethodMethod}}_memberRating')); }, function() { addError($('#{{classApiMethodMethod}}_memberRating')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputMemberRating"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Member Rating"
-															id="{{classApiMethodMethod}}_memberRating"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setMemberRating classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
-																name="setMemberRating"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setMemberRating classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
-																name="setMemberRating"
-		{{else}}
-																class="valueMemberRating w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}MemberRating w3-input w3-border "
-																name="memberRating"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}MemberRating ">{{currikiResource_.memberRating}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMemberRating', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_memberRating')); }, function() { addError($('#{{classApiMethodMethod}}_memberRating')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.memberRating}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}MemberRating ">{{currikiResource_.memberRating}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmAligned"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceAligned">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_aligned">Aligned</label>
+													<label>Aligned</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputAligned"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputAligned"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_aligned')); $('#{{classApiMethodMethod}}_aligned').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setAligned', null, function() { addGlow($('#{{classApiMethodMethod}}_aligned')); }, function() { addError($('#{{classApiMethodMethod}}_aligned')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputAligned"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Aligned"
-															id="{{classApiMethodMethod}}_aligned"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setAligned classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
-																name="setAligned"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setAligned classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
-																name="setAligned"
-		{{else}}
-																class="valueAligned w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Aligned w3-input w3-border "
-																name="aligned"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Aligned ">{{currikiResource_.aligned}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setAligned', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_aligned')); }, function() { addError($('#{{classApiMethodMethod}}_aligned')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.aligned}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Aligned ">{{currikiResource_.aligned}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPageUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePageUrl">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_pageUrl">Page URL</label>
+													<label>Page URL</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPageUrl"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPageUrl"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_pageUrl')); $('#{{classApiMethodMethod}}_pageUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPageUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_pageUrl')); }, function() { addError($('#{{classApiMethodMethod}}_pageUrl')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPageUrl"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Page URL"
-															id="{{classApiMethodMethod}}_pageUrl"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPageUrl classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
-																name="setPageUrl"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPageUrl classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
-																name="setPageUrl"
-		{{else}}
-																class="valuePageUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}PageUrl w3-input w3-border "
-																name="pageUrl"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}PageUrl ">{{currikiResource_.pageUrl}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPageUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_pageUrl')); }, function() { addError($('#{{classApiMethodMethod}}_pageUrl')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.pageUrl}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}PageUrl ">{{currikiResource_.pageUrl}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIndexed"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexed">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_indexed">Indexed</label>
+													<label>Indexed</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputIndexed"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputIndexed"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexed')); $('#{{classApiMethodMethod}}_indexed').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexed', null, function() { addGlow($('#{{classApiMethodMethod}}_indexed')); }, function() { addError($('#{{classApiMethodMethod}}_indexed')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexed"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Indexed"
-															id="{{classApiMethodMethod}}_indexed"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setIndexed classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
-																name="setIndexed"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setIndexed classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
-																name="setIndexed"
-		{{else}}
-																class="valueIndexed w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Indexed w3-input w3-border "
-																name="indexed"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Indexed ">{{currikiResource_.indexed}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexed', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_indexed')); }, function() { addError($('#{{classApiMethodMethod}}_indexed')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.indexed}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Indexed ">{{currikiResource_.indexed}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmLastIndexDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceLastIndexDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_lastIndexDate">Last Index Date</label>
+													<label>Last Index Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputLastIndexDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLastIndexDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_lastIndexDate')); $('#{{classApiMethodMethod}}_lastIndexDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setLastIndexDate', null, function() { addGlow($('#{{classApiMethodMethod}}_lastIndexDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastIndexDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputLastIndexDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setLastIndexDate classCurrikiResource inputCurrikiResource{{pk}}LastIndexDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_lastIndexDate"
-																value="{{currikiResource_.lastIndexDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setLastIndexDate', s, function() { addGlow($('#{{classApiMethodMethod}}_lastIndexDate')); }, function() { addError($('#{{classApiMethodMethod}}_lastIndexDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}LastIndexDate ">{{currikiResource_.lastIndexDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}LastIndexDate " title="{{formatZonedDateTime currikiResource_.lastIndexDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.lastIndexDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmIndexRequired"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexRequired">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_indexRequired">Index Required</label>
+													<label>Index Required</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputIndexRequired"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputIndexRequired"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexRequired')); $('#{{classApiMethodMethod}}_indexRequired').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexRequired', null, function() { addGlow($('#{{classApiMethodMethod}}_indexRequired')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequired')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexRequired"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Index Required"
-															id="{{classApiMethodMethod}}_indexRequired"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setIndexRequired classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
-																name="setIndexRequired"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setIndexRequired classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
-																name="setIndexRequired"
-		{{else}}
-																class="valueIndexRequired w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}IndexRequired w3-input w3-border "
-																name="indexRequired"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}IndexRequired ">{{currikiResource_.indexRequired}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexRequired', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_indexRequired')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequired')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.indexRequired}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}IndexRequired ">{{currikiResource_.indexRequired}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmIndexRequiredDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceIndexRequiredDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_indexRequiredDate">IndexRequiredDate</label>
+													<label>IndexRequiredDate</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputIndexRequiredDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputIndexRequiredDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); $('#{{classApiMethodMethod}}_indexRequiredDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setIndexRequiredDate', null, function() { addGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequiredDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputIndexRequiredDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setIndexRequiredDate classCurrikiResource inputCurrikiResource{{pk}}IndexRequiredDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_indexRequiredDate"
-																value="{{currikiResource_.indexRequiredDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setIndexRequiredDate', s, function() { addGlow($('#{{classApiMethodMethod}}_indexRequiredDate')); }, function() { addError($('#{{classApiMethodMethod}}_indexRequiredDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}IndexRequiredDate ">{{currikiResource_.indexRequiredDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}IndexRequiredDate " title="{{formatZonedDateTime currikiResource_.indexRequiredDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.indexRequiredDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmRescrape"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRescrape">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_rescrape">rescrape</label>
+													<label>rescrape</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputRescrape"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputRescrape"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_rescrape')); $('#{{classApiMethodMethod}}_rescrape').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRescrape', null, function() { addGlow($('#{{classApiMethodMethod}}_rescrape')); }, function() { addError($('#{{classApiMethodMethod}}_rescrape')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputRescrape"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="rescrape"
-															id="{{classApiMethodMethod}}_rescrape"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setRescrape classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
-																name="setRescrape"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setRescrape classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
-																name="setRescrape"
-		{{else}}
-																class="valueRescrape w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Rescrape w3-input w3-border "
-																name="rescrape"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Rescrape ">{{currikiResource_.rescrape}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRescrape', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_rescrape')); }, function() { addError($('#{{classApiMethodMethod}}_rescrape')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.rescrape}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Rescrape ">{{currikiResource_.rescrape}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmGoButton"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceGoButton">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_goButton">Go Button</label>
+													<label>Go Button</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputGoButton"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputGoButton"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_goButton')); $('#{{classApiMethodMethod}}_goButton').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setGoButton', null, function() { addGlow($('#{{classApiMethodMethod}}_goButton')); }, function() { addError($('#{{classApiMethodMethod}}_goButton')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputGoButton"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Go Button"
-															id="{{classApiMethodMethod}}_goButton"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setGoButton classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
-																name="setGoButton"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setGoButton classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
-																name="setGoButton"
-		{{else}}
-																class="valueGoButton w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}GoButton w3-input w3-border "
-																name="goButton"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}GoButton ">{{currikiResource_.goButton}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setGoButton', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_goButton')); }, function() { addError($('#{{classApiMethodMethod}}_goButton')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.goButton}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}GoButton ">{{currikiResource_.goButton}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDownloadButton"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDownloadButton">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_downloadButton">Download Button</label>
+													<label>Download Button</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDownloadButton"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDownloadButton"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_downloadButton')); $('#{{classApiMethodMethod}}_downloadButton').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDownloadButton', null, function() { addGlow($('#{{classApiMethodMethod}}_downloadButton')); }, function() { addError($('#{{classApiMethodMethod}}_downloadButton')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDownloadButton"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Download Button"
-															id="{{classApiMethodMethod}}_downloadButton"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setDownloadButton classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
-																name="setDownloadButton"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setDownloadButton classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
-																name="setDownloadButton"
-		{{else}}
-																class="valueDownloadButton w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DownloadButton w3-input w3-border "
-																name="downloadButton"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}DownloadButton ">{{currikiResource_.downloadButton}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDownloadButton', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_downloadButton')); }, function() { addError($('#{{classApiMethodMethod}}_downloadButton')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.downloadButton}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}DownloadButton ">{{currikiResource_.downloadButton}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTopOfSearch"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTopOfSearch">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_topOfSearch">Top of Search</label>
+													<label>Top of Search</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputTopOfSearch"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTopOfSearch"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_topOfSearch')); $('#{{classApiMethodMethod}}_topOfSearch').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTopOfSearch', null, function() { addGlow($('#{{classApiMethodMethod}}_topOfSearch')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearch')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputTopOfSearch"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Top of Search"
-															id="{{classApiMethodMethod}}_topOfSearch"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setTopOfSearch classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
-																name="setTopOfSearch"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setTopOfSearch classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
-																name="setTopOfSearch"
-		{{else}}
-																class="valueTopOfSearch w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TopOfSearch w3-input w3-border "
-																name="topOfSearch"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}TopOfSearch ">{{currikiResource_.topOfSearch}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTopOfSearch', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_topOfSearch')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearch')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.topOfSearch}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}TopOfSearch ">{{currikiResource_.topOfSearch}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmRemove"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceRemove">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_remove">Remove</label>
+													<label>Remove</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputRemove"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputRemove"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_remove')); $('#{{classApiMethodMethod}}_remove').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setRemove', null, function() { addGlow($('#{{classApiMethodMethod}}_remove')); }, function() { addError($('#{{classApiMethodMethod}}_remove')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputRemove"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Remove"
-															id="{{classApiMethodMethod}}_remove"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setRemove classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
-																name="setRemove"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setRemove classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
-																name="setRemove"
-		{{else}}
-																class="valueRemove w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Remove w3-input w3-border "
-																name="remove"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Remove ">{{currikiResource_.remove}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setRemove', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_remove')); }, function() { addError($('#{{classApiMethodMethod}}_remove')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.remove}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Remove ">{{currikiResource_.remove}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSpam"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSpam">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_spam">Spam</label>
+													<label>Spam</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSpam"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSpam"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_spam')); $('#{{classApiMethodMethod}}_spam').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSpam', null, function() { addGlow($('#{{classApiMethodMethod}}_spam')); }, function() { addError($('#{{classApiMethodMethod}}_spam')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSpam"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Spam"
-															id="{{classApiMethodMethod}}_spam"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSpam classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
-																name="setSpam"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSpam classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
-																name="setSpam"
-		{{else}}
-																class="valueSpam w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Spam w3-input w3-border "
-																name="spam"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Spam ">{{currikiResource_.spam}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSpam', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_spam')); }, function() { addError($('#{{classApiMethodMethod}}_spam')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.spam}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Spam ">{{currikiResource_.spam}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmTopOfSearchInt"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceTopOfSearchInt">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_topOfSearchInt">Top of search int</label>
+													<label>Top of search int</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputTopOfSearchInt"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTopOfSearchInt"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); $('#{{classApiMethodMethod}}_topOfSearchInt').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setTopOfSearchInt', null, function() { addGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearchInt')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputTopOfSearchInt"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Top of search int"
-															id="{{classApiMethodMethod}}_topOfSearchInt"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setTopOfSearchInt classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
-																name="setTopOfSearchInt"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setTopOfSearchInt classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
-																name="setTopOfSearchInt"
-		{{else}}
-																class="valueTopOfSearchInt w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}TopOfSearchInt w3-input w3-border "
-																name="topOfSearchInt"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}TopOfSearchInt ">{{currikiResource_.topOfSearchInt}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setTopOfSearchInt', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_topOfSearchInt')); }, function() { addError($('#{{classApiMethodMethod}}_topOfSearchInt')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.topOfSearchInt}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}TopOfSearchInt ">{{currikiResource_.topOfSearchInt}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmPartnerInt"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourcePartnerInt">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_partnerInt">Partner Int</label>
+													<label>Partner Int</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputPartnerInt"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputPartnerInt"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_partnerInt')); $('#{{classApiMethodMethod}}_partnerInt').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setPartnerInt', null, function() { addGlow($('#{{classApiMethodMethod}}_partnerInt')); }, function() { addError($('#{{classApiMethodMethod}}_partnerInt')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputPartnerInt"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Partner Int"
-															id="{{classApiMethodMethod}}_partnerInt"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setPartnerInt classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
-																name="setPartnerInt"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setPartnerInt classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
-																name="setPartnerInt"
-		{{else}}
-																class="valuePartnerInt w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}PartnerInt w3-input w3-border "
-																name="partnerInt"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}PartnerInt ">{{currikiResource_.partnerInt}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setPartnerInt', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_partnerInt')); }, function() { addError($('#{{classApiMethodMethod}}_partnerInt')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.partnerInt}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}PartnerInt ">{{currikiResource_.partnerInt}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmReviewResource"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceReviewResource">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_reviewResource">Review Resource</label>
+													<label>Review Resource</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputReviewResource"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputReviewResource"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_reviewResource')); $('#{{classApiMethodMethod}}_reviewResource').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setReviewResource', null, function() { addGlow($('#{{classApiMethodMethod}}_reviewResource')); }, function() { addError($('#{{classApiMethodMethod}}_reviewResource')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputReviewResource"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Review Resource"
-															id="{{classApiMethodMethod}}_reviewResource"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setReviewResource classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
-																name="setReviewResource"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setReviewResource classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
-																name="setReviewResource"
-		{{else}}
-																class="valueReviewResource w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ReviewResource w3-input w3-border "
-																name="reviewResource"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ReviewResource ">{{currikiResource_.reviewResource}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setReviewResource', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_reviewResource')); }, function() { addError($('#{{classApiMethodMethod}}_reviewResource')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.reviewResource}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ReviewResource ">{{currikiResource_.reviewResource}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmOldUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceOldUrl">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_oldUrl">Old URL</label>
+													<label>Old URL</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputOldUrl"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputOldUrl"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_oldUrl')); $('#{{classApiMethodMethod}}_oldUrl').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setOldUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_oldUrl')); }, function() { addError($('#{{classApiMethodMethod}}_oldUrl')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputOldUrl"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Old URL"
-															id="{{classApiMethodMethod}}_oldUrl"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setOldUrl classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
-																name="setOldUrl"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setOldUrl classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
-																name="setOldUrl"
-		{{else}}
-																class="valueOldUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}OldUrl w3-input w3-border "
-																name="oldUrl"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}OldUrl ">{{currikiResource_.oldUrl}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setOldUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_oldUrl')); }, function() { addError($('#{{classApiMethodMethod}}_oldUrl')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.oldUrl}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}OldUrl ">{{currikiResource_.oldUrl}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmContentDisplayOk"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceContentDisplayOk">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_contentDisplayOk">Content Display OK</label>
+													<label>Content Display OK</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputContentDisplayOk"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputContentDisplayOk"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); $('#{{classApiMethodMethod}}_contentDisplayOk').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setContentDisplayOk', null, function() { addGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); }, function() { addError($('#{{classApiMethodMethod}}_contentDisplayOk')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputContentDisplayOk"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Content Display OK"
-															id="{{classApiMethodMethod}}_contentDisplayOk"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setContentDisplayOk classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
-																name="setContentDisplayOk"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setContentDisplayOk classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
-																name="setContentDisplayOk"
-		{{else}}
-																class="valueContentDisplayOk w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ContentDisplayOk w3-input w3-border "
-																name="contentDisplayOk"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ContentDisplayOk ">{{currikiResource_.contentDisplayOk}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setContentDisplayOk', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_contentDisplayOk')); }, function() { addError($('#{{classApiMethodMethod}}_contentDisplayOk')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.contentDisplayOk}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ContentDisplayOk ">{{currikiResource_.contentDisplayOk}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmMetadata"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceMetadata">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_metadata">Metadata</label>
+													<label>Metadata</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputMetadata"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputMetadata"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_metadata')); $('#{{classApiMethodMethod}}_metadata').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setMetadata', null, function() { addGlow($('#{{classApiMethodMethod}}_metadata')); }, function() { addError($('#{{classApiMethodMethod}}_metadata')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputMetadata"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Metadata"
-															id="{{classApiMethodMethod}}_metadata"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setMetadata classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
-																name="setMetadata"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setMetadata classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
-																name="setMetadata"
-		{{else}}
-																class="valueMetadata w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Metadata w3-input w3-border "
-																name="metadata"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Metadata ">{{currikiResource_.metadata}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setMetadata', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_metadata')); }, function() { addError($('#{{classApiMethodMethod}}_metadata')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.metadata}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Metadata ">{{currikiResource_.metadata}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmApprovalStatus"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceApprovalStatus">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_approvalStatus">Approval Status</label>
+													<label>Approval Status</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputApprovalStatus"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputApprovalStatus"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_approvalStatus')); $('#{{classApiMethodMethod}}_approvalStatus').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setApprovalStatus', null, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatus')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatus')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputApprovalStatus"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Approval Status"
-															id="{{classApiMethodMethod}}_approvalStatus"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setApprovalStatus classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
-																name="setApprovalStatus"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setApprovalStatus classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
-																name="setApprovalStatus"
-		{{else}}
-																class="valueApprovalStatus w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatus w3-input w3-border "
-																name="approvalStatus"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ApprovalStatus ">{{currikiResource_.approvalStatus}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setApprovalStatus', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_approvalStatus')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatus')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.approvalStatus}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ApprovalStatus ">{{currikiResource_.approvalStatus}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmApprovalStatusDate"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceApprovalStatusDate">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_approvalStatusDate">Approval Status Date</label>
+													<label>Approval Status Date</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputApprovalStatusDate"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputApprovalStatusDate"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); $('#{{classApiMethodMethod}}_approvalStatusDate').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setApprovalStatusDate', null, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatusDate')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputApprovalStatusDate"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-																type="text"
-																class="w3-input w3-border datepicker setApprovalStatusDate classCurrikiResource inputCurrikiResource{{pk}}ApprovalStatusDate w3-input w3-border "
-																placeholder="MM/DD/YYYY HH:MM AM"
-																data-timeformat="MM/dd/yyyy"
-																id="{{classApiMethodMethod}}_approvalStatusDate"
-																value="{{currikiResource_.approvalStatusDate}}"
-														{{#eq 'Page' classApiMethodMethod}}
-															onclick="removeGlow($(this)); ";
-															onchange="var t = moment(this.value, 'MM/DD/YYYY'); if(t) { var s = t.format('YYYY-MM-DD'); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setApprovalStatusDate', s, function() { addGlow($('#{{classApiMethodMethod}}_approvalStatusDate')); }, function() { addError($('#{{classApiMethodMethod}}_approvalStatusDate')); }); } "
-														{{/eq}}
-														/>
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}ApprovalStatusDate ">{{currikiResource_.approvalStatusDate}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}ApprovalStatusDate " title="{{formatZonedDateTime currikiResource_.approvalStatusDate 'EEEE MMMM d yyyy H:mm:ss.SSS zz VV' requestLocaleId requestZoneId}}">{{formatZonedDateTime currikiResource_.approvalStatusDate 'EEE MMM d yyyy h:mm a zz' requestLocaleId requestZoneId}}</span>
+	{{/eq}}
 {{/inline}}
 
 {{#*inline "htmSpamUser"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceSpamUser">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_spamUser">Spam User</label>
+													<label>Spam User</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSpamUser"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSpamUser"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_spamUser')); $('#{{classApiMethodMethod}}_spamUser').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setSpamUser', null, function() { addGlow($('#{{classApiMethodMethod}}_spamUser')); }, function() { addError($('#{{classApiMethodMethod}}_spamUser')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSpamUser"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Spam User"
-															id="{{classApiMethodMethod}}_spamUser"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setSpamUser classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
-																name="setSpamUser"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setSpamUser classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
-																name="setSpamUser"
-		{{else}}
-																class="valueSpamUser w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}SpamUser w3-input w3-border "
-																name="spamUser"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SpamUser ">{{currikiResource_.spamUser}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSpamUser', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_spamUser')); }, function() { addError($('#{{classApiMethodMethod}}_spamUser')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.spamUser}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}SpamUser ">{{currikiResource_.spamUser}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmUrl"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceUrl">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_url">URL</label>
+													<label>URL</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputUrl"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputUrl"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_url')); $('#{{classApiMethodMethod}}_url').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setUrl', null, function() { addGlow($('#{{classApiMethodMethod}}_url')); }, function() { addError($('#{{classApiMethodMethod}}_url')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputUrl"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="URL"
-															id="{{classApiMethodMethod}}_url"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUrl classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
-																name="setUrl"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUrl classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
-																name="setUrl"
-		{{else}}
-																class="valueUrl w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}Url w3-input w3-border "
-																name="url"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Url ">{{currikiResource_.url}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUrl', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_url')); }, function() { addError($('#{{classApiMethodMethod}}_url')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.url}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}Url ">{{currikiResource_.url}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmDisplaySeqNo"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceDisplaySeqNo">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_displaySeqNo">Display Sequence Number</label>
+													<label>Display Sequence Number</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputDisplaySeqNo"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDisplaySeqNo"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_displaySeqNo')); $('#{{classApiMethodMethod}}_displaySeqNo').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setDisplaySeqNo', null, function() { addGlow($('#{{classApiMethodMethod}}_displaySeqNo')); }, function() { addError($('#{{classApiMethodMethod}}_displaySeqNo')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputDisplaySeqNo"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="Display Sequence Number"
-															id="{{classApiMethodMethod}}_displaySeqNo"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setDisplaySeqNo classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
-																name="setDisplaySeqNo"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setDisplaySeqNo classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
-																name="setDisplaySeqNo"
-		{{else}}
-																class="valueDisplaySeqNo w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}DisplaySeqNo w3-input w3-border "
-																name="displaySeqNo"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}DisplaySeqNo ">{{currikiResource_.displaySeqNo}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setDisplaySeqNo', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_displaySeqNo')); }, function() { addError($('#{{classApiMethodMethod}}_displaySeqNo')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.displaySeqNo}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}DisplaySeqNo ">{{currikiResource_.displaySeqNo}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmFileId"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}CurrikiResourceFileId">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-blue">
-													<label for="{{classApiMethodMethod}}_fileId">File ID</label>
+													<label>File ID</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputFileId"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputFileId"}}
+															</span>
+														</div>
 													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-blue "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_fileId')); $('#{{classApiMethodMethod}}_fileId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#CurrikiResourceForm :input[name=pk]').val() }], 'setFileId', null, function() { addGlow($('#{{classApiMethodMethod}}_fileId')); }, function() { addError($('#{{classApiMethodMethod}}_fileId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputFileId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															placeholder="File ID"
-															id="{{classApiMethodMethod}}_fileId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setFileId classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
-																name="setFileId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setFileId classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
-																name="setFileId"
-		{{else}}
-																class="valueFileId w3-input w3-border classCurrikiResource inputCurrikiResource{{pk}}FileId w3-input w3-border "
-																name="fileId"
-		{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}FileId ">{{currikiResource_.fileId}}</span>
 	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setFileId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_fileId')); }, function() { addError($('#{{classApiMethodMethod}}_fileId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{currikiResource_.fileId}}"
-	{{/eq}}
-														/>
+{{/inline}}
 
-													{{else}}
-														{{#ifContainsKeys userKeys}}
-															<span class="varCurrikiResource{{pk}}FileId ">{{currikiResource_.fileId}}</span>
-			{{/ifContainsKeys}}
-		{{/ifContainsAnyRoles}}
+{{#*inline "htmFileName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Filename</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputFileName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputFileName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}FileName ">{{currikiResource_.fileName}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmUploadDate"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Upload Date</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputUploadDate"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputUploadDate"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}UploadDate ">{{currikiResource_.uploadDate}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmSequence"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Sequence</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSequence"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputSequence"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Sequence ">{{currikiResource_.sequence}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmUniqueName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Unique Name</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputUniqueName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputUniqueName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}UniqueName ">{{currikiResource_.uniqueName}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmExt"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Ext</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputExt"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputExt"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Ext ">{{currikiResource_.ext}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmTempactive"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Tempactive</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTempactive"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputTempactive"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Tempactive ">{{currikiResource_.tempactive}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmS3path"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>S3 Path</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputS3path"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputS3path"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}S3path ">{{currikiResource_.s3path}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmSdfStatus"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>SDF Status</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSdfStatus"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputSdfStatus"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SdfStatus ">{{currikiResource_.sdfStatus}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmTranscoded"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Transcoded</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputTranscoded"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputTranscoded"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Transcoded ">{{currikiResource_.transcoded}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmLodestar"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Lodestar</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputLodestar"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputLodestar"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Lodestar ">{{currikiResource_.lodestar}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmArchive"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Archive</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputArchive"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputArchive"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Archive ">{{currikiResource_.archive}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmIdentifier"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Identifier</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputIdentifier"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputIdentifier"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Identifier ">{{currikiResource_.identifier}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmDisplayName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Display Name</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputDisplayName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputDisplayName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}DisplayName ">{{currikiResource_.displayName}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmSubjectArea"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Subject Area</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSubjectArea"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputSubjectArea"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}SubjectArea ">{{currikiResource_.subjectArea}}</span>
+	{{/eq}}
+{{/inline}}
+
+{{#*inline "htmName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-blue">
+													<label>Name</label>
+												</div>
+												<div class="w3-cell-row  ">
+													<div class="w3-cell ">
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputName"}}
+															</span>
+														</div>
+													</div>
+												</div>
+											</div>
+										</div>
+	{{/eq}}
+								</div>
+{{/inline}}
+
+{{#*inline "inputName"}}
+	{{#eq 'Page' classApiMethodMethod}}
+														<span class="varCurrikiResource{{pk}}Name ">{{currikiResource_.name}}</span>
+	{{/eq}}
 {{/inline}}

--- a/src/main/resources/templates/enUS/PageLayout.hbs
+++ b/src/main/resources/templates/enUS/PageLayout.hbs
@@ -49,7 +49,7 @@
 {{else}}
 				<a href="/user" class="w3-bar-item w3-button w3-text-teal "><i class="fad fa-house-user w3-text-teal "></i> Login</a>
 {{/if}}
-				<a href="/resource" class="w3-bar-item w3-button w3-text-teal "><i class="fad fa-file w3-text-teal "></i> Resources</a>
+				<a href="/resource" class="w3-bar-item w3-button w3-text-blue "><i class="far fa-file w3-text-blue "></i> resources</a>
 {{/inline}}
 {{#*inline "htmBodyStartPageLayout"}}		<!-- inline "htmBodyStartPageLayout" -->
 {{/inline}}

--- a/src/main/resources/templates/enUS/SiteUserGenPage.hbs
+++ b/src/main/resources/templates/enUS/SiteUserGenPage.hbs
@@ -26,16 +26,145 @@
 				if(pk != null) {
 				}
 				websocketSiteUser(websocketSiteUserInner);
+				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
+				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlSiteUser"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadSiteUserPage"}}{{> "htmTitleSiteUserPage"}}{{> "htmMetaSiteUserPage"}}{{> "htmStyleSiteUserPage"}}{{> "htmScriptsSiteUserPage"}}{{> "htmScriptSiteUserPage"}}{{/inline}}
+{{#*inline "htmBodySearchSiteUserPage"}}		<!-- #*inline "htmBodySearchSiteUserPage" -->
+	<div>
+{{#each varsQ}}
+		<div class="w3-padding ">
+			<label for="fqSiteUser_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<input id="fqSiteUser_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
+			<div class="pageSearchVal w3-tiny "></div>
+		</div>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyFiltersSiteUserPage"}}		<!-- #*inline "htmBodyFiltersSiteUserPage" -->
+	<div>
+{{#each varsFq }}
+		<div class="w3-padding ">
+			<label for="fqSiteUser_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
+			<div class="w3-cell-row ">
+				<div class="w3-cell w3-cell-top ">
+					<button id="buttonFacetSiteUser_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
+				</div>
+				<div class="w3-cell w3-cell-top ">
+					<input id="fqSiteUser_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
+				</div>
+			</div>
+		</div>
+		<div class="w3-padding w3-tiny ">
+			<div class="pageSearchVal " id="pageSearchVal-fqSiteUser_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
+			<div class="pageSearchVal " id="pageSearchVal-buttonFacetSiteUser_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
+		</div>
+		<ol class="pageFacetField " id="pageFacetFieldSiteUser_{{ @key }}">
+{{#each facetField.counts }}
+			<li class="">{{ @key }}: {{ this }}</li>
+{{/each}}
+		</ol>
+{{/each}}
+	</div>
+{{/inline}}
+{{#*inline "htmBodyRangeSiteUserPage"}}		<!-- #*inline "htmBodyRangeSiteUserPage" -->
+	<table class="w3-padding ">
+		<tr>			<td class="w3-padding w3-tiny " colspan="2">
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-SiteUser">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-SiteUser">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-SiteUser">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
+				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-SiteUser">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+		<tr class="">
+			<td class="">
+			<span>Range Gap</span>
+			</td>
+			<td class="">
+				<select
+ name="facet.range.gap" id="pageFacetRangeGap-SiteUser" onchange="facetRangeChange(this, 'SiteUser'); ">
+					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
+					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
+					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
+					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
+					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
+					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
+					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
+				</select>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range Start</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-SiteUser" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'SiteUser'); "/></span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2">
+				<span>Range End</span>
+			</td>
+		</tr>
+		<tr class="">
+			<td class="" colspan="2"
+			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-SiteUser" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'SiteUser'); "/></span>
+			</td>
+		</tr>
+	</table>
+	<table class="w3-padding ">
+{{#each varsRange }}
+		<tr class="">
+			<td class="">
+				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeSiteUser_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'SiteUser'); "/></span>
+			</td>
+			<td class="">
+			<label for="pageFacetRangeSiteUser_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{#*inline "htmBodyPivotSiteUserPage"}}		<!-- #*inline "htmBodyPivotSiteUserPage" -->
+		<div class="w3-padding w3-tiny pageSearchVal " id="pageSearchVal-pivotSiteUser">
+{{#if defaultPivotVars }}
+			<div class="pageSearchVal " id="pageSearchVal-pivotSiteUser">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
+{{/if}}
+		</div>
+		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenSiteUser">
+{{#each defaultPivotVars }}
+			<div class="pageSearchVal pageSearchVal-hiddenSiteUser " id="pageSearchVal-hiddenSiteUser_{{ this }}">{{ this }}</div>
+{{/each}}
+		</div>
+	<table class="w3-table ">
+{{#each varsFq }}
+		<tr class="">
+			<td class="">
+				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotSiteUser_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'SiteUser'); "/></span>
+			</td>
+			<td class="w3-cell ">
+			<label for="pageFacetPivotSiteUser_{{ @key }}">{{ displayName }}</label>
+			</td>
+		</tr>
+{{/each}}
+	</table>
+{{/inline}}
+{{/inline}}
+{{#*inline "htmBodyMenuSiteUserPage"}}		<!-- #*inline "htmBodyMenuSiteUserPage" -->
+{{> "htmBodyMenuBaseModelPage"}}{{/inline}}
+{{#*inline "htmBodyGraphSiteUserPage"}}		<!-- #*inline "htmBodyGraphSiteUserPage" -->
+<div id="htmBodyGraphBaseModelPage" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0SiteUserPage"}}		<!-- #*inline "htmBodyCount0SiteUserPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 				{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -43,7 +172,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-gray">
 				{{#if contextIconCssClasses}}
-					<i class="contextIconCssClasses + " site-menu-icon "></i>
+					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
 				{{/if}}
 				<span class="">no site user found</span>
 			</span>
@@ -53,7 +182,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3-gray w3-hover-gray">
 			{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 			{{/if}}
 				<span class="">site user</span>
 			</a>
@@ -63,13 +192,12 @@
 				<span class="">{{siteUser_.objectTitle}}</span>
 			</span>
 		</h2>
-{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1SiteUserPage"}}		<!-- #*inline "htmBodyCount1SiteUserPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -107,7 +235,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 	{{#if contextIconCssClasses}}
-				<i class="contextIconCssClasses + " site-menu-icon "></i>
+				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
 	{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -143,14 +271,18 @@
 {{> "table1SiteUserPage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormSiteUserPage"}}	{{#if pk}}
+{{#*inline "htmFormSiteUserPage"}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="SiteUserForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
+		<form action="" id="SiteUserForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
+{{#if id}}
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
+{{/if}}
 			<input name="focusId" type="hidden"/>
+			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
+{{#if id}}
 {{#block "htmForm_searchpageSiteUser"}}{{/block}}
-	{{/if}}
+{{/if}}
 {{/inline}}
 {{#*inline "htmFormSiteUserPage_patchSiteUser"}}
 		<button
@@ -160,7 +292,7 @@
 			<i class="fas fa-edit "></i>
 			Modify site users
 		</button>
-		<div id="patchSiteUserModal" class="w3-modal w3-padding-32 ">
+		<div id="patchSiteUserModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -176,6 +308,10 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="PATCH"}}
 {{> "htmDeleted" classApiMethodMethod="PATCH"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSeeArchived" classApiMethodMethod="PATCH"}}
+{{> "htmSeeDeleted" classApiMethodMethod="PATCH"}}
 							</div>
 						<button
 							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-gray "
@@ -194,7 +330,7 @@
 			<i class="fas fa-file-plus "></i>
 			Create a site user
 		</button>
-		<div id="postSiteUserModal" class="w3-modal w3-padding-32 ">
+		<div id="postSiteUserModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -211,6 +347,10 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="POST"}}
 {{> "htmDeleted" classApiMethodMethod="POST"}}
+							</div>
+							<div class="w3-cell-row ">
+{{> "htmSeeArchived" classApiMethodMethod="POST"}}
+{{> "htmSeeDeleted" classApiMethodMethod="POST"}}
 							</div>
 						</div>
 						<button
@@ -230,7 +370,7 @@
 			<i class="fas fa-file-import "></i>
 			Import site users
 		</button>
-		<div id="putimportSiteUserModal" class="w3-modal w3-padding-32 ">
+		<div id="putimportSiteUserModal" class="w3-modal ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -243,7 +383,7 @@
 						<div class="w3-cell-row ">
 							<textarea
 								class="PUTImport_searchList w3-input w3-border "
-								style="height: 400px; "
+								style="height: 300px; "
 								placeholder="{ 'searchList': [ { 'pk': ... , 'saves': [ ... ] }, ... ] }"
 								></textarea>
 						</div>
@@ -257,15 +397,9 @@
 		</div>
 {{/inline}}
 {{#*inline "htmFormSiteUserPage_searchpageSiteUser"}}
-		<div id="searchpageSiteUserModal" class="w3-padding-32 ">
+		<div id="searchpageSiteUserModal" class="">
 			<div class="">
 				<div class="w3-card-4 ">
-					<header class="w3-container w3-gray">
-	{{#eq "Page" classApiMethodMethod}}
-						<span class="w3-button w3-display-topright " onclick="$('#searchpageSiteUserModal').hide(); ">×</span>
-	{{/eq}}
-						<h2 class="w3-padding "></h2>
-					</header>
 					<div class="" id="searchpageSiteUserFormValues">
 						<div id="searchpageSiteUserForm">
 							<div class="w3-cell-row ">
@@ -283,10 +417,6 @@
 {{> "htmSeeDeleted" classApiMethodMethod="Page"}}
 							</div>
 						</div>
-						<button
-							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-gray "
-							onclick="searchpageSiteUser(); "
-							></button>
 					</div>
 				</div>
 			</div>
@@ -300,6 +430,47 @@
 {{/inline}}
 {{#*inline "htmBodySiteUserPage"}}
 {{#block "htmBodyStart"}}{{/block}}
+	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
+			<span title="Filters" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
+			<span title="Range" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
+		</div>
+<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
+	<div class="w3-bar w3-gray ">
+		<span class="w3-bar-item w3-padding ">Search</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodySearch"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
+	<div class="w3-bar w3-gray ">
+		<span class="w3-bar-item w3-padding ">Filters</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyFilters"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
+	<div class="w3-bar w3-gray ">
+		<span class="w3-bar-item w3-padding ">Range</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyRange"}}{{/block}}
+	</div>
+</div>
+<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
+	<div class="w3-bar w3-gray ">
+		<span class="w3-bar-item w3-padding ">Pivot</span>
+	</div>
+	<div class="w3-bar-block ">
+{{#block "htmBodyPivot"}}{{/block}}
+	</div>
+</div>
+	</div>
+<div class="pageContent w3-content ">
+{{#block "htmBodyMenu"}}{{/block}}
+{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq siteUserCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -313,8 +484,10 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
+{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
+</div>
 {{/inline}}
 {{#*inline "table1SiteUserPage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -347,7 +520,7 @@
 			<tr>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "yyyy-MM-dd'T'HH:mm:ss.SSS'['VV']'" siteLocale}}</span>
+							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "MMM d, yyyy h:mm:ss a" siteLocale}}</span>
 						</a>
 					</td>
 					<td>
@@ -420,7 +593,7 @@
 					name="suggestSiteUser"
 					id="suggestSiteUser{{id}}"
 					autocomplete="off"
-					oninput="suggestSiteUserObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListSiteUser{{id}}'), {{pk}}; "
+					oninput="suggestSiteUserObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListSiteUser{{id}}'), {{pk}}; "
 					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/api/user?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listSiteUser}}
 					value="{{query2}}"
@@ -448,60 +621,494 @@
 {{/inline}}
 {{> BaseModelPage baseModel_=siteUser_}}
 
+{{#*inline "htmUserId"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserId">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserId"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userId')); $('#{{classApiMethodMethod}}_userId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserId', null, function() { addGlow($('#{{classApiMethodMethod}}_userId')); }, function() { addError($('#{{classApiMethodMethod}}_userId')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserId"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The unique user ID from the SSO server"
+															id="{{classApiMethodMethod}}_userId"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserId classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
+																name="setUserId"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserId classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
+																name="setUserId"
+		{{else}}
+																class="valueUserId w3-input w3-border classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
+																name="userId"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userId')); }, function() { addError($('#{{classApiMethodMethod}}_userId')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userId}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserId ">{{siteUser_.userId}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
+{{#*inline "htmUserName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserName">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserName"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userName')); $('#{{classApiMethodMethod}}_userName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserName', null, function() { addGlow($('#{{classApiMethodMethod}}_userName')); }, function() { addError($('#{{classApiMethodMethod}}_userName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserName"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The user's username"
+															id="{{classApiMethodMethod}}_userName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserName classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
+																name="setUserName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserName classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
+																name="setUserName"
+		{{else}}
+																class="valueUserName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
+																name="userName"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userName')); }, function() { addError($('#{{classApiMethodMethod}}_userName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserName ">{{siteUser_.userName}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
+{{#*inline "htmUserEmail"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserEmail">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserEmail"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userEmail')); $('#{{classApiMethodMethod}}_userEmail').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserEmail', null, function() { addGlow($('#{{classApiMethodMethod}}_userEmail')); }, function() { addError($('#{{classApiMethodMethod}}_userEmail')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserEmail"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The user's email"
+															id="{{classApiMethodMethod}}_userEmail"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserEmail classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
+																name="setUserEmail"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserEmail classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
+																name="setUserEmail"
+		{{else}}
+																class="valueUserEmail w3-input w3-border classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
+																name="userEmail"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserEmail', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userEmail')); }, function() { addError($('#{{classApiMethodMethod}}_userEmail')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userEmail}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserEmail ">{{siteUser_.userEmail}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
+{{#*inline "htmUserFirstName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserFirstName">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserFirstName"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userFirstName')); $('#{{classApiMethodMethod}}_userFirstName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserFirstName', null, function() { addGlow($('#{{classApiMethodMethod}}_userFirstName')); }, function() { addError($('#{{classApiMethodMethod}}_userFirstName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserFirstName"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The user's first name"
+															id="{{classApiMethodMethod}}_userFirstName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserFirstName classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
+																name="setUserFirstName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserFirstName classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
+																name="setUserFirstName"
+		{{else}}
+																class="valueUserFirstName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
+																name="userFirstName"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserFirstName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userFirstName')); }, function() { addError($('#{{classApiMethodMethod}}_userFirstName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userFirstName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserFirstName ">{{siteUser_.userFirstName}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
+{{#*inline "htmUserLastName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserLastName">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserLastName"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userLastName')); $('#{{classApiMethodMethod}}_userLastName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserLastName', null, function() { addGlow($('#{{classApiMethodMethod}}_userLastName')); }, function() { addError($('#{{classApiMethodMethod}}_userLastName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserLastName"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The user's last name"
+															id="{{classApiMethodMethod}}_userLastName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserLastName classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
+																name="setUserLastName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserLastName classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
+																name="setUserLastName"
+		{{else}}
+																class="valueUserLastName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
+																name="userLastName"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserLastName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userLastName')); }, function() { addError($('#{{classApiMethodMethod}}_userLastName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userLastName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserLastName ">{{siteUser_.userLastName}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
+{{#*inline "htmUserFullName"}}
+								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserUserFullName">
+											<div class="w3-card ">
+												<div class="w3-cell-row w3-padding ">
+													<div class="w3-cell ">
+														{{> "inputUserFullName"}}
+													</div>
+	{{#ifContainsAnyRoles roles rolesRequired}}
+		{{#eq 'Page' classApiMethodMethod}}
+															<div class="w3-cell w3-left-align w3-cell-top ">
+																<button
+																		tabindex="-1"
+																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
+																		onclick="removeGlow($('#{{classApiMethodMethod}}_userFullName')); $('#{{classApiMethodMethod}}_userFullName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserFullName', null, function() { addGlow($('#{{classApiMethodMethod}}_userFullName')); }, function() { addError($('#{{classApiMethodMethod}}_userFullName')); }); "
+																		>
+																	<i class="far fa-eraser "></i>
+																</button>
+															</div>
+														{{/eq}}
+	{{/ifContainsAnyRoles}}
+												</div>
+											</div>
+										</div>
+									</div>
+								</div>
+{{/inline}}
+
+{{#*inline "inputUserFullName"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
+														<input
+															type="text"
+															title="The user's full name"
+															id="{{classApiMethodMethod}}_userFullName"
+	{{#eq "Page" classApiMethodMethod}}
+																class="setUserFullName classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
+																name="setUserFullName"
+	{{else}}
+		{{#eq "PATCH" classApiMethodMethod}}
+																class="setUserFullName classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
+																name="setUserFullName"
+		{{else}}
+																class="valueUserFullName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
+																name="userFullName"
+		{{/eq}}
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+																onclick="removeGlow($(this)); "
+																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserFullName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userFullName')); }, function() { addError($('#{{classApiMethodMethod}}_userFullName')); }); "
+	{{/eq}}
+	{{#eq "Page" classApiMethodMethod}}
+															value="{{siteUser_.userFullName}}"
+	{{/eq}}
+														/>
+
+													{{else}}
+															<span class="varSiteUser{{pk}}UserFullName ">{{siteUser_.userFullName}}</span>
+		{{/ifContainsAnyRoles}}
+{{/inline}}
+
 {{#*inline "htmSeeArchived"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserSeeArchived">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-gray">
-													<label>see archived</label>
+													<label for="{{classApiMethodMethod}}_seeArchived">see archived</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSeeArchived"}}
-															</span>
-														</div>
+														{{> "inputSeeArchived"}}
 													</div>
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSeeArchived"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varSiteUser{{pk}}SeeArchived ">{{siteUser_.seeArchived}}</span>
+															<input
+																type="checkbox"
+																id="{{classApiMethodMethod}}_seeArchived"
+																value="true"
+	{{else}}
+														<select
+															id="{{classApiMethodMethod}}_seeArchived"
 	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															class="classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
+															name="setSeeArchived"
+	{{else}}
+		{{#eq 'Page' classApiMethodMethod}}
+																class="classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
+																name="setSeeArchived"
+		{{else}}
+																class="setSeeArchived valueSeeArchived classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
+																name="setSeeArchived"
+		{{/eq}}
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSeeArchived', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_seeArchived')); }, function() { addError($('#{{classApiMethodMethod}}_seeArchived')); }); "
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+		{{#if siteUser_.seeArchived}}
+																checked="checked"
+		{{/if}}
+																/>
+	{{else}}
+															>
+															<option value="" selected="selected"></option>
+															<option value="true">true</option>
+															<option value="false">false</option>
+														</select>
+	{{/eq}}
+
+													{{else}}
+															<span class="varSiteUser{{pk}}SeeArchived ">{{siteUser_.seeArchived}}</span>
+		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSeeDeleted"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									{{#eq 'Page' classApiMethodMethod}}
-										<div class="w3-padding ">
+									<div class="w3-padding ">
+										<div id="suggest{{classApiMethodMethod}}SiteUserSeeDeleted">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-gray">
-													<label>see deleted</label>
+													<label for="{{classApiMethodMethod}}_seeDeleted">see deleted</label>
 												</div>
-												<div class="w3-cell-row  ">
+												<div class="w3-cell-row w3-padding ">
 													<div class="w3-cell ">
-														<div class="w3-rest ">
-															<span class="">
-																{{> "inputSeeDeleted"}}
-															</span>
-														</div>
+														{{> "inputSeeDeleted"}}
 													</div>
 												</div>
 											</div>
 										</div>
-	{{/eq}}
+									</div>
 								</div>
 {{/inline}}
 
 {{#*inline "inputSeeDeleted"}}
+		{{#ifContainsAnyRoles roles rolesRequired}}
 	{{#eq 'Page' classApiMethodMethod}}
-														<span class="varSiteUser{{pk}}SeeDeleted ">{{siteUser_.seeDeleted}}</span>
+															<input
+																type="checkbox"
+																id="{{classApiMethodMethod}}_seeDeleted"
+																value="true"
+	{{else}}
+														<select
+															id="{{classApiMethodMethod}}_seeDeleted"
 	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															class="classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
+															name="setSeeDeleted"
+	{{else}}
+		{{#eq 'Page' classApiMethodMethod}}
+																class="classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
+																name="setSeeDeleted"
+		{{else}}
+																class="setSeeDeleted valueSeeDeleted classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
+																name="setSeeDeleted"
+		{{/eq}}
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSeeDeleted', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_seeDeleted')); }, function() { addError($('#{{classApiMethodMethod}}_seeDeleted')); }); "
+	{{/eq}}
+	{{#eq 'Page' classApiMethodMethod}}
+		{{#if siteUser_.seeDeleted}}
+																checked="checked"
+		{{/if}}
+																/>
+	{{else}}
+															>
+															<option value="" selected="selected"></option>
+															<option value="true">true</option>
+															<option value="false">false</option>
+														</select>
+	{{/eq}}
+
+													{{else}}
+															<span class="varSiteUser{{pk}}SeeDeleted ">{{siteUser_.seeDeleted}}</span>
+		{{/ifContainsAnyRoles}}
 {{/inline}}

--- a/src/main/resources/templates/enUS/SiteUserGenPage.hbs
+++ b/src/main/resources/templates/enUS/SiteUserGenPage.hbs
@@ -26,145 +26,16 @@
 				if(pk != null) {
 				}
 				websocketSiteUser(websocketSiteUserInner);
-				window.varsFq = JSON.parse('{{{toJsonObjectStringInApostrophes varsFq}}}');
-				pageGraph();
 			});
 		</script>
 {{/inline}}
 {{#*inline "htmUrlSiteUser"}}{{pageUri}}?q={{query.q}}&amp;rows={{#if rows}}{{rows}}{{else}}{{pagination.rows}}{{/if}}&amp;rows={{#if start}}{{start}}{{else}}{{pagination.start}}{{/if}}{{#each query.fq}}{{#eq fq this}}{{else}}&fq={{fq}}:{{val}}{{/eq}}{{/each}}{{#each query.sort}}{{#eq sort this}}{{else}}&sort={{var}} {{order}}{{/eq}}{{/each}}{{/inline}}
 {{#*inline "htmHeadSiteUserPage"}}{{> "htmTitleSiteUserPage"}}{{> "htmMetaSiteUserPage"}}{{> "htmStyleSiteUserPage"}}{{> "htmScriptsSiteUserPage"}}{{> "htmScriptSiteUserPage"}}{{/inline}}
-{{#*inline "htmBodySearchSiteUserPage"}}		<!-- #*inline "htmBodySearchSiteUserPage" -->
-	<div>
-{{#each varsQ}}
-		<div class="w3-padding ">
-			<label for="fqSiteUser_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<input id="fqSiteUser_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="qChange(this); " data-var="{{ var }}" autocomplete="off="/>
-			<div class="pageSearchVal w3-tiny "></div>
-		</div>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyFiltersSiteUserPage"}}		<!-- #*inline "htmBodyFiltersSiteUserPage" -->
-	<div>
-{{#each varsFq }}
-		<div class="w3-padding ">
-			<label for="fqSiteUser_{{ @key }}">{{ displayName }}<sup class="w3-tiny "> ({{ classSimpleName }})</sup></label>
-			<div class="w3-cell-row ">
-				<div class="w3-cell w3-cell-top ">
-					<button id="buttonFacetSiteUser_{{ @key }}" class="w3-button " onclick="facetFieldChange(this); " title="see values " data-var="{{ var }}" data-clear="{{#if facetField }}true{{else}}false{{/if}}"><i class="fas fa-list "></i></button>
-				</div>
-				<div class="w3-cell w3-cell-top ">
-					<input id="fqSiteUser_{{ @key }}" placeholder="{{ displayName }}" class="w3-input " onkeyup="fqChange(this); " data-var="{{ var }}" autocomplete="off=" value="{{ val }}"/>
-				</div>
-			</div>
-		</div>
-		<div class="w3-padding w3-tiny ">
-			<div class="pageSearchVal " id="pageSearchVal-fqSiteUser_{{ @key }}">{{#if val }}fq={{ var }}:{{encodeURIComponent val }}{{/if}}</div>
-			<div class="pageSearchVal " id="pageSearchVal-buttonFacetSiteUser_{{ @key }}">{{#if facetField.var }}facet.field={{ facetField.var }}{{/if}}</div>
-		</div>
-		<ol class="pageFacetField " id="pageFacetFieldSiteUser_{{ @key }}">
-{{#each facetField.counts }}
-			<li class="">{{ @key }}: {{ this }}</li>
-{{/each}}
-		</ol>
-{{/each}}
-	</div>
-{{/inline}}
-{{#*inline "htmBodyRangeSiteUserPage"}}		<!-- #*inline "htmBodyRangeSiteUserPage" -->
-	<table class="w3-padding ">
-		<tr>			<td class="w3-padding w3-tiny " colspan="2">
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeGap-SiteUser">{{#if defaultRangeGap }}facet.range.gap={{encodeURIComponent defaultRangeGap }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeStart-SiteUser">{{#if defaultRangeStart }}facet.range.start={{encodeURIComponent defaultRangeStart }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeEnd-SiteUser">{{#if defaultRangeEnd }}facet.range.end={{encodeURIComponent defaultRangeEnd }}{{/if}}</div>
-				<div class="pageSearchVal " id="pageSearchVal-pageFacetRangeVar-SiteUser">{{#if defaultRangeVar }}facet.range={!tag=r1}{{encodeURIComponent defaultRangeVar }}{{/if}}</div>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-		<tr class="">
-			<td class="">
-			<span>Range Gap</span>
-			</td>
-			<td class="">
-				<select
- name="facet.range.gap" id="pageFacetRangeGap-SiteUser" onchange="facetRangeChange(this, 'SiteUser'); ">
-					<option value="+1YEAR"{{#eq defaultRangeGap '+1YEAR'}} selected="selected"{{else}}{{/eq}}>Year</option>
-					<option value="+1MONTH"{{#eq defaultRangeGap '+1MONTH'}} selected="selected"{{else}}{{/eq}}>Month</option>
-					<option value="+1WEEK"{{#eq defaultRangeGap '+1WEEK'}} selected="selected"{{else}}{{/eq}}>Week</option>
-					<option value="+1DAY"{{#eq defaultRangeGap '+1DAY'}} selected="selected"{{else}}{{#if defaultRangeGap}}{{else}} selected="selected"{{/if}}{{/eq}}>Day</option>
-					<option value="+1HOUR"{{#eq defaultRangeGap '+1HOUR'}} selected="selected"{{else}}{{/eq}}>Hour</option>
-					<option value="+1MINUTE"{{#eq defaultRangeGap '+1MINUTE'}} selected="selected"{{else}}{{/eq}}>Minute</option>
-					<option value="+1SECOND"{{#eq defaultRangeGap '+1SECOND'}} selected="selected"{{else}}{{/eq}}>Second</option>
-				</select>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range Start</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-			<span><input type="datetime-local" name="facetRangeStart" id="pageFacetRangeStart-SiteUser" value="{{formatZonedDateTime defaultRangeStart "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'SiteUser'); "/></span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2">
-				<span>Range End</span>
-			</td>
-		</tr>
-		<tr class="">
-			<td class="" colspan="2"
-			<span><input type="datetime-local" name="facetRangeEnd" id="pageFacetRangeEnd-SiteUser" value="{{formatZonedDateTime defaultRangeEnd "yyyy-MM-dd'T'HH:mm" defaultLocaleId defaultZoneId}}" onclick="facetRangeChange(this, 'SiteUser'); "/></span>
-			</td>
-		</tr>
-	</table>
-	<table class="w3-padding ">
-{{#each varsRange }}
-		<tr class="">
-			<td class="">
-				<span><input type="radio" name="pageFacetRange" class="pageFacetRange " id="pageFacetRangeSiteUser_{{ @key }}" value="{{ var }}"{{#eq defaultRangeVar var }} checked="checked"{{/eq}} onclick="facetRangeChange(this, 'SiteUser'); "/></span>
-			</td>
-			<td class="">
-			<label for="pageFacetRangeSiteUser_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{#*inline "htmBodyPivotSiteUserPage"}}		<!-- #*inline "htmBodyPivotSiteUserPage" -->
-		<div class="w3-padding w3-tiny " id="pageSearchVal-pivotSiteUser">
-{{#if defaultPivotVars }}
-			<div class="pageSearchVal " id="pageSearchVal-pivotSiteUser">facet.pivot={{#each defaultPivotVars }}{{#if @index }},{{/if}}{{ this }}{{/each}}</div>
-{{/if}}
-		</div>
-		<div style="display: none; " class="w3-padding w3-tiny " id="pageSearchVal-hiddenSiteUser">
-{{#each defaultPivotVars }}
-			<div class="pageSearchVal pageSearchVal-hiddenSiteUser " id="pageSearchVal-hiddenSiteUser_{{ this }}">{{ this }}</div>
-{{/each}}
-		</div>
-	<table class="w3-table ">
-{{#each varsFq }}
-		<tr class="">
-			<td class="">
-				<span><input type="checkbox" name="pageFacetPivot" class="pageFacetPivot " id="pageFacetPivotSiteUser_{{ @key }}" value="{{ var }}"{{#if pivot }} checked="checked"{{/if}} onclick="facetPivotChange(this, 'SiteUser'); "/></span>
-			</td>
-			<td class="w3-cell ">
-			<label for="pageFacetPivotSiteUser_{{ @key }}">{{ displayName }}</label>
-			</td>
-		</tr>
-{{/each}}
-	</table>
-{{/inline}}
-{{/inline}}
-{{#*inline "htmBodyMenuSiteUserPage"}}		<!-- #*inline "htmBodyMenuSiteUserPage" -->
-{{> "htmBodyMenuBaseModelPage"}}{{/inline}}
-{{#*inline "htmBodyGraphSiteUserPage"}}		<!-- #*inline "htmBodyGraphSiteUserPage" -->
-<div id="htmBodyGraphBaseModelPage" class="htmBodyGraph "></div>{{/inline}}
 {{#*inline "htmBodyCount0SiteUserPage"}}		<!-- #*inline "htmBodyCount0SiteUserPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+					<i class="contextIconCssClasses site-menu-icon "></i>
 				{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -172,7 +43,7 @@
 		<h2>
 			<span class="w3-bar-item w3-padding w3-center w3-block w3-gray">
 				{{#if contextIconCssClasses}}
-					<i class="{{ contextIconCssClasses }}  site-menu-icon "></i>
+					<i class="contextIconCssClasses + " site-menu-icon "></i>
 				{{/if}}
 				<span class="">no site user found</span>
 			</span>
@@ -182,7 +53,7 @@
 		<h1 class="w3-center ">
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-block w3-gray w3-hover-gray">
 			{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses site-menu-icon "></i>
 			{{/if}}
 				<span class="">site user</span>
 			</a>
@@ -192,12 +63,13 @@
 				<span class="">{{siteUser_.objectTitle}}</span>
 			</span>
 		</h2>
+{{#block "htmForm"}}{{/block}}
 {{/inline}}
 {{#*inline "htmBodyCount1SiteUserPage"}}		<!-- #*inline "htmBodyCount1SiteUserPage" -->
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -235,7 +107,7 @@
 		<h1>
 			<a href="{{pageUri}}" class="w3-bar-item w3-btn w3-center w3-block w3-gray w3-hover-gray">
 	{{#if contextIconCssClasses}}
-				<i class="{{ contextIconCssClasses }} site-menu-icon "></i>
+				<i class="contextIconCssClasses + " site-menu-icon "></i>
 	{{/if}}
 				<span class="">site users</span>
 			</a>
@@ -271,18 +143,14 @@
 {{> "table1SiteUserPage"}}
 		</div>
 {{/inline}}
-{{#*inline "htmFormSiteUserPage"}}
+{{#*inline "htmFormSiteUserPage"}}	{{#if pk}}
 		<!-- #*inline "htmForm" -->
-		<form action="" id="SiteUserForm" class="pageForm " style="" onsubmit="event.preventDefault(); return false; ">
-{{#if id}}
+		<form action="" id="SiteUserForm" style="display: inline-block; width: 100%; " onsubmit="event.preventDefault(); return false; ">
 			<input name="pk" class="valuePk" type="hidden" value="{{pk}}"/>
-{{/if}}
 			<input name="focusId" type="hidden"/>
-			<input name="pageResponse" id="pageResponse" class="pageResponse"  value='{{{toJsonObjectStringInApostrophes pageResponse }}}' type="hidden"/>
 		</form>
-{{#if id}}
 {{#block "htmForm_searchpageSiteUser"}}{{/block}}
-{{/if}}
+	{{/if}}
 {{/inline}}
 {{#*inline "htmFormSiteUserPage_patchSiteUser"}}
 		<button
@@ -292,7 +160,7 @@
 			<i class="fas fa-edit "></i>
 			Modify site users
 		</button>
-		<div id="patchSiteUserModal" class="w3-modal ">
+		<div id="patchSiteUserModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -308,10 +176,6 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="PATCH"}}
 {{> "htmDeleted" classApiMethodMethod="PATCH"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSeeArchived" classApiMethodMethod="PATCH"}}
-{{> "htmSeeDeleted" classApiMethodMethod="PATCH"}}
 							</div>
 						<button
 							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-gray "
@@ -330,7 +194,7 @@
 			<i class="fas fa-file-plus "></i>
 			Create a site user
 		</button>
-		<div id="postSiteUserModal" class="w3-modal ">
+		<div id="postSiteUserModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -347,10 +211,6 @@
 							<div class="w3-cell-row ">
 {{> "htmArchived" classApiMethodMethod="POST"}}
 {{> "htmDeleted" classApiMethodMethod="POST"}}
-							</div>
-							<div class="w3-cell-row ">
-{{> "htmSeeArchived" classApiMethodMethod="POST"}}
-{{> "htmSeeDeleted" classApiMethodMethod="POST"}}
 							</div>
 						</div>
 						<button
@@ -370,7 +230,7 @@
 			<i class="fas fa-file-import "></i>
 			Import site users
 		</button>
-		<div id="putimportSiteUserModal" class="w3-modal ">
+		<div id="putimportSiteUserModal" class="w3-modal w3-padding-32 ">
 			<div class="w3-modal-content ">
 				<div class="w3-card-4 ">
 					<header class="w3-container w3-gray">
@@ -383,7 +243,7 @@
 						<div class="w3-cell-row ">
 							<textarea
 								class="PUTImport_searchList w3-input w3-border "
-								style="height: 300px; "
+								style="height: 400px; "
 								placeholder="{ 'searchList': [ { 'pk': ... , 'saves': [ ... ] }, ... ] }"
 								></textarea>
 						</div>
@@ -397,9 +257,15 @@
 		</div>
 {{/inline}}
 {{#*inline "htmFormSiteUserPage_searchpageSiteUser"}}
-		<div id="searchpageSiteUserModal" class="">
+		<div id="searchpageSiteUserModal" class="w3-padding-32 ">
 			<div class="">
 				<div class="w3-card-4 ">
+					<header class="w3-container w3-gray">
+	{{#eq "Page" classApiMethodMethod}}
+						<span class="w3-button w3-display-topright " onclick="$('#searchpageSiteUserModal').hide(); ">×</span>
+	{{/eq}}
+						<h2 class="w3-padding "></h2>
+					</header>
 					<div class="" id="searchpageSiteUserFormValues">
 						<div id="searchpageSiteUserForm">
 							<div class="w3-cell-row ">
@@ -417,6 +283,10 @@
 {{> "htmSeeDeleted" classApiMethodMethod="Page"}}
 							</div>
 						</div>
+						<button
+							class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-margin w3-gray "
+							onclick="searchpageSiteUser(); "
+							></button>
 					</div>
 				</div>
 			</div>
@@ -430,47 +300,6 @@
 {{/inline}}
 {{#*inline "htmBodySiteUserPage"}}
 {{#block "htmBodyStart"}}{{/block}}
-	<div class="w3-sidebar w3-bar-block " style="min-width: 300px; ">		<div class="">			<span title="Search" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleSearch').toggle(); "><i class="fad fa-magnifying-glass "></i></span>
-			<span title="Filters" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleFilters').toggle(); "><i class="fad fa-filters "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarTogglePivot').hide(); $('.siteSidebarToggleRange').toggle(); "><i class="fad fa-calendar-range "></i></span>
-			<span title="Range" class="w3-button w3-xlarge w3-gray " onclick="$('.siteSidebarToggleSearch').hide(); $('.siteSidebarToggleFilters').hide(); $('.siteSidebarToggleRange').hide(); $('.siteSidebarTogglePivot').toggle(); "><i class="fad fa-table-pivot "></i></span>
-		</div>
-<div  class="siteSidebarToggle siteSidebarToggleSearch" style="display: none; ">
-	<div class="w3-bar w3-gray ">
-		<span class="w3-bar-item w3-padding ">Search</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodySearch"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleFilters" style="display: none; ">
-	<div class="w3-bar w3-gray ">
-		<span class="w3-bar-item w3-padding ">Filters</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyFilters"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarToggleRange" style="display: none; ">
-	<div class="w3-bar w3-gray ">
-		<span class="w3-bar-item w3-padding ">Range</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyRange"}}{{/block}}
-	</div>
-</div>
-<div  class="siteSidebarToggle siteSidebarTogglePivot" style="display: none; ">
-	<div class="w3-bar w3-gray ">
-		<span class="w3-bar-item w3-padding ">Pivot</span>
-	</div>
-	<div class="w3-bar-block ">
-{{#block "htmBodyPivot"}}{{/block}}
-	</div>
-</div>
-	</div>
-<div class="pageContent w3-content ">
-{{#block "htmBodyMenu"}}{{/block}}
-{{#block "htmBodyGraph"}}{{/block}}
 	{{#eq siteUserCount int0}}
 {{#block "htmBodyCount0"}}{{/block}}
 	{{else}}
@@ -484,10 +313,8 @@
 {{#block "htmBodyAll"}}{{/block}}
 		{{/eq}}
 	{{/eq}}
-{{#block "htmForm"}}{{/block}}
 {{#block "htmForms"}}{{/block}}
 {{#block "htmBodyEnd"}}{{/block}}
-</div>
 {{/inline}}
 {{#*inline "table1SiteUserPage"}}
 		<table class="w3-table w3-bordered w3-striped w3-border w3-hoverable ">
@@ -506,8 +333,8 @@
 	{{/inline}}
 {{#*inline "thead2SiteUserPage"}}
 			<tr>
-				<th></th>
 				<th>created</th>
+				<th></th>
 			</tr>
 {{/inline}}
 {{#*inline "tbody1SiteUserPage"}}
@@ -520,13 +347,13 @@
 			<tr>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<i class="far fa-user-cog "></i>
-							<span class="white-space-pre-wrap ">{{objectTitle}}</span>
+							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "yyyy-MM-dd'T'HH:mm:ss.SSS'['VV']'" siteLocale}}</span>
 						</a>
 					</td>
 					<td>
 						<a href="{{pageUrlPk}}">
-							<span class="white-space-pre-wrap ">{{siteZonedDateTimeFormat created "MMM d, yyyy h:mm:ss a" siteLocale}}</span>
+							<i class="far fa-user-cog "></i>
+							<span class="white-space-pre-wrap ">{{objectTitle}}</span>
 						</a>
 					</td>
 			</tr>
@@ -539,11 +366,11 @@
 {{/inline}}
 {{#*inline "tfoot2SiteUserPage"}}
 		<tr>
-			{{#if getColumnObjectTitle}}
+			{{#if getColumnCreated}}
 				<td>
 				</td>
 			{{/if}}
-			{{#if getColumnCreated}}
+			{{#if getColumnObjectTitle}}
 				<td>
 				</td>
 			{{/if}}
@@ -593,15 +420,15 @@
 					name="suggestSiteUser"
 					id="suggestSiteUser{{id}}"
 					autocomplete="off"
-					oninput="suggestSiteUserObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'classCanonicalName,pk,pageUrlPk,objectTitle' } ], $('#suggestListSiteUser{{id}}'), {{pk}}; "
-					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/user?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
+					oninput="suggestSiteUserObjectSuggest( [ { 'name': 'q', 'value': 'objectSuggest:' + $(this).val() }, { 'name': 'rows', 'value': '10' }, { 'name': 'fl', 'value': 'pk,pageUrlPk,objectTitle' } ], $('#suggestListSiteUser{{id}}'), {{pk}}; "
+					onkeyup="if (event.keyCode === 13) { event.preventDefault(); window.location.href = '/api/user?q={{query1}}:' + encodeURIComponent(this.value) + '{{fqs}}{{sorts}}&amp;rows={{start2}}&amp;rows={{rows1}}"
 				{{#if listSiteUser}}
 					value="{{query2}}"
 				{{/if}}
 				/>
 				<button
 					class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-					onclick="window.location.href = '/user?q=&quot;, query1, &quot;:' + encodeURIComponent(this.previousElementSibling.value) + '&quot;, fqs, sorts, &quot;&amp;rows=&quot;, start2, &quot;&amp;rows=&quot;, rows1, &quot;'; "
+					onclick="window.location.href = '/api/user?q=&quot;, query1, &quot;:' + encodeURIComponent(this.previousElementSibling.value) + '&quot;, fqs, sorts, &quot;&amp;rows=&quot;, start2, &quot;&amp;rows=&quot;, rows1, &quot;'; "
 					>
 					<i class="fas fa-search "></i>
 				</button>
@@ -613,7 +440,7 @@
 				</div>
 			</div>
 			<div class="">
-				<a href="/user" class="">
+				<a href="/api/user" class="">
 					<i class="far fa-user-cog"></i>
 					see all the site users
 				</a>
@@ -621,494 +448,60 @@
 {{/inline}}
 {{> BaseModelPage baseModel_=siteUser_}}
 
-{{#*inline "htmUserId"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserId">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserId"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userId')); $('#{{classApiMethodMethod}}_userId').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserId', null, function() { addGlow($('#{{classApiMethodMethod}}_userId')); }, function() { addError($('#{{classApiMethodMethod}}_userId')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserId"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The unique user ID from the SSO server"
-															id="{{classApiMethodMethod}}_userId"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserId classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
-																name="setUserId"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserId classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
-																name="setUserId"
-		{{else}}
-																class="valueUserId w3-input w3-border classSiteUser inputSiteUser{{pk}}UserId w3-input w3-border "
-																name="userId"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserId', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userId')); }, function() { addError($('#{{classApiMethodMethod}}_userId')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userId}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserId ">{{siteUser_.userId}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
-{{#*inline "htmUserName"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserName">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserName"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userName')); $('#{{classApiMethodMethod}}_userName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserName', null, function() { addGlow($('#{{classApiMethodMethod}}_userName')); }, function() { addError($('#{{classApiMethodMethod}}_userName')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserName"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The user's username"
-															id="{{classApiMethodMethod}}_userName"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserName classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
-																name="setUserName"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserName classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
-																name="setUserName"
-		{{else}}
-																class="valueUserName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserName w3-input w3-border "
-																name="userName"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userName')); }, function() { addError($('#{{classApiMethodMethod}}_userName')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userName}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserName ">{{siteUser_.userName}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
-{{#*inline "htmUserEmail"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserEmail">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserEmail"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userEmail')); $('#{{classApiMethodMethod}}_userEmail').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserEmail', null, function() { addGlow($('#{{classApiMethodMethod}}_userEmail')); }, function() { addError($('#{{classApiMethodMethod}}_userEmail')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserEmail"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The user's email"
-															id="{{classApiMethodMethod}}_userEmail"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserEmail classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
-																name="setUserEmail"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserEmail classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
-																name="setUserEmail"
-		{{else}}
-																class="valueUserEmail w3-input w3-border classSiteUser inputSiteUser{{pk}}UserEmail w3-input w3-border "
-																name="userEmail"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserEmail', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userEmail')); }, function() { addError($('#{{classApiMethodMethod}}_userEmail')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userEmail}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserEmail ">{{siteUser_.userEmail}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
-{{#*inline "htmUserFirstName"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserFirstName">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserFirstName"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userFirstName')); $('#{{classApiMethodMethod}}_userFirstName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserFirstName', null, function() { addGlow($('#{{classApiMethodMethod}}_userFirstName')); }, function() { addError($('#{{classApiMethodMethod}}_userFirstName')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserFirstName"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The user's first name"
-															id="{{classApiMethodMethod}}_userFirstName"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserFirstName classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
-																name="setUserFirstName"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserFirstName classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
-																name="setUserFirstName"
-		{{else}}
-																class="valueUserFirstName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserFirstName w3-input w3-border "
-																name="userFirstName"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserFirstName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userFirstName')); }, function() { addError($('#{{classApiMethodMethod}}_userFirstName')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userFirstName}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserFirstName ">{{siteUser_.userFirstName}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
-{{#*inline "htmUserLastName"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserLastName">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserLastName"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userLastName')); $('#{{classApiMethodMethod}}_userLastName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserLastName', null, function() { addGlow($('#{{classApiMethodMethod}}_userLastName')); }, function() { addError($('#{{classApiMethodMethod}}_userLastName')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserLastName"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The user's last name"
-															id="{{classApiMethodMethod}}_userLastName"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserLastName classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
-																name="setUserLastName"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserLastName classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
-																name="setUserLastName"
-		{{else}}
-																class="valueUserLastName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserLastName w3-input w3-border "
-																name="userLastName"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserLastName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userLastName')); }, function() { addError($('#{{classApiMethodMethod}}_userLastName')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userLastName}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserLastName ">{{siteUser_.userLastName}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
-{{#*inline "htmUserFullName"}}
-								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserUserFullName">
-											<div class="w3-card ">
-												<div class="w3-cell-row w3-padding ">
-													<div class="w3-cell ">
-														{{> "inputUserFullName"}}
-													</div>
-	{{#ifContainsAnyRoles roles rolesRequired}}
-		{{#eq 'Page' classApiMethodMethod}}
-															<div class="w3-cell w3-left-align w3-cell-top ">
-																<button
-																		tabindex="-1"
-																		class="w3-btn w3-round w3-border w3-border-black w3-ripple w3-padding w3-bar-item w3-gray "
-																		onclick="removeGlow($('#{{classApiMethodMethod}}_userFullName')); $('#{{classApiMethodMethod}}_userFullName').val(null); patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:' + $('#SiteUserForm :input[name=pk]').val() }], 'setUserFullName', null, function() { addGlow($('#{{classApiMethodMethod}}_userFullName')); }, function() { addError($('#{{classApiMethodMethod}}_userFullName')); }); "
-																		>
-																	<i class="far fa-eraser "></i>
-																</button>
-															</div>
-														{{/eq}}
-	{{/ifContainsAnyRoles}}
-												</div>
-											</div>
-										</div>
-									</div>
-								</div>
-{{/inline}}
-
-{{#*inline "inputUserFullName"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
-														<input
-															type="text"
-															title="The user's full name"
-															id="{{classApiMethodMethod}}_userFullName"
-	{{#eq "Page" classApiMethodMethod}}
-																class="setUserFullName classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
-																name="setUserFullName"
-	{{else}}
-		{{#eq "PATCH" classApiMethodMethod}}
-																class="setUserFullName classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
-																name="setUserFullName"
-		{{else}}
-																class="valueUserFullName w3-input w3-border classSiteUser inputSiteUser{{pk}}UserFullName w3-input w3-border "
-																name="userFullName"
-		{{/eq}}
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-																onclick="removeGlow($(this)); "
-																onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setUserFullName', $(this).val(), function() { addGlow($('#{{classApiMethodMethod}}_userFullName')); }, function() { addError($('#{{classApiMethodMethod}}_userFullName')); }); "
-	{{/eq}}
-	{{#eq "Page" classApiMethodMethod}}
-															value="{{siteUser_.userFullName}}"
-	{{/eq}}
-														/>
-
-													{{else}}
-															<span class="varSiteUser{{pk}}UserFullName ">{{siteUser_.userFullName}}</span>
-		{{/ifContainsAnyRoles}}
-{{/inline}}
-
 {{#*inline "htmSeeArchived"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserSeeArchived">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-gray">
-													<label for="{{classApiMethodMethod}}_seeArchived">see archived</label>
+													<label>see archived</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSeeArchived"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSeeArchived"}}
+															</span>
+														</div>
 													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSeeArchived"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
 	{{#eq 'Page' classApiMethodMethod}}
-															<input
-																type="checkbox"
-																id="{{classApiMethodMethod}}_seeArchived"
-																value="true"
-	{{else}}
-														<select
-															id="{{classApiMethodMethod}}_seeArchived"
+														<span class="varSiteUser{{pk}}SeeArchived ">{{siteUser_.seeArchived}}</span>
 	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															class="classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
-															name="setSeeArchived"
-	{{else}}
-		{{#eq 'Page' classApiMethodMethod}}
-																class="classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
-																name="setSeeArchived"
-		{{else}}
-																class="setSeeArchived valueSeeArchived classSiteUser inputSiteUser{{pk}}SeeArchived w3-input w3-border "
-																name="setSeeArchived"
-		{{/eq}}
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSeeArchived', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_seeArchived')); }, function() { addError($('#{{classApiMethodMethod}}_seeArchived')); }); "
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-		{{#if siteUser_.seeArchived}}
-																checked="checked"
-		{{/if}}
-																/>
-	{{else}}
-															>
-															<option value="" selected="selected"></option>
-															<option value="true">true</option>
-															<option value="false">false</option>
-														</select>
-	{{/eq}}
-
-													{{else}}
-															<span class="varSiteUser{{pk}}SeeArchived ">{{siteUser_.seeArchived}}</span>
-		{{/ifContainsAnyRoles}}
 {{/inline}}
 
 {{#*inline "htmSeeDeleted"}}
 								<div class="w3-cell w3-cell-top w3-center w3-mobile ">
-									<div class="w3-padding ">
-										<div id="suggest{{classApiMethodMethod}}SiteUserSeeDeleted">
+									{{#eq 'Page' classApiMethodMethod}}
+										<div class="w3-padding ">
 											<div class="w3-card ">
 												<div class="w3-cell-row w3-gray">
-													<label for="{{classApiMethodMethod}}_seeDeleted">see deleted</label>
+													<label>see deleted</label>
 												</div>
-												<div class="w3-cell-row w3-padding ">
+												<div class="w3-cell-row  ">
 													<div class="w3-cell ">
-														{{> "inputSeeDeleted"}}
+														<div class="w3-rest ">
+															<span class="">
+																{{> "inputSeeDeleted"}}
+															</span>
+														</div>
 													</div>
 												</div>
 											</div>
 										</div>
-									</div>
+	{{/eq}}
 								</div>
 {{/inline}}
 
 {{#*inline "inputSeeDeleted"}}
-		{{#ifContainsAnyRoles roles rolesRequired}}
 	{{#eq 'Page' classApiMethodMethod}}
-															<input
-																type="checkbox"
-																id="{{classApiMethodMethod}}_seeDeleted"
-																value="true"
-	{{else}}
-														<select
-															id="{{classApiMethodMethod}}_seeDeleted"
+														<span class="varSiteUser{{pk}}SeeDeleted ">{{siteUser_.seeDeleted}}</span>
 	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															class="classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
-															name="setSeeDeleted"
-	{{else}}
-		{{#eq 'Page' classApiMethodMethod}}
-																class="classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
-																name="setSeeDeleted"
-		{{else}}
-																class="setSeeDeleted valueSeeDeleted classSiteUser inputSiteUser{{pk}}SeeDeleted w3-input w3-border "
-																name="setSeeDeleted"
-		{{/eq}}
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-															onchange="patch{{classSimpleName}}Val([{ name: 'softCommit', value: 'true' }, { name: 'fq', value: 'pk:{{pk}}' }], 'setSeeDeleted', $(this).prop('checked'), function() { addGlow($('#{{classApiMethodMethod}}_seeDeleted')); }, function() { addError($('#{{classApiMethodMethod}}_seeDeleted')); }); "
-	{{/eq}}
-	{{#eq 'Page' classApiMethodMethod}}
-		{{#if siteUser_.seeDeleted}}
-																checked="checked"
-		{{/if}}
-																/>
-	{{else}}
-															>
-															<option value="" selected="selected"></option>
-															<option value="true">true</option>
-															<option value="false">false</option>
-														</select>
-	{{/eq}}
-
-													{{else}}
-															<span class="varSiteUser{{pk}}SeeDeleted ">{{siteUser_.seeDeleted}}</span>
-		{{/ifContainsAnyRoles}}
 {{/inline}}


### PR DESCRIPTION
With reference to the SQL statement shared by Niket:

_"select r.*, rl.url, rl.displayseqno, rf.fileid, rf.filename, rf.uploaddate, rf.sequence, rf.uniquename, rf.ext, rf.active, rf.tempactive, rf.s3path, rf.SDFstatus, rf.transcoded, rf.lodestar, rf.archive, edu.identifier, edu.displayname, sub.subjectarea, sub.displayname, inst.displayname, inst.name"_

We have already added the entry for the first 3 fields (rl.url, rl.displayseqno, and rf.fileid) and this PR aims to add the necessary code for all the other fields as seen above.